### PR TITLE
feat(weight): add online weight transform from mg to hf when sglang sync weight

### DIFF
--- a/rlinf/hybrid_engines/sglang/sglang_0_4_4/io_struct.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_4/io_struct.py
@@ -47,3 +47,13 @@ class SyncWeightInput:
 @dataclass
 class SyncWeightOutput:
     pass
+
+
+@dataclass
+class SyncHFWeightInput:
+    pass
+
+
+@dataclass
+class SyncHFWeightOutput:
+    pass

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_4/sgl_engine.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_4/sgl_engine.py
@@ -46,7 +46,7 @@ from sglang.srt.utils import (
 from rlinf.scheduler import WorkerAddress
 from rlinf.utils.placement import ComponentPlacement
 
-from .io_struct import OffloadReqInput, SyncWeightInput
+from .io_struct import OffloadReqInput, SyncHFWeightInput, SyncWeightInput
 from .sgl_scheduler import run_scheduler_process
 from .tokenizer_manager import TokenizerManager
 
@@ -103,6 +103,11 @@ class Engine(_Engine):
         return loop.run_until_complete(
             self.tokenizer_manager.offload_model_weights(obj, None)
         )
+
+    def sync_hf_weight(self):
+        obj = SyncHFWeightInput()
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self.tokenizer_manager.sync_hf_weight(obj))
 
     def sync_weight(self):
         obj = SyncWeightInput()

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_4/sgl_scheduler.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_4/sgl_scheduler.py
@@ -52,6 +52,8 @@ from rlinf.workers.rollout.utils import (
 from .io_struct import (
     OffloadReqInput,
     OffloadReqOutput,
+    SyncHFWeightInput,
+    SyncHFWeightOutput,
     SyncWeightInput,
     SyncWeightOutput,
     TaskMethodInput,
@@ -95,6 +97,7 @@ class Scheduler(_Scheduler, Worker):
                 (TaskMethodInput, self.run_task_method),
                 (OffloadReqInput, self.offload_model_weights),
                 (SyncWeightInput, self.sync_weight),
+                (SyncHFWeightInput, self.sync_hf_weight),
             ]
         )
         self.cfg = config
@@ -127,6 +130,11 @@ class Scheduler(_Scheduler, Worker):
             )
 
             self.actor_weight_rank = rank_map[(self.get_parent_rank(), self._rank)]
+
+        # it's important to use load_weight to load resharded weight from megatron
+        for _, module in self.tp_worker.worker.model_runner.model.named_modules():
+            if hasattr(module, "use_presharded_weights"):
+                module.use_presharded_weights = True
 
         self._logger.info(
             f"Running Scheduler dp rank {self.get_parent_rank()}, tp rank {self.tp_rank}, corresponding actor weight rank = {self.actor_weight_rank}"
@@ -184,6 +192,34 @@ class Scheduler(_Scheduler, Worker):
         self.sync_in_tp("offload_model_weights")
         # self.cuda_info("After offload Model weights and kv cache")
         return OffloadReqOutput()
+
+    def sync_hf_weight(self, recv_req: SyncHFWeightInput):
+        use_cudagraph = not self.cfg.rollout.enforce_eager
+        colocate = self.placement_mode == PlacementMode.COLLOCATED
+
+        assert use_cudagraph, "use_cudagraph must be True now."
+
+        state_dict = self.recv(
+            src_group_name=self._actor_group_name,
+            src_rank=self.actor_weight_rank,
+        )
+
+        model = self.tp_worker.worker.model_runner.model
+
+        if colocate:
+            self.resume_memory_occupation(ResumeMemoryOccupationReqInput())
+        for name, handle in state_dict.items():
+            func, args = handle
+            list_args = list(args)
+            # NOTE: the key is to change device id to the current device id
+            # in case two processes have different CUDA_VISIBLE_DEVICES
+            list_args[6] = torch.cuda.current_device()
+            new_weight = func(*list_args)
+
+            model.load_weights([(name, new_weight.clone())])
+            del new_weight
+        self.sync_in_tp("sync_hf_weight")
+        return SyncHFWeightOutput()
 
     def sync_weight(self, recv_req: SyncWeightInput):
         use_cudagraph = not self.cfg.rollout.enforce_eager

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_4/tokenizer_manager.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_4/tokenizer_manager.py
@@ -23,6 +23,8 @@ from sglang.srt.server_args import PortArgs, ServerArgs
 from .io_struct import (
     OffloadReqInput,
     OffloadReqOutput,
+    SyncHFWeightInput,
+    SyncHFWeightOutput,
     SyncWeightInput,
     SyncWeightOutput,
     TaskMethodInput,
@@ -52,6 +54,9 @@ class TokenizerManager(_TokenizerManager):
         self.sync_weight_communicator = _Communicator(
             self.send_to_scheduler, server_args.dp_size
         )
+        self.sync_hf_weight_communicator = _Communicator(
+            self.send_to_scheduler, server_args.dp_size
+        )
 
         self._result_dispatcher._mapping.extend(
             [
@@ -66,6 +71,10 @@ class TokenizerManager(_TokenizerManager):
                 (
                     SyncWeightOutput,
                     self.sync_weight_communicator.handle_recv,
+                ),
+                (
+                    SyncHFWeightOutput,
+                    self.sync_hf_weight_communicator.handle_recv,
                 ),
             ]
         )
@@ -93,6 +102,14 @@ class TokenizerManager(_TokenizerManager):
         if obj is None:
             obj = OffloadReqInput()
         await self.offload_model_weights_communicator(obj)
+
+    async def sync_hf_weight(
+        self,
+        obj: SyncHFWeightInput,
+        request: Optional[fastapi.Request] = None,
+    ):
+        self.auto_create_handle_loop()
+        await self.sync_hf_weight_communicator(obj)
 
     async def sync_weight(
         self,

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_6/io_struct.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_6/io_struct.py
@@ -47,3 +47,13 @@ class SyncWeightInput:
 @dataclass
 class SyncWeightOutput:
     pass
+
+
+@dataclass
+class SyncHFWeightInput:
+    pass
+
+
+@dataclass
+class SyncHFWeightOutput:
+    pass

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_6/sgl_engine.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_6/sgl_engine.py
@@ -46,7 +46,7 @@ from sglang.srt.utils import (
 from rlinf.scheduler import WorkerAddress
 from rlinf.utils.placement import ComponentPlacement
 
-from .io_struct import OffloadReqInput, SyncWeightInput
+from .io_struct import OffloadReqInput, SyncHFWeightInput, SyncWeightInput
 from .sgl_scheduler import run_scheduler_process
 from .tokenizer_manager import TokenizerManager
 
@@ -103,6 +103,11 @@ class Engine(_Engine):
         return loop.run_until_complete(
             self.tokenizer_manager.offload_model_weights(obj, None)
         )
+
+    def sync_hf_weight(self):
+        obj = SyncHFWeightInput()
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self.tokenizer_manager.sync_hf_weight(obj))
 
     def sync_weight(self):
         obj = SyncWeightInput()

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_6/sgl_scheduler.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_6/sgl_scheduler.py
@@ -51,6 +51,8 @@ from rlinf.workers.rollout.utils import (
 from .io_struct import (
     OffloadReqInput,
     OffloadReqOutput,
+    SyncHFWeightInput,
+    SyncHFWeightOutput,
     SyncWeightInput,
     SyncWeightOutput,
     TaskMethodInput,
@@ -94,6 +96,7 @@ class Scheduler(_Scheduler, Worker):
                 (TaskMethodInput, self.run_task_method),
                 (OffloadReqInput, self.offload_model_weights),
                 (SyncWeightInput, self.sync_weight),
+                (SyncHFWeightInput, self.sync_hf_weight),
             ]
         )
         self.cfg = config
@@ -126,6 +129,10 @@ class Scheduler(_Scheduler, Worker):
             )
 
             self.actor_weight_rank = rank_map[(self.get_parent_rank(), self._rank)]
+        # it's important to use load_weight to load resharded weight from megatron
+        for _, module in self.tp_worker.worker.model_runner.model.named_modules():
+            if hasattr(module, "use_presharded_weights"):
+                module.use_presharded_weights = True
 
         self._logger.info(
             f"Running Scheduler dp rank {self.get_parent_rank()}, tp rank {self.tp_rank}, corresponding actor weight rank = {self.actor_weight_rank}"
@@ -183,6 +190,34 @@ class Scheduler(_Scheduler, Worker):
         self.sync_in_tp("offload_model_weights")
         # self.cuda_info("After offload Model weights and kv cache")
         return OffloadReqOutput()
+
+    def sync_hf_weight(self, recv_req: SyncHFWeightInput):
+        use_cudagraph = not self.cfg.rollout.enforce_eager
+        colocate = self.placement_mode == PlacementMode.COLLOCATED
+
+        assert use_cudagraph, "use_cudagraph must be True now."
+
+        state_dict = self.recv(
+            src_group_name=self._actor_group_name,
+            src_rank=self.actor_weight_rank,
+        )
+
+        model = self.tp_worker.worker.model_runner.model
+
+        if colocate:
+            self.resume_memory_occupation(ResumeMemoryOccupationReqInput())
+        for name, handle in state_dict.items():
+            func, args = handle
+            list_args = list(args)
+            # NOTE: the key is to change device id to the current device id
+            # in case two processes have different CUDA_VISIBLE_DEVICES
+            list_args[6] = torch.cuda.current_device()
+            new_weight = func(*list_args)
+
+            model.load_weights([(name, new_weight.clone())])
+            del new_weight
+        self.sync_in_tp("sync_hf_weight")
+        return SyncHFWeightOutput()
 
     def sync_weight(self, recv_req: SyncWeightInput):
         use_cudagraph = not self.cfg.rollout.enforce_eager

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_6/tokenizer_manager.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_6/tokenizer_manager.py
@@ -22,6 +22,8 @@ from sglang.srt.server_args import PortArgs, ServerArgs
 from .io_struct import (
     OffloadReqInput,
     OffloadReqOutput,
+    SyncHFWeightInput,
+    SyncHFWeightOutput,
     SyncWeightInput,
     SyncWeightOutput,
     TaskMethodInput,
@@ -51,6 +53,9 @@ class TokenizerManager(_TokenizerManager):
         self.sync_weight_communicator = _Communicator(
             self.send_to_scheduler, server_args.dp_size
         )
+        self.sync_hf_weight_communicator = _Communicator(
+            self.send_to_scheduler, server_args.dp_size
+        )
 
         self._result_dispatcher._mapping.extend(
             [
@@ -65,6 +70,10 @@ class TokenizerManager(_TokenizerManager):
                 (
                     SyncWeightOutput,
                     self.sync_weight_communicator.handle_recv,
+                ),
+                (
+                    SyncHFWeightOutput,
+                    self.sync_hf_weight_communicator.handle_recv,
                 ),
             ]
         )
@@ -92,6 +101,16 @@ class TokenizerManager(_TokenizerManager):
         if obj is None:
             obj = OffloadReqInput()
         await self.offload_model_weights_communicator(obj)
+
+    async def sync_hf_weight(
+        self,
+        obj: SyncHFWeightInput = None,
+        request: Optional[fastapi.Request] = None,
+    ):
+        self.auto_create_handle_loop()
+        if obj is None:
+            obj = SyncHFWeightInput()
+        await self.sync_hf_weight_communicator(obj)
 
     async def sync_weight(
         self,

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_9/io_struct.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_9/io_struct.py
@@ -47,3 +47,13 @@ class SyncWeightInput:
 @dataclass
 class SyncWeightOutput:
     pass
+
+
+@dataclass
+class SyncHFWeightInput:
+    pass
+
+
+@dataclass
+class SyncHFWeightOutput:
+    pass

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_9/sgl_engine.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_9/sgl_engine.py
@@ -46,7 +46,7 @@ from sglang.srt.utils import (
 from rlinf.scheduler import WorkerAddress
 from rlinf.utils.placement import ComponentPlacement
 
-from .io_struct import OffloadReqInput, SyncWeightInput
+from .io_struct import OffloadReqInput, SyncHFWeightInput, SyncWeightInput
 from .sgl_scheduler import run_scheduler_process
 from .tokenizer_manager import TokenizerManager
 
@@ -104,6 +104,11 @@ class Engine(_Engine):
         return loop.run_until_complete(
             self.tokenizer_manager.offload_model_weights(obj, None)
         )
+
+    def sync_hf_weight(self):
+        obj = SyncHFWeightInput()
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(self.tokenizer_manager.sync_hf_weight(obj))
 
     def sync_weight(self):
         obj = SyncWeightInput()

--- a/rlinf/workers/rollout/sglang/sglang_worker.py
+++ b/rlinf/workers/rollout/sglang/sglang_worker.py
@@ -160,7 +160,7 @@ class SGLangWorker(Worker):
         self._engine.offload_model_weights()
 
     def sync_model_from_actor(self):
-        self._engine.sync_weight()
+        self._engine.sync_hf_weight()
 
     def rollout(self, input_channel: Channel, output_channel: Channel):
         while True:
@@ -362,8 +362,8 @@ class AsyncSGLangWorker(SGLangWorker):
 
     async def sync_model_from_actor(self):
         """Update the weights of the SGLang engine."""
-        await self._engine.tokenizer_manager.sync_weight(
-            obj=io_struct.SyncWeightInput()
+        await self._engine.tokenizer_manager.sync_hf_weight(
+            obj=io_struct.SyncHFWeightInput()
         )
 
     def shutdown(self):


### PR DESCRIPTION
Feature: add online weight transform from mg to hf when sglang sync weight

Breaking:  it will change the format of weight sync from megatron to sglang.

### Description
add online weight transform from mg to hf when sglang trying to sync weight.  it's done by `TransformFunc` 's functions in `rlinf/utils/resharding/utils.py`. currently it only support qwen2_5 model arch.  To accept hf weight, I use SGLang's inner function `model.load_weights` to  load weights which are resharded by megatron.

### How has this been tested?
Tested 1.5B, 7B in single machine with 8 A800, 1.5B in 4 machines with 32 H100.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

### Breaking

It will change the way of syncing weight from megatron to sglang by turning resharded weight into huggingface format at megatron's side, then use `load_weights` to load corresponding weights. Furthermore, it requires that cuda graph be enabled.
