### PR TITLE
hotfix: use reduce_tensor to serialize weight when syncing to sglang

### DIFF
--- a/rlinf/workers/actor/megatron_actor_worker.py
+++ b/rlinf/workers/actor/megatron_actor_worker.py
@@ -928,9 +928,10 @@ class MegatronActor(MegatronModelManager, Worker):
                 f"In disaggregated mode, weight_dst_rank_in_rollout should be a list of ranks, got {type(self._weight_dst_rank_in_rollout)}"
             )
             self.reshard_state_dict = self._get_rollout_model_state_dict()
+            handle = {k: reduce_tensor(v) for k, v in self.reshard_state_dict.items()}
             for weight_dst_rank in self._weight_dst_rank_in_rollout:
                 self.send(
-                    self.reshard_state_dict,
+                    handle,
                     self._rollout_group_name,
                     weight_dst_rank,
                 )


### PR DESCRIPTION

### Description
Fix sync weight from megatron to sglang in disaggrated mode, use `reduce_tensor` to serialize resharded state_dict.


### How has this been tested?
Tested 1.5B in 8 A800 in disaggrated mode.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.