### PR TITLE
fix: fix fsdp wrap to support use_orig_param=True

### DIFF
--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -88,15 +88,13 @@ class FSDPModelManager:
 
         if self._cfg.model.sharding_strategy == "full_shard":
             sharding_strategy = ShardingStrategy.FULL_SHARD
-            auto_wrap_policy = get_fsdp_wrap_policy(
-                module=module, config=None, is_lora=self._cfg.model.is_lora
-            )
         elif self._cfg.model.sharding_strategy == "shard_grad_op":
             sharding_strategy = ShardingStrategy.SHARD_GRAD_OP
-            auto_wrap_policy = None
         else:
             sharding_strategy = ShardingStrategy.NO_SHARD
-            auto_wrap_policy = None
+        auto_wrap_policy = get_fsdp_wrap_policy(
+            module=module, config=None, is_lora=self._cfg.model.is_lora
+        )
 
         betas = (self._cfg.optim.adam_beta1, self._cfg.optim.adam_beta2)
 

--- a/rlinf/hybrid_engines/fsdp/utils.py
+++ b/rlinf/hybrid_engines/fsdp/utils.py
@@ -32,7 +32,6 @@ import torch
 from accelerate import init_empty_weights
 from prismatic.extern.hf.modeling_prismatic import PrismaticProjector
 from torch.distributed.fsdp.wrap import (
-    size_based_auto_wrap_policy,
     transformer_auto_wrap_policy,
 )
 from transformers.trainer_pt_utils import get_module_class_from_name
@@ -97,13 +96,12 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
         "transformer_layer_cls_to_wrap", default_transformer_cls_names_to_wrap
     )
 
-
     # Build policies list
     policies = []
 
     # Add vision transformer policies for VLA models
     if is_vla_model:
-        from timm.models.vision_transformer import Block, VisionTransformer
+        from timm.models.vision_transformer import VisionTransformer
         from torch.distributed.fsdp.wrap import _module_wrap_policy, _or_policy
 
         # Vision transformer policies
@@ -118,12 +116,12 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
             module_classes={PrismaticProjector},
         )
         policies.append(prismatic_fsdp_wrapping_policy)
-        
+
         if hasattr(module, "value_head"):
             from rlinf.models.embodiment.modules.value_head import ValueHead
+
             value_head_policy = functools.partial(
-                _module_wrap_policy,
-                module_classes={ValueHead}
+                _module_wrap_policy, module_classes={ValueHead}
             )
             policies.append(value_head_policy)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Change the auto_wrap_policy for fsdp.
- Delete the nesting wrapped modules in vision encoders and apply auto_wrap_policy for all FSDP shard strategy. 
- Add the missing wrapped module for ValueHead. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Under the default ``use_orig_param=True`` setting, 
- Previously using ``NO_SHARD`` will cause nn.Module parameters shape error.
- Previously using ``is_lora=False`` under PPO setting will cause error. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run default embodiment test scripts. 
To test the first modification, you can set the actor placement on one gpu only.
To test the second modification, you can set ``is_lora=False`` with any ppo yamls. 

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.