### PR TITLE
fix: description of vh_mode parameter in doc

### DIFF
--- a/docs/source-en/rst_source/tutorials/user/yaml.rst
+++ b/docs/source-en/rst_source/tutorials/user/yaml.rst
@@ -963,7 +963,7 @@ actor
 
 ``actor.model.policy_setup``: Policy configuration (widowx_bridge).
 
-``actor.model.vh_mode``: Vision-head mode (a0).
+``actor.model.vh_mode``: Value-head mode (a0).
 
 ``actor.model.image_size``: Input image dimensions [height, width].
 

--- a/docs/source-zh/rst_source/tutorials/user/yaml.rst
+++ b/docs/source-zh/rst_source/tutorials/user/yaml.rst
@@ -901,7 +901,7 @@ actor
 
 ``actor.model.policy_setup``：策略配置（widowx_bridge）。  
 
-``actor.model.vh_mode``：视觉头模式（a0）。  
+``actor.model.vh_mode``：价值头模式（a0）。  
 
 ``actor.model.image_size``：输入图像尺寸 [H, W]。  
 


### PR DESCRIPTION
The param vh_mode means "Value head mode", but incorrectly described as "Vision head mode" in document.

### Description
Correct the descriptions in Chinese and English documents.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.