### PR TITLE
fix(sglang): reset radix tree after weight sync

### DIFF
--- a/rlinf/hybrid_engines/sglang/sglang_0_4_4/sgl_scheduler.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_4/sgl_scheduler.py
@@ -199,6 +199,7 @@ class Scheduler(_Scheduler, Worker):
             # disaggregate mode, recv tensor directly
             for name, tensor in state_dict.items():
                 model.load_weights([(name, tensor)])
+        self.flush_cache()
         self.sync_in_tp("sync_hf_weight")
         return SyncHFWeightOutput()
 

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_6/sgl_scheduler.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_6/sgl_scheduler.py
@@ -197,6 +197,7 @@ class Scheduler(_Scheduler, Worker):
             # disaggregate mode, recv tensor directly
             for name, tensor in state_dict.items():
                 model.load_weights([(name, tensor)])
+        self.flush_cache()
         self.sync_in_tp("sync_hf_weight")
         return SyncHFWeightOutput()
 

--- a/rlinf/hybrid_engines/sglang/sglang_0_4_9/sgl_scheduler.py
+++ b/rlinf/hybrid_engines/sglang/sglang_0_4_9/sgl_scheduler.py
@@ -199,6 +199,7 @@ class Scheduler(_Scheduler, Worker):
             # disaggregate mode, recv tensor directly
             for name, tensor in state_dict.items():
                 model.load_weights([(name, tensor)])
+        self.flush_cache()
         self.sync_in_tp("sync_hf_weight")
         return SyncHFWeightOutput()
 

--- a/rlinf/runners/math_runner.py
+++ b/rlinf/runners/math_runner.py
@@ -181,7 +181,7 @@ class MathRunner:
         if self.cfg.runner.resume_dir is None:
             return
 
-        # Checkpoint loading
+        # Resume from checkpoint
         logging.info(f"Load from checkpoint folder: {self.cfg.runner.resume_dir}")
         # set global step
         self.global_steps = int(self.cfg.runner.resume_dir.split("global_step_")[-1])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
SGLang's radix tree for KV cache needs to be reset after weight sync. Otherwise, it may use old KV cache for future rollout.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In pipeline mode, this causes reward to drop after a long run. In collocated mode, because offloading weight indirectly calls `flush_cache`, the problem doesn't manifest.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested for pipeline mode. The reward is now grows normally.

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.