### PR TITLE
feat: simplify the maniskill reset id

### DIFF
--- a/rlinf/envs/maniskill/maniskill_env.py
+++ b/rlinf/envs/maniskill/maniskill_env.py
@@ -111,15 +111,12 @@ class ManiskillEnv(gym.Env):
     def _init_reset_state_ids(self):
         self._generator = torch.Generator()
         self._generator.manual_seed(self.seed)
-        self.all_reset_state_ids = torch.randperm(
-            self.total_num_group_envs, generator=self._generator
-        ).to(self.device)
         self.update_reset_state_ids()
 
     def update_reset_state_ids(self):
         reset_state_ids = torch.randint(
             low=0,
-            high=len(self.all_reset_state_ids),
+            high=len(self.total_num_group_envs),
             size=(self.num_group,),
             generator=self._generator,
         )

--- a/rlinf/envs/maniskill/maniskill_env.py
+++ b/rlinf/envs/maniskill/maniskill_env.py
@@ -116,7 +116,7 @@ class ManiskillEnv(gym.Env):
     def update_reset_state_ids(self):
         reset_state_ids = torch.randint(
             low=0,
-            high=len(self.total_num_group_envs),
+            high=self.total_num_group_envs,
             size=(self.num_group,),
             generator=self._generator,
         )

--- a/rlinf/envs/offload_wrapper/maniskill_wrapper.py
+++ b/rlinf/envs/offload_wrapper/maniskill_wrapper.py
@@ -65,7 +65,6 @@ class ManiskillEnv(BaseManiskillEnv, EnvOffloadMixin):
             "action_space_state": action_space_state,
             "prev_step_reward": self.prev_step_reward.cpu(),
             "reset_state_ids": self.reset_state_ids.cpu(),
-            "all_reset_state_ids": self.all_reset_state_ids.cpu(),
             "generator_state": self._generator.get_state(),
             "is_start": self.is_start,
             "video_cnt": self.video_cnt,
@@ -176,7 +175,6 @@ class ManiskillEnv(BaseManiskillEnv, EnvOffloadMixin):
         # Restore simulator task state
         self.prev_step_reward = state["prev_step_reward"].to(self.device)
         self.reset_state_ids = state["reset_state_ids"].to(self.device)
-        self.all_reset_state_ids = state["all_reset_state_ids"].to(self.device)
         self._generator.set_state(state["generator_state"])
         self.is_start = state["is_start"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Simplify the logic for selecting random reset ids in ManiSkill.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, if the number of possible groups for one env is too large, there will be unnecessary tensor allocation. 

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Test the evaluation scripts with the ``PutOnPlateInScene25EEPose-v1`` env. 

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.