### PR TITLE
fix: openvla/oft dependency issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,8 @@ repos:
     rev: "v0.12.9"
     hooks:
       - id: ruff
-        args: ["--preview"]
+        args: ["--preview", "--fix"]
       - id: ruff-format
-        args: ["--check"]
 
   - repo: https://github.com/commit-check/commit-check
     rev: "v0.10.2"

--- a/docker/embodied/Dockerfile.openvla.hf.fsdp
+++ b/docker/embodied/Dockerfile.openvla.hf.fsdp
@@ -85,6 +85,9 @@ RUN pip install \
 
 RUN pip install -r /workspace/openvla/experiments/robot/libero/libero_requirements.txt 
 
+# OpenVLA overrides torch with v2.2, needs to be reset
+RUN pip install torch==2.5.1
+
 RUN echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 RUN echo "conda activate" >> ~/.bashrc
 

--- a/docker/embodied/Dockerfile.openvlaoft.hf.fsdp
+++ b/docker/embodied/Dockerfile.openvlaoft.hf.fsdp
@@ -85,6 +85,9 @@ RUN pip install \
 
 RUN pip install -r /workspace/openvla_oft/experiments/robot/libero/libero_requirements.txt 
 
+# OpenVLA overrides torch with v2.2, needs to be reset
+RUN pip install torch==2.5.1
+
 RUN echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 RUN echo "conda activate" >> ~/.bashrc
 

--- a/docs/source-en/rst_source/start/installation.rst
+++ b/docs/source-en/rst_source/start/installation.rst
@@ -186,7 +186,7 @@ vLLM installation:
 
 .. _embodied-dependencies:
 
-Additional Embodied Dependencies
+Embodied Dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For embodied experiments, first install the necessary system dependencies (currently only supported on Debian/Ubuntu via ``apt``):
@@ -200,8 +200,11 @@ Then, depending on the experiment type, install the required packages for ``open
 
 .. code-block:: shell
 
-   # For OpenVLA/OpenVLA-oft experiments
+   # For OpenVLA experiments
    UV_TORCH_BACKEND=auto uv pip install -r requirements/openvla.txt --no-build-isolation
+
+   # For OpenVLA-oft experiment
+   UV_TORCH_BACKEND=auto uv pip install -r requirements/openvla_oft.txt --no-build-isolation
 
    # For Pi0 experiments
    UV_TORCH_BACKEND=auto uv pip install -r requirements/pi0.txt --no-build-isolation

--- a/docs/source-en/rst_source/start/llm.rst
+++ b/docs/source-en/rst_source/start/llm.rst
@@ -53,14 +53,15 @@ we highly recommend updating the following configuration option in
 ``cluster.component_placement``.
 
 
-You can dynamically set it to **1, 2, 4, or 8** depending on your available resources.
+You can set it to **0-1**, **0-3** or  **0-7** to use 2/4/8 GPUs depending on your available resources.
+Refer to :doc:`../../tutorials/user/yaml` for a more detailed explanation of the placement configuration.
 
 .. code-block:: yaml
 
    cluster:
      num_nodes: 1
      component_placement:
-        actor,rollout: all
+        actor,rollout: 0
 
 Finally, before running the script, you need to modify the corresponding configuration options in the YAML file according to the download paths of the model and dataset. Specifically, update:
 

--- a/docs/source-en/rst_source/start/vla.rst
+++ b/docs/source-en/rst_source/start/vla.rst
@@ -34,20 +34,21 @@ the model is cited in `paper <https://arxiv.org/abs/2505.19789>`_
 
 **Step 2: Execute the provided launch script:**
 
-For user convenience, our configuration file is set up to run with a single GPU by default.  
+For user convenience, our configuration file is set up to run with at least two GPUs by default.  
 However, if you have multiple GPUs and wish to accelerate the quickstart process,  
 we highly recommend updating the following configuration option in  
 ``./examples/embodiment/config/maniskill_ppo_openvla_quickstart.yaml``:  
 ``cluster.component_placement``.
 
-You can dynamically set it to **1, 2, 4, or 8** depending on your available resources.
+You can set it to **0-3** or  **0-7** to use 4/8 GPUs depending on your available resources.
+Refer to :doc:`../../tutorials/user/yaml` for a more detailed explanation of the placement configuration.
 
 .. code-block:: yaml
 
    cluster:
      num_nodes: 1
      component_placement:
-        actor,rollout: all
+        actor,rollout: 0-1
 
 Finally, before running the script, you need to modify the corresponding configuration options in the YAML file according to the download paths of the model and dataset. Specifically, update:
 

--- a/docs/source-zh/rst_source/start/installation.rst
+++ b/docs/source-zh/rst_source/start/installation.rst
@@ -121,10 +121,10 @@ RLinf 提供两种安装方式。我们 **推荐使用 Docker**，因为这可�
 这一步已经包括了 **FSDP + Huggingface** 的完整配置。
 
 第二步，如果你的实验使用的是 **Megatron 和 SGLang/vLLM** 后端，  
-请参考 :ref:`Megatron 及 SGLang/vLLM 依赖 <megatron-and-sglang-vllm-dependencies>` 安装相应依赖。
+请参考 :ref:`Megatron 和 SGLang/vLLM 依赖 <megatron-and-sglang-vllm-dependencies>` 安装相应依赖。
 
 第三步，如果你要运行具身智能相关实验（如 OpenVLA、OpenVLA-OFT、Pi0），  
-请参考 :ref:`具身智能依赖 <embodied-dependencies>` 安装专用依赖项。
+请参考 :ref:`具身智能相关依赖 <embodied-dependencies>` 安装专用依赖项。
 
 .. _common-dependencies:
 
@@ -195,8 +195,11 @@ vLLM 安装：
 
 .. code-block:: shell
 
-   # OpenVLA / OpenVLA-OFT 实验所需依赖
+   # OpenVLA 实验所需依赖
    UV_TORCH_BACKEND=auto uv pip install -r requirements/openvla.txt --no-build-isolation
+
+   # OpenVLA-oft 实验所需依赖
+   UV_TORCH_BACKEND=auto uv pip install -r requirements/openvla_oft.txt --no-build-isolation
 
    # Pi0 实验所需依赖
    UV_TORCH_BACKEND=auto uv pip install -r requirements/pi0.txt --no-build-isolation

--- a/docs/source-zh/rst_source/start/llm.rst
+++ b/docs/source-zh/rst_source/start/llm.rst
@@ -50,14 +50,15 @@
 我们推荐你修改配置文件  
 ``./examples/math/config/qwen2.5-1.5b-single-gpu.yaml`` 中的参数 ``cluster.component_placement``。
 
-你可以根据资源情况将其动态设置为 **1, 2, 4 或 8**。
+你可以根据实际资源将该项设置为 **0-1**， **0-3** 或 **0-7**来使用 2/4/8 张 GPU。
+查看 :doc:`../../tutorials/user/yaml` 以获取有关 Placement 配置的更详细说明。
 
 .. code-block:: yaml
 
    cluster:
      num_nodes: 1
      component_placement:
-        actor,rollout: all
+        actor,rollout: 0
 
 在运行脚本之前，请根据你的模型和数据集下载路径，  
 在 YAML 配置文件中修改以下字段：

--- a/docs/source-zh/rst_source/start/vla.rst
+++ b/docs/source-zh/rst_source/start/vla.rst
@@ -34,20 +34,21 @@ ManiSkill3 是一个基于 GPU 加速的机器人研究仿真平台，
 
 **步骤 2：运行官方提供的训练脚本**
 
-为方便使用，我们提供的配置文件默认支持单卡训练。  
+为方便使用，我们提供的配置文件需要至少双卡进行训练。  
 如果你有多张 GPU 并希望加快训练速度，  
 建议你修改配置文件  
 ``./examples/embodiment/config/maniskill_ppo_openvla_quickstart.yaml`` 中的参数  
 ``cluster.component_placement``。
 
-你可以根据实际资源设置为 **1、2、4 或 8**。
+你可以根据实际资源将该项设置为 **0-3** 或 **0-7**来使用 4/8 张 GPU。
+查看 :doc:`../../tutorials/user/yaml` 以获取有关 Placement 配置的更详细说明。
 
 .. code-block:: yaml
 
    cluster:
      num_nodes: 1
      component_placement:
-        actor,rollout: all
+        actor,rollout: 0-1
 
 运行脚本之前，请根据你下载的模型和数据集路径，修改 YAML 文件中的以下字段：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pybind11",
     "torch-memory-saver",
     "setuptools>=69.5.1,<75.9",
+    "ninja",
 
     # Logging
     "swanlab",
@@ -80,6 +81,11 @@ conflicts = [
       { extra = "vllm" },
       { extra = "embodied" },
     ],
+]
+override-dependencies = [
+    "torch==2.6.0",
+    "torchvision==0.21.0",
+    "torchaudio==2.6.0"
 ]
 
 [tool.ruff]

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -53,10 +53,13 @@ For embodied experiments, first install the necessary system dependencies (curre
 bash requirements/install_embodied_deps.sh
 uv sync --extra embodied
 ```
-Next, depending on the experiment types, install the `openvla` or `pi0` dependencies.
+Next, depending on the experiment types, install the `openvla`, `openvla_oft` or `pi0` dependencies.
 ```shell
-# For OpenVLA/OpenVLA-oft experiments
+# For OpenVLA experiments
 UV_TORCH_BACKEND=auto uv pip install -r requirements/openvla.txt --no-build-isolation
+
+# For OpenVLA-oft experiment
+UV_TORCH_BACKEND=auto uv pip install -r requirements/openvla_oft.txt --no-build-isolation
 
 # For Pi0 experiment
 UV_TORCH_BACKEND=auto uv pip install -r requirements/pi0.txt --no-build-isolation

--- a/requirements/openvla.txt
+++ b/requirements/openvla.txt
@@ -1,6 +1,4 @@
 openvla @ git+https://github.com/openvla/openvla.git
-openvla_oft @ git+https://github.com/moojink/openvla-oft.git
-# https://github.com/openvla/openvla/blob/main/experiments/robot/libero/libero_requirements.txt
 flash-attn==2.5.5
 imageio[ffmpeg]
 robosuite==1.4.1

--- a/requirements/openvla_oft.txt
+++ b/requirements/openvla_oft.txt
@@ -1,0 +1,9 @@
+openvla_oft @ git+https://github.com/moojink/openvla-oft.git
+# https://github.com/openvla/openvla/blob/main/experiments/robot/libero/libero_requirements.txt
+flash-attn==2.5.5
+imageio[ffmpeg]
+robosuite==1.4.1
+bddl
+easydict
+cloudpickle
+gym

--- a/rlinf/scheduler/worker/worker_group.py
+++ b/rlinf/scheduler/worker/worker_group.py
@@ -154,6 +154,9 @@ class WorkerGroup(Generic[WorkerClsType]):
         placements = self._placement_strategy.get_placement(
             self._cluster, self._isolate_gpu
         )
+        master_addr = next(
+            self._cluster.get_node_ip(p.node_id) for p in placements if p.rank == 0
+        )
         self._world_size = len(placements)
         for placement in placements:
             worker_name = WorkerAddress.from_parent_name_rank(
@@ -165,6 +168,7 @@ class WorkerGroup(Generic[WorkerClsType]):
             env_vars = {
                 "GROUP_NAME": self._worker_group_name,
                 "WORKER_NAME": worker_name,
+                "MASTER_ADDR": master_addr,
                 "WORLD_SIZE": str(self._world_size),
                 "RANK": str(placement.rank),
                 "NODE_RANK": str(placement.node_rank),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The pyproject dependencies and the docker files contain several issues that prevent reproducing the embodied experiments. This PR fixes the following:
* The `prismatic` package is imported at the top of the file `rlinf/hybrid_engines/fsdp/utils.py`, which then imports `accelerate`. The `accelerate` package uses whether there is a `WORLD_SIZE` env var to determine whether the environment is multi-node, which I might add it's completely wrong as the `WORLD_SIZE` env var actually refers to the total number of processes, not nodes. And since WorkerGroup always set `WORLD_SIZE`, the `accelerate` initializes a `DistributedOverwatch`, which requires `MASTER_ADDR`. However, at this point, the Worker's `__init__` has not been called (because it's still in the package import phase), where `MASTER_ADDR` is set later. This thus results in failure. This PR moves the `MASTER_ADDR` setting to before Worker process creation (therefore before package importing) to address this.
* The `openvla` and `openvla_oft` packages forces torch to be 2.2. This PR overrides the dependency to torch 2.6.0.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.