### PR TITLE
fix: default gloo group due to prismatic import & dep enhancement

### DIFF
--- a/docker/embodied/Dockerfile.openvla.hf.fsdp
+++ b/docker/embodied/Dockerfile.openvla.hf.fsdp
@@ -88,8 +88,8 @@ RUN pip install -r /workspace/openvla/experiments/robot/libero/libero_requiremen
 # OpenVLA overrides torch with v2.2, needs to be reset
 RUN pip install torch==2.5.1
 
-RUN python -m mani_skill.utils.download_asset bridge_v2_real2sim
-RUN python -m mani_skill.utils.download_asset widowx250s
+RUN python -m mani_skill.utils.download_asset bridge_v2_real2sim -y
+RUN python -m mani_skill.utils.download_asset widowx250s -y
 
 RUN echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 RUN echo "conda activate" >> ~/.bashrc

--- a/docker/embodied/Dockerfile.openvlaoft.hf.fsdp
+++ b/docker/embodied/Dockerfile.openvlaoft.hf.fsdp
@@ -88,8 +88,8 @@ RUN pip install -r /workspace/openvla_oft/experiments/robot/libero/libero_requir
 # OpenVLA overrides torch with v2.2, needs to be reset
 RUN pip install torch==2.5.1
 
-RUN python -m mani_skill.utils.download_asset bridge_v2_real2sim
-RUN python -m mani_skill.utils.download_asset widowx250s
+RUN python -m mani_skill.utils.download_asset bridge_v2_real2sim -y
+RUN python -m mani_skill.utils.download_asset widowx250s -y
 
 RUN echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 RUN echo "conda activate" >> ~/.bashrc

--- a/docker/embodied/Dockerfile.pi0.hf.fsdp
+++ b/docker/embodied/Dockerfile.pi0.hf.fsdp
@@ -85,8 +85,8 @@ RUN pip install \
     -e /workspace/libero \
     -e /workspace/lerobot
 
-RUN python -m mani_skill.utils.download_asset bridge_v2_real2sim
-RUN python -m mani_skill.utils.download_asset widowx250s
+RUN python -m mani_skill.utils.download_asset bridge_v2_real2sim -y
+RUN python -m mani_skill.utils.download_asset widowx250s -y
 
 RUN echo "source /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
 RUN echo "conda activate" >> ~/.bashrc

--- a/docs/source-en/rst_source/start/installation.rst
+++ b/docs/source-en/rst_source/start/installation.rst
@@ -162,27 +162,15 @@ Run the following commands to install Megatron, SGLang or vLLM, and their depend
 
 .. code-block:: shell
 
-   uv sync --extra sgl_vllm
+   uv sync --extra sglang-vllm
    mkdir -p /opt && git clone https://github.com/NVIDIA/Megatron-LM.git -b core_r0.13.0 /opt/Megatron-LM
-   APEX_CPP_EXT=1 APEX_CUDA_EXT=1 uv pip install -r requirements/megatron.txt --no-build-isolation
+   APEX_CPP_EXT=1 APEX_CUDA_EXT=1 NVCC_APPEND_FLAGS="--threads 24" APEX_PARALLEL_BUILD=24 uv pip install -r requirements/megatron.txt --no-build-isolation
 
 Before using Megatron, ensure its path is added to the ``PYTHONPATH`` environment variable:
 
 .. code-block:: shell
 
    export PYTHONPATH=/opt/Megatron-LM:$PYTHONPATH
-
-SGLang installation:
-
-.. code-block:: shell
-
-   uv sync --extra sglang
-
-vLLM installation:
-
-.. code-block:: shell
-
-   uv sync --extra vllm
 
 .. _embodied-dependencies:
 

--- a/docs/source-zh/rst_source/start/installation.rst
+++ b/docs/source-zh/rst_source/start/installation.rst
@@ -157,27 +157,15 @@ Megatron 和 SGLang/vLLM 依赖
 
 .. code-block:: shell
 
-   uv sync --extra sgl_vllm
+   uv sync --extra sglang-vllm
    mkdir -p /opt && git clone https://github.com/NVIDIA/Megatron-LM.git -b core_r0.13.0 /opt/Megatron-LM
-   APEX_CPP_EXT=1 APEX_CUDA_EXT=1 uv pip install -r requirements/megatron.txt --no-build-isolation
+   APEX_CPP_EXT=1 APEX_CUDA_EXT=1 NVCC_APPEND_FLAGS="--threads 24" APEX_PARALLEL_BUILD=24 uv pip install -r requirements/megatron.txt --no-build-isolation
 
 使用 Megatron 前，请将其路径加入 ``PYTHONPATH`` 环境变量：
 
 .. code-block:: shell
 
    export PYTHONPATH=/opt/Megatron-LM:$PYTHONPATH
-
-SGLang 安装：
-
-.. code-block:: shell
-
-   uv sync --extra sglang
-
-vLLM 安装：
-
-.. code-block:: shell
-
-   uv sync --extra vllm
 
 .. _embodied-dependencies:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sglang = [
+sglang-vllm = [
     "transformers==4.51.1",
     "sglang[all]==0.4.6.post5",
-]
-vllm = [
-    "transformers==4.51.1",
     "vllm==0.8.5",
 ]
 embodied = [
@@ -77,15 +74,15 @@ embodied = [
 prerelease = "allow"
 conflicts = [
     [
-      { extra = "sglang" },
-      { extra = "vllm" },
+      { extra = "sglang-vllm" },
       { extra = "embodied" },
     ],
 ]
 override-dependencies = [
     "torch==2.6.0",
     "torchvision==0.21.0",
-    "torchaudio==2.6.0"
+    "torchaudio==2.6.0",
+    "xgrammar==0.1.19"
 ]
 
 [tool.ruff]

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -26,25 +26,14 @@ UV_TORCH_BACKEND=auto uv sync
 ### Megatron and SGLang/vLLM Dependencies
 Run the following to install Megatron, SGLang or vLLM and their dependencies.
 
-Megatron installation:
 ```shell
-uv sync --extra sgl_vllm
+uv sync --extra sglang-vllm
 mkdir -p /opt && git clone https://github.com/NVIDIA/Megatron-LM.git -b core_r0.13.0 /opt/Megatron-LM
-APEX_CPP_EXT=1 APEX_CUDA_EXT=1 uv pip install -r requirements/megatron.txt --no-build-isolation
+APEX_CPP_EXT=1 APEX_CUDA_EXT=1 NVCC_APPEND_FLAGS="--threads 24" APEX_PARALLEL_BUILD=24 uv pip install -r requirements/megatron.txt --no-build-isolation
 ```
 Before using Megatron, make sure it's path is added to the `PYTHONPATH` environment variables.
 ```shell
 export PYTHONPATH=/opt/Megatron-LM:$PYTHONPATH
-```
-
-SGLang installation:
-```shell
-uv sync --extra sglang
-```
-
-vLLM installation:
-```shell
-uv sync --extra vllm
 ```
 
 ### Embodied Dependencies

--- a/requirements/install_embodied_deps.sh
+++ b/requirements/install_embodied_deps.sh
@@ -18,9 +18,9 @@ apt-get install -y --no-install-recommends \
     libsm6 \
     libxext6 \
     libxrender-dev \
-    libgomp1 \
+    libgomp1
 
-python -m mani_skill.utils.download_asset bridge_v2_real2sim
-python -m mani_skill.utils.download_asset widowx250s
+python -m mani_skill.utils.download_asset bridge_v2_real2sim -y
+python -m mani_skill.utils.download_asset widowx250s -y
 
 

--- a/rlinf/workers/rollout/sglang/__init__.py
+++ b/rlinf/workers/rollout/sglang/__init__.py
@@ -30,7 +30,7 @@ package_version = get_version(package_name)
 sglang_version = None
 
 if package_version is None:
-    raise ValueError(f"vllm version {package_version} not supported")
+    raise ValueError(f"sglang version {package_version} not supported")
 elif package_version >= parse("0.4.4") and package_version < parse("0.4.6.post2"):
     sglang_version = package_version
     from rlinf.hybrid_engines.sglang.sglang_0_4_4 import io_struct


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The `prismatic` package initializes a `DistributedOverwatch` by default, which initializes `accelerate.PartialState`, which in turn initializes a torch.distributed process group in `GLOO`. This results in default group being `GLOO`, which does not support CUDA tensors and allreduce average. The docker image includes a custom version of `prismatic` and so the problem does not exist. But this custom version is not included in the Dockerfile and the pyproject.toml, causing problems when run with custom environment.

This fix moves the `prismatic` import lazily when used to avoid creating process group before FSDP. This fixes https://github.com/RLinf/RLinf/issues/125.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.