### PR TITLE
fix: remove env channel timeout

### DIFF
--- a/rlinf/envs/env_manager.py
+++ b/rlinf/envs/env_manager.py
@@ -213,7 +213,7 @@ class EnvManager:
         self.process.start()
 
         # Wait for initialization
-        result = self.result_queue.get(timeout=60)
+        result = self.result_queue.get()
         if result["status"] != "ready":
             raise RuntimeError(f"Simulator initialization failed: {result}")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR removes the unnecessary timeout value for channel in env_manager, which causes random crash when simulators take a long time to initialize.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.