### PR TITLE
chore: use modern Python 3.9+ annotation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 isort = {known-first-party = ["rlinf"]}
-select = ["C", "E", "F", "I", "W", "CPY001", "RUF013", "PERF102", "PLC1802", "PLC0208", "D", "RUF002"]
+select = ["C", "E", "F", "I", "W", "CPY001", "RUF013", "UP006", "PERF102", "PLC1802", "PLC0208", "D", "RUF002"]
 ignore = [
     "C901", # "complex-structure"
     "E501", # "line-too-long"

--- a/rlinf/algorithms/advantages.py
+++ b/rlinf/algorithms/advantages.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 
@@ -32,7 +32,7 @@ def compute_gae_advantages_and_returns(
     loss_mask: Optional[torch.Tensor] = None,
     dones: Optional[torch.Tensor] = None,
     **kwargs,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Calculate advantages and returns for Proximal Policy Optimization (PPO).
     NOTE: currently this function does not support auto-reset.

--- a/rlinf/algorithms/losses.py
+++ b/rlinf/algorithms/losses.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Optional
 
 import torch
 
@@ -34,7 +34,7 @@ def compute_ppo_actor_loss(
     loss_mask_sum: Optional[torch.Tensor] = None,
     critic_warmup: Optional[bool] = False,
     **kwargs,
-) -> Tuple[torch.Tensor, Dict]:
+) -> tuple[torch.Tensor, dict]:
     """
     Compute PPO actor loss function.
 
@@ -127,7 +127,7 @@ def compute_ppo_critic_loss(
     max_episode_steps: Optional[int] = None,
     loss_mask_sum: Optional[torch.Tensor] = None,
     **kwargs,
-) -> Tuple[torch.Tensor, Dict]:
+) -> tuple[torch.Tensor, dict]:
     """
     Compute PPO critic loss function.
 
@@ -177,7 +177,7 @@ def compute_ppo_critic_loss(
 
 
 @register_policy_loss("actor_critic")
-def compute_ppo_actor_critic_loss(**kwargs) -> Tuple[torch.Tensor, Dict]:
+def compute_ppo_actor_critic_loss(**kwargs) -> tuple[torch.Tensor, dict]:
     """
     Compute PPO actor loss function.
 
@@ -208,7 +208,7 @@ def compute_ppo_actor_critic_loss(**kwargs) -> Tuple[torch.Tensor, Dict]:
 
 
 @register_policy_loss("actor")
-def compute_grpo_actor_loss_fn(**kwargs) -> Tuple[torch.Tensor, Dict]:
+def compute_grpo_actor_loss_fn(**kwargs) -> tuple[torch.Tensor, dict]:
     """
     Compute actor loss for Group Relative Policy Optimization (GRPO).
 

--- a/rlinf/algorithms/registry.py
+++ b/rlinf/algorithms/registry.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from functools import wraps
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Optional
 
 import torch
 
@@ -27,7 +27,7 @@ from rlinf.algorithms.utils import (
     preprocess_reasoning_advantages_inputs,
 )
 
-ADV_REGISTRY: Dict[str, Callable] = {}
+ADV_REGISTRY: dict[str, Callable] = {}
 
 
 def register_advantage(name: str):
@@ -53,7 +53,7 @@ def get_adv_and_returns(name: str) -> Callable:
     return ADV_REGISTRY[name.lower()]
 
 
-LOSS_REGISTRY: Dict[str, Callable] = {}
+LOSS_REGISTRY: dict[str, Callable] = {}
 
 
 def register_policy_loss(name: str):
@@ -74,7 +74,7 @@ def get_policy_loss(name: str):
     return LOSS_REGISTRY[name]
 
 
-def policy_loss(**kwargs) -> Tuple[torch.Tensor, Dict]:
+def policy_loss(**kwargs) -> tuple[torch.Tensor, dict]:
     """
     Unified actor loss entry.
     """
@@ -92,7 +92,7 @@ def policy_loss(**kwargs) -> Tuple[torch.Tensor, Dict]:
     return loss, metrics_data
 
 
-def calculate_adv_and_returns(**kwargs) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+def calculate_adv_and_returns(**kwargs) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
     """
     Unified entry for advantage + return computation.
     Accepts variable keyword arguments, preprocesses them, then dispatches

--- a/rlinf/algorithms/rewards/code/__init__.py
+++ b/rlinf/algorithms/rewards/code/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
 from omegaconf import DictConfig
 
 from toolkits.code_verifier.verify import (
@@ -27,9 +25,9 @@ class CodeRewardOffline:
 
     def get_reward(
         self,
-        response: List[str],
-        reference: List[List[str]],
-        prompts: List[str],
-    ) -> List[float]:
+        response: list[str],
+        reference: list[list[str]],
+        prompts: list[str],
+    ) -> list[float]:
         rewards = fim_llm_as_judge_verify_call(response, reference, prompts)
         return [float(reward) * self.scale for reward in rewards]

--- a/rlinf/algorithms/rewards/math/__init__.py
+++ b/rlinf/algorithms/rewards/math/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
 from omegaconf import DictConfig
 
 from toolkits.math_verifier.verify import math_verify_call
@@ -24,8 +22,8 @@ class MathReward:
         self.scale = config.get("reward_scale", 1.0)
 
     def get_reward(
-        self, response: List[str], reference: List[List[str]]
-    ) -> List[float]:
+        self, response: list[str], reference: list[list[str]]
+    ) -> list[float]:
         """
         Calculates reward scores for a list of responses compared to corresponding lists of reference answers.
         For each response, the function checks if it matches any of the provided references using the `process_results` function.

--- a/rlinf/algorithms/rewards/vqa/__init__.py
+++ b/rlinf/algorithms/rewards/vqa/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
 import torch
 from omegaconf import DictConfig
 
@@ -44,7 +42,7 @@ class VQAReward:
         )
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    def get_reward(self, completions: List[str], answers: List[dict]) -> List[float]:
+    def get_reward(self, completions: list[str], answers: list[dict]) -> list[float]:
         rewards = []
         reward_weights = []
         for reward_name, reward_function in self.NEEDED_REWARD_FUNCTIONS.items():

--- a/rlinf/algorithms/rewards/vqa/format_rewards.py
+++ b/rlinf/algorithms/rewards/vqa/format_rewards.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import re
-from typing import List
 
 
-def think_format_reward(completions, answers) -> List[float]:
+def think_format_reward(completions, answers) -> list[float]:
     """
     Think format reward function compatible with GRPO training.
 
@@ -39,7 +38,7 @@ def think_format_reward(completions, answers) -> List[float]:
     return rewards
 
 
-def answer_format_reward(completions, answers) -> List[float]:
+def answer_format_reward(completions, answers) -> list[float]:
     """
     Reward function that checks for proper answer formatting.
 

--- a/rlinf/algorithms/rewards/vqa/qa_rewards.py
+++ b/rlinf/algorithms/rewards/vqa/qa_rewards.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import re
-from typing import List
 
 
-def qa_accuracy_reward(completions: List[str], answers: List[dict]) -> List[float]:
+def qa_accuracy_reward(completions: list[str], answers: list[dict]) -> list[float]:
     """
     Reward function that evaluates question-answering accuracy for VQA tasks.
 

--- a/rlinf/data/datasets/__init__.py
+++ b/rlinf/data/datasets/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import torch
 from omegaconf import DictConfig
@@ -27,7 +27,7 @@ from rlinf.data.datasets.vlm import VLMDatasetRegistry
 
 def create_rl_dataset(
     config: DictConfig, tokenizer: AutoTokenizer
-) -> Tuple[Dataset, Dataset]:
+) -> tuple[Dataset, Dataset]:
     """Create rl datasets.
 
     Arguments:
@@ -85,7 +85,7 @@ def create_rl_dataset(
     return train_dataset, val_dataset
 
 
-def collate_fn(data_list: List["DatasetItem"]) -> Dict[str, Any]:
+def collate_fn(data_list: list["DatasetItem"]) -> dict[str, Any]:
     """
     Collate function for batching dataset items.
     """
@@ -118,7 +118,7 @@ def collate_fn(data_list: List["DatasetItem"]) -> Dict[str, Any]:
 
     batch_idx = torch.tensor([int(it.idx) for it in data_list], dtype=torch.long)
 
-    batch: Dict[str, Any] = {
+    batch: dict[str, Any] = {
         "prompt": batch_prompt,  # [B, L]
         "length": batch_length,  # [B]
         "answer": [it.answer for it in data_list],  # List[str]

--- a/rlinf/data/datasets/item.py
+++ b/rlinf/data/datasets/item.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import torch
 
@@ -39,7 +39,7 @@ class DatasetItem:
     answer: str | dict
     idx: int
     solution: Optional[str] = None
-    image_data: Optional[List[Union[bytes, str]]] = None
+    image_data: Optional[list[Union[bytes, str]]] = None
     prompt_text: Optional[str] = None
-    meta: Optional[Dict[str, Any]] = None
-    multi_modal_inputs: Optional[Dict[str, Any]] = None
+    meta: Optional[dict[str, Any]] = None
+    multi_modal_inputs: Optional[dict[str, Any]] = None

--- a/rlinf/data/datasets/math.py
+++ b/rlinf/data/datasets/math.py
@@ -15,7 +15,7 @@
 import json
 import logging
 import os
-from typing import Any, List, Tuple, Union
+from typing import Any, Union
 
 import torch
 from omegaconf import DictConfig
@@ -29,7 +29,7 @@ from rlinf.data.datasets.utils import batch_pad_to_fixed_len
 class MathDataset(Dataset):
     def __init__(
         self,
-        data_paths: Union[str, List[str]],
+        data_paths: Union[str, list[str]],
         config: DictConfig,
         tokenizer: AutoTokenizer,
     ):
@@ -109,7 +109,7 @@ class MathDataset(Dataset):
                     f"(kept {len(self.data)} / {total})."
                 )
 
-    def _load_data(self) -> List[Any]:
+    def _load_data(self) -> list[Any]:
         """
         Load and merge data from multiple files(json or jsonl).
         """
@@ -137,7 +137,7 @@ class MathDataset(Dataset):
     def __len__(self):
         return len(self.data)
 
-    def encode(self, text: str) -> Tuple[List[int], int]:
+    def encode(self, text: str) -> tuple[list[int], int]:
         """
         Use tokenizer to encode the text and return the token ids and length.
         """

--- a/rlinf/data/datasets/utils.py
+++ b/rlinf/data/datasets/utils.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
 import torch
 
 
 def batch_pad_to_fixed_len(
-    batch: List[torch.Tensor],
+    batch: list[torch.Tensor],
     max_batch_len: int,
     pad_token: int,
     left_pad: bool = False,

--- a/rlinf/data/io_struct.py
+++ b/rlinf/data/io_struct.py
@@ -15,7 +15,7 @@
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import torch
 from omegaconf import DictConfig
@@ -32,14 +32,14 @@ from rlinf.utils.data_iter_utils import (
 
 
 def get_batch_size(
-    batch: Dict[str, torch.Tensor], batch_tensor_key: str = "input_ids"
+    batch: dict[str, torch.Tensor], batch_tensor_key: str = "input_ids"
 ) -> int:
     """Get the batch size from the batch dictionary."""
     return batch[batch_tensor_key].size(0)
 
 
 def get_seq_length(
-    batch: Dict[str, torch.Tensor], batch_tensor_key: str = "input_ids"
+    batch: dict[str, torch.Tensor], batch_tensor_key: str = "input_ids"
 ) -> int:
     """Get the sequence length from the batch dictionary."""
     return batch[batch_tensor_key].size(1)
@@ -57,12 +57,12 @@ class RolloutRequest:
     """
 
     n: int
-    input_ids: List[List[int]]
-    image_data: Union[List[List[bytes]], List[List[str]]]
-    answers: List[Union[List[str], Dict]]
-    multi_modal_inputs: List[Optional[Dict]]
+    input_ids: list[list[int]]
+    image_data: Union[list[list[bytes]], list[list[str]]]
+    answers: list[Union[list[str], dict]]
+    multi_modal_inputs: list[Optional[dict]]
 
-    def to_seq_group_infos(self) -> List["SeqGroupInfo"]:
+    def to_seq_group_infos(self) -> list["SeqGroupInfo"]:
         """Convert the RolloutRequest into a list of SeqGroupInfo objects.
 
         Returns:
@@ -111,14 +111,14 @@ class SeqGroupInfo:
     """
 
     id: int
-    input_ids: List[int]
-    answer: Union[List[str], Dict]
+    input_ids: list[int]
+    answer: Union[list[str], dict]
     group_size: int
     idx_completed: set[int] = field(init=False, compare=False)
     idx_aborted: set[int] = field(init=False, compare=False)
-    results: List[Optional[Dict]] = field(init=False, compare=False)
-    image_data: Optional[List] = None
-    multi_modal_inputs: Optional[Dict] = None
+    results: list[Optional[dict]] = field(init=False, compare=False)
+    image_data: Optional[list] = None
+    multi_modal_inputs: Optional[dict] = None
 
     def __post_init__(self):
         assert self.group_size > 0, "group_size must be greater than 0"
@@ -126,7 +126,7 @@ class SeqGroupInfo:
         self.idx_aborted = set()
         self.results = [None for _ in range(self.group_size)]
 
-    def record_sglang_result(self, idx: int, result: Dict, logger=None):
+    def record_sglang_result(self, idx: int, result: dict, logger=None):
         """Record a single sglang execution result and update internal tracking.
 
         This method is responsible for updating the internal state of the SeqGroupInfo
@@ -204,21 +204,21 @@ class RolloutResult:
 
     num_sequence: int
     group_size: int
-    prompt_lengths: List[int]
-    prompt_ids: List[List[int]]
-    response_lengths: List[int]
-    response_ids: List[List[int]]
-    is_end: List[bool]
-    rewards: Optional[List[float] | torch.Tensor] = None
-    advantages: Optional[List[float] | torch.Tensor] = None
-    prompt_texts: Optional[List[str]] = None
-    response_texts: Optional[List[str]] = None
-    answers: Optional[List[str | dict]] = None
-    image_data: Optional[Union[List[List[bytes]], List[List[str]]]] = None
-    multi_modal_inputs: Optional[List[dict]] = None
+    prompt_lengths: list[int]
+    prompt_ids: list[list[int]]
+    response_lengths: list[int]
+    response_ids: list[list[int]]
+    is_end: list[bool]
+    rewards: Optional[list[float] | torch.Tensor] = None
+    advantages: Optional[list[float] | torch.Tensor] = None
+    prompt_texts: Optional[list[str]] = None
+    response_texts: Optional[list[str]] = None
+    answers: Optional[list[str | dict]] = None
+    image_data: Optional[Union[list[list[bytes]], list[list[str]]]] = None
+    multi_modal_inputs: Optional[list[dict]] = None
     # Inference
     # Logprobs returned by rollout engines
-    rollout_logprobs: Optional[List[List[float]]] = None
+    rollout_logprobs: Optional[list[list[float]]] = None
     # Logprobs recomputed by inference when rollout has returned logprobs
     recompute_prev_logprobs: Optional[torch.Tensor] = None
     # The final prev_logprobs used for training
@@ -238,7 +238,7 @@ class RolloutResult:
         response_lengths: torch.Tensor,
         max_prompt_len: int,
         total_len: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         B = prompt_lengths.size(0)
 
         # =========================
@@ -272,9 +272,9 @@ class RolloutResult:
     @staticmethod
     def from_vllm_results(
         group_size: int,
-        results: List["VllmRequestOutput"],
-        answers: Optional[Union[List[str], Dict]] = None,
-        multi_modal_inputs: Optional[List[Dict]] = None,
+        results: list["VllmRequestOutput"],
+        answers: Optional[Union[list[str], dict]] = None,
+        multi_modal_inputs: Optional[list[dict]] = None,
         return_logprobs: bool = False,
     ) -> "RolloutResult":
         """
@@ -292,8 +292,8 @@ class RolloutResult:
         """
 
         def get_logprobs(
-            response_ids: List[int], output: "CompletionOutput"
-        ) -> List[float]:
+            response_ids: list[int], output: "CompletionOutput"
+        ) -> list[float]:
             logprobs = []
             returned_logprobs = output.logprobs
             assert logprobs is not None, (
@@ -367,12 +367,12 @@ class RolloutResult:
 
     @staticmethod
     def from_sglang_results(
-        results: List[Dict],
+        results: list[dict],
         group_size: int,
-        input_ids: List[List[int]],
-        answers: Optional[List[List[int]]] = None,
-        image_data: Optional[Union[List[List[bytes]], List[List[str]]]] = None,
-        multi_modal_inputs: Optional[List[Dict]] = None,
+        input_ids: list[list[int]],
+        answers: Optional[list[list[int]]] = None,
+        image_data: Optional[Union[list[list[bytes]], list[list[str]]]] = None,
+        multi_modal_inputs: Optional[list[dict]] = None,
         return_logprobs: bool = False,
     ) -> "RolloutResult":
         """Create a MathRolloutResult from the given results and input IDs.
@@ -427,7 +427,7 @@ class RolloutResult:
 
     @staticmethod
     def merge_result_list(
-        rollout_results: List["RolloutResult"],
+        rollout_results: list["RolloutResult"],
     ) -> "RolloutResult":
         assert len(rollout_results) > 0, "No rollout results to merge."
         if len(rollout_results) == 1:
@@ -454,7 +454,7 @@ class RolloutResult:
             else:
                 return torch.cat([dst_tensor, src_tensor], dim=0)
 
-        def merge_list(dst_list: List, src_list: List):
+        def merge_list(dst_list: list, src_list: list):
             assert dst_list is None or isinstance(dst_list, list), (
                 f"Expected list, got {type(dst_list)}"
             )
@@ -519,8 +519,8 @@ class RolloutResult:
 
     @staticmethod
     def split_result_list_by_group(
-        rollout_results: List["RolloutResult"],
-    ) -> List["RolloutResult"]:
+        rollout_results: list["RolloutResult"],
+    ) -> list["RolloutResult"]:
         """
         Split RolloutResult objects by group_size.
 
@@ -546,7 +546,7 @@ class RolloutResult:
     @staticmethod
     def _split_single_result_by_group(
         rollout_result: "RolloutResult",
-    ) -> List["RolloutResult"]:
+    ) -> list["RolloutResult"]:
         """
         Split a single RolloutResult into multiple RolloutResult objects by group_size.
 
@@ -677,7 +677,7 @@ class RolloutResult:
         data_seq_length: int,
         training_seq_length: int,
         pad_token: int,
-    ) -> Dict[str, torch.Tensor]:
+    ) -> dict[str, torch.Tensor]:
         """
         Transform the rollout result into a format suitable for the actor.
 
@@ -814,8 +814,8 @@ class RolloutResult:
 
     @staticmethod
     def merge_batches(
-        batches: List[Dict[str, torch.Tensor]],
-    ) -> Dict[str, torch.Tensor]:
+        batches: list[dict[str, torch.Tensor]],
+    ) -> dict[str, torch.Tensor]:
         """Merge two batches into one."""
         merged_batch = {}
         if len(batches) == 0:
@@ -919,7 +919,7 @@ class BatchResizingIterator:
             micro_batch = self.prefetch_micro_batch
             self.prefetch_micro_batch = None
         else:
-            micro_batch: Dict[str, torch.Tensor] = next(self.micro_batch_iter)
+            micro_batch: dict[str, torch.Tensor] = next(self.micro_batch_iter)
             self.global_batch_done = False
             self.consumed_batch_size += micro_batch[self.batch_tensor_key].shape[0]
             self.batches.append(micro_batch)
@@ -941,7 +941,7 @@ class BatchResizingIterator:
         """
         self.global_batch_handler = handler
 
-    def _fill_global_batches(self, current_batch: Dict[str, torch.Tensor]):
+    def _fill_global_batches(self, current_batch: dict[str, torch.Tensor]):
         """Keep getting batches until the batch size is multiple of a global batch if requires_global_batch."""
         current_batch_size = current_batch[self.batch_tensor_key].shape[0]
         while (
@@ -1026,8 +1026,8 @@ def put_tensor_cpu(data_dict):
 @dataclass(kw_only=True)
 class EnvOutput:
     simulator_type: str
-    obs: Dict[str, Any]
-    final_obs: Optional[Dict[str, Any]] = None
+    obs: dict[str, Any]
+    final_obs: Optional[dict[str, Any]] = None
     dones: Optional[torch.Tensor] = None  # [B]
     rewards: Optional[torch.Tensor] = None  # [B]
 
@@ -1041,7 +1041,7 @@ class EnvOutput:
             self.rewards.cpu().contiguous() if self.rewards is not None else None
         )
 
-    def prepare_observations(self, obs: Dict[str, Any]) -> Dict[str, Any]:
+    def prepare_observations(self, obs: dict[str, Any]) -> dict[str, Any]:
         wrist_image_tensor = None
         if self.simulator_type == "libero":
             image_tensor = torch.stack(
@@ -1100,12 +1100,12 @@ class EnvOutput:
 @dataclass(kw_only=True)
 class EmbodiedRolloutResult:
     # required
-    prev_logprobs: List[torch.Tensor] = field(default_factory=list)
-    prev_values: List[torch.Tensor] = field(default_factory=list)
-    dones: List[torch.Tensor] = field(default_factory=list)
-    rewards: List[torch.Tensor] = field(default_factory=list)
+    prev_logprobs: list[torch.Tensor] = field(default_factory=list)
+    prev_values: list[torch.Tensor] = field(default_factory=list)
+    dones: list[torch.Tensor] = field(default_factory=list)
+    rewards: list[torch.Tensor] = field(default_factory=list)
 
-    forward_inputs: List[Dict[str, Any]] = field(default_factory=list)
+    forward_inputs: list[dict[str, Any]] = field(default_factory=list)
 
     def __post_init__(self):
         self.prev_logprobs = (
@@ -1133,7 +1133,7 @@ class EmbodiedRolloutResult:
             put_tensor_cpu(forward_inputs) for forward_inputs in self.forward_inputs
         ]
 
-    def append_result(self, result: Dict[str, Any]):
+    def append_result(self, result: dict[str, Any]):
         self.prev_logprobs.append(
             result["prev_logprobs"].cpu().contiguous()
         ) if "prev_logprobs" in result else []
@@ -1186,7 +1186,7 @@ class EmbodiedRolloutResult:
 
         return rollout_result_dict
 
-    def to_splited_dict(self, split_size) -> List[Dict[str, Any]]:
+    def to_splited_dict(self, split_size) -> list[dict[str, Any]]:
         rollout_result_list = []
         for i in range(split_size):
             rollout_result_list.append(self.to_dict())

--- a/rlinf/envs/behavior/behavior_env.py
+++ b/rlinf/envs/behavior/behavior_env.py
@@ -14,7 +14,6 @@
 
 import json
 import os
-from typing import Tuple
 
 import cv2
 import gymnasium as gym
@@ -153,7 +152,7 @@ class BehaviorEnv(gym.Env):
 
     def step(
         self, actions=None
-    ) -> Tuple[dict, torch.Tensor, torch.Tensor, torch.Tensor, dict]:
+    ) -> tuple[dict, torch.Tensor, torch.Tensor, torch.Tensor, dict]:
         if actions is None:
             assert self._is_start, "Actions must be provided after the first reset."
             obs, infos = self.reset()
@@ -241,14 +240,14 @@ class BehaviorEnv(gym.Env):
         self._is_start = value
 
     @property
-    def video_writer(self) -> Tuple[Container, Stream]:
+    def video_writer(self) -> tuple[Container, Stream]:
         """
         Returns the video writer for the current evaluation step.
         """
         return self._video_writer
 
     @video_writer.setter
-    def video_writer(self, video_writer: Tuple[Container, Stream]) -> None:
+    def video_writer(self, video_writer: tuple[Container, Stream]) -> None:
         if self._video_writer is not None:
             (container, stream) = self._video_writer
             # Flush any remaining packets

--- a/rlinf/envs/libero/libero_env.py
+++ b/rlinf/envs/libero/libero_env.py
@@ -14,7 +14,7 @@
 
 import copy
 import os
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import gym
 import numpy as np
@@ -301,7 +301,7 @@ class LiberoEnv(gym.Env):
 
     def reset(
         self,
-        env_idx: Optional[Union[int, List[int], np.ndarray]] = None,
+        env_idx: Optional[Union[int, list[int], np.ndarray]] = None,
         reset_state_ids=None,
         options: Optional[dict] = {},
     ):

--- a/rlinf/envs/libero/utils.py
+++ b/rlinf/envs/libero/utils.py
@@ -16,7 +16,7 @@
 
 import math
 import os
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import imageio
 import libero.libero.benchmark as benchmark
@@ -27,7 +27,7 @@ from PIL import Image, ImageDraw, ImageFont
 
 
 def tile_images(
-    images: List[Union[np.ndarray, torch.Tensor]], nrows: int = 1
+    images: list[Union[np.ndarray, torch.Tensor]], nrows: int = 1
 ) -> Union[np.ndarray, torch.Tensor]:
     """
     Copied from maniskill https://github.com/haosulab/ManiSkill
@@ -43,7 +43,7 @@ def tile_images(
     if nrows == 1:
         images = sorted(images, key=lambda x: x.shape[0 + batched], reverse=True)
 
-    columns: List[List[Union[np.ndarray, torch.Tensor]]] = []
+    columns: list[list[Union[np.ndarray, torch.Tensor]]] = []
     if batched:
         max_h = images[0].shape[1] * nrows
         cur_h = 0
@@ -94,7 +94,7 @@ def tile_images(
 
 
 def put_text_on_image(
-    image: np.ndarray, lines: List[str], max_width: int = 200
+    image: np.ndarray, lines: list[str], max_width: int = 200
 ) -> np.ndarray:
     """
     Put text lines on an image with automatic line wrapping.
@@ -139,8 +139,8 @@ def put_text_on_image(
 
 def put_info_on_image(
     image: np.ndarray,
-    info: Dict[str, float],
-    extras: Optional[List[str]] = None,
+    info: dict[str, float],
+    extras: Optional[list[str]] = None,
     overlay: bool = True,
 ) -> np.ndarray:
     """
@@ -161,7 +161,7 @@ def put_info_on_image(
     return put_text_on_image(image, lines)
 
 
-def get_libero_image(obs: Dict[str, np.ndarray]) -> np.ndarray:
+def get_libero_image(obs: dict[str, np.ndarray]) -> np.ndarray:
     """
     Extracts image from observations and preprocesses it.
 
@@ -177,7 +177,7 @@ def get_libero_image(obs: Dict[str, np.ndarray]) -> np.ndarray:
 
 
 def get_libero_wrist_image(
-    obs: Dict[str, np.ndarray], resize_size: Union[int, Tuple[int, int]] = 224
+    obs: dict[str, np.ndarray], resize_size: Union[int, tuple[int, int]] = 224
 ) -> np.ndarray:
     """
     Extracts wrist camera image from observations and preprocesses it.
@@ -222,7 +222,7 @@ def quat2axisangle(quat: np.ndarray) -> np.ndarray:
 
 
 def save_rollout_video(
-    rollout_images: List[np.ndarray], output_dir: str, video_name: str, fps: int = 30
+    rollout_images: list[np.ndarray], output_dir: str, video_name: str, fps: int = 30
 ) -> None:
     """
     Saves an MP4 replay of an episode.
@@ -262,7 +262,7 @@ def get_benchmark_overridden(benchmark_name) -> Benchmark:
         return libreo_cls
 
     # Build aggregated task map once, preserving order and de-duplicating by task name
-    aggregated_task_map: Dict[str, benchmark.Task] = {}
+    aggregated_task_map: dict[str, benchmark.Task] = {}
     for suite_name in getattr(benchmark, "libero_suites", []):
         suite_map = benchmark.task_maps.get(suite_name, {})
         for task_name, task in suite_map.items():

--- a/rlinf/envs/libero/venv.py
+++ b/rlinf/envs/libero/venv.py
@@ -15,7 +15,7 @@
 import warnings
 from multiprocessing import Pipe, connection
 from multiprocessing.context import Process
-from typing import Any, Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Union
 
 import gym
 import numpy as np
@@ -30,8 +30,8 @@ from libero.libero.envs.venv import (
     _setup_buf,
 )
 
-gym_old_venv_step_type = Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
-gym_new_venv_step_type = Tuple[
+gym_old_venv_step_type = tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+gym_new_venv_step_type = tuple[
     np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray
 ]
 warnings.simplefilter("once", DeprecationWarning)
@@ -155,7 +155,7 @@ class ReconfigureSubprocEnvWorker(SubprocEnvWorker):
 
 
 class ReconfigureSubprocEnv(SubprocVectorEnv):
-    def __init__(self, env_fns: List[Callable[[], gym.Env]], **kwargs: Any) -> None:
+    def __init__(self, env_fns: list[Callable[[], gym.Env]], **kwargs: Any) -> None:
         def worker_fn(fn: Callable[[], gym.Env]) -> ReconfigureSubprocEnvWorker:
             return ReconfigureSubprocEnvWorker(fn, share_memory=False)
 

--- a/rlinf/envs/maniskill/maniskill_env.py
+++ b/rlinf/envs/maniskill/maniskill_env.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import gymnasium as gym
 import numpy as np
@@ -190,7 +190,7 @@ class ManiskillEnv(gym.Env):
     def reset(
         self,
         *,
-        seed: Optional[Union[int, List[int]]] = None,
+        seed: Optional[Union[int, list[int]]] = None,
         options: Optional[dict] = {},
     ):
         raw_obs, infos = self.env.reset(seed=seed, options=options)
@@ -203,8 +203,8 @@ class ManiskillEnv(gym.Env):
         return extracted_obs, infos
 
     def step(
-        self, actions: Union[Array, Dict] = None, auto_reset=True
-    ) -> Tuple[Array, Array, Array, Array, Dict]:
+        self, actions: Union[Array, dict] = None, auto_reset=True
+    ) -> tuple[Array, Array, Array, Array, dict]:
         if actions is None:
             assert self._is_start, "Actions must be provided after the first reset."
         if self.is_start:

--- a/rlinf/envs/utils.py
+++ b/rlinf/envs/utils.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import numpy as np
 import torch
 
 
 def to_tensor(
-    array: Union[Dict, torch.Tensor, np.ndarray, List, Any], device: str = "cpu"
-) -> Union[Dict, torch.Tensor]:
+    array: Union[dict, torch.Tensor, np.ndarray, list, Any], device: str = "cpu"
+) -> Union[dict, torch.Tensor]:
     """
     Copied from ManiSkill!
     Maps any given sequence to a torch tensor on the CPU/GPU. If physx gpu is not enabled then we use CPU, otherwise GPU, unless specified
@@ -52,8 +52,8 @@ def to_tensor(
 
 
 def list_of_dict_to_dict_of_list(
-    list_of_dict: List[Dict[str, Any]],
-) -> Dict[str, List[Any]]:
+    list_of_dict: list[dict[str, Any]],
+) -> dict[str, list[Any]]:
     """
     Convert a list of dictionaries to a dictionary of lists.
 

--- a/rlinf/hybrid_engines/megatron/megatron_model_manager.py
+++ b/rlinf/hybrid_engines/megatron/megatron_model_manager.py
@@ -15,7 +15,7 @@
 import gc
 import itertools
 import logging
-from typing import Iterator, List, Optional
+from typing import Iterator, Optional
 
 import torch
 from omegaconf import DictConfig
@@ -233,7 +233,7 @@ class MegatronModelManager:
 
     def make_data_iterator_list(
         self, data_iterator: Iterator, padding: bool = False, vpp_size: int = 1
-    ) -> List[Iterator]:
+    ) -> list[Iterator]:
         """
         Convert the data iterator into the format expected by Megatron.
         With interleaved pipeline parallelism, Megatron expects a

--- a/rlinf/hybrid_engines/sglang/common/io_struct.py
+++ b/rlinf/hybrid_engines/sglang/common/io_struct.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from sglang.srt.managers.schedule_batch import Req
 
@@ -25,15 +25,15 @@ class AbortGenerationInput:
 
 @dataclass
 class AbortGenerationOutput:
-    waiting_reqs: List[Req]
-    running_reqs: List[Req]
+    waiting_reqs: list[Req]
+    running_reqs: list[Req]
 
 
 @dataclass
 class TaskMethodInput:
     method_name: str
-    args: List[Any] = field(default_factory=list)
-    kwargs: Dict[str, Any] = field(default_factory=dict)
+    args: list[Any] = field(default_factory=list)
+    kwargs: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/rlinf/hybrid_engines/sglang/common/tokenizer_manager.py
+++ b/rlinf/hybrid_engines/sglang/common/tokenizer_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import Optional
 
 import fastapi
 from sglang.srt.managers.tokenizer_manager import TokenizerManager as _TokenizerManager
@@ -80,7 +80,7 @@ class TokenizerManager(_TokenizerManager):
         self.auto_create_handle_loop()
         if isinstance(obj, str):
             obj = TaskMethodInput(method_name=obj)
-        res: List[TaskMethodOutput] = await self.run_task_method_communicator(obj)
+        res: list[TaskMethodOutput] = await self.run_task_method_communicator(obj)
         return res[0].result
 
     async def sync_hf_weight(

--- a/rlinf/hybrid_engines/vllm/vllm_0_8_5/executor.py
+++ b/rlinf/hybrid_engines/vllm/vllm_0_8_5/executor.py
@@ -16,7 +16,7 @@ import signal
 import sys
 import threading
 import weakref
-from typing import Dict, List, Optional
+from typing import Optional
 
 import psutil
 from omegaconf import DictConfig
@@ -174,7 +174,7 @@ class VLLMWorkerProc(WorkerProc):
         self.rank = rank  # global rank in 2D parallel (tp,pp)
 
         wrapper = WorkerWrapperBase(vllm_config=vllm_config, rpc_rank=rank)
-        all_kwargs: List[Dict] = [
+        all_kwargs: list[dict] = [
             {} for _ in range(vllm_config.parallel_config.world_size)
         ]
         all_kwargs[rank] = {

--- a/rlinf/models/embodiment/modules/explore_noise_net.py
+++ b/rlinf/models/embodiment/modules/explore_noise_net.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections import OrderedDict
-from typing import List
 
 import torch
 import torch.nn as nn
@@ -43,7 +42,7 @@ class ExploreNoiseNet(nn.Module):
         self,
         in_dim: int,
         out_dim: int,
-        hidden_dims: List[int],
+        hidden_dims: list[int],
         activation_type: str,
         noise_logvar_range: list,  # [min_std, max_std]
         noise_scheduler_type: str,

--- a/rlinf/models/embodiment/openpi_action_model.py
+++ b/rlinf/models/embodiment/openpi_action_model.py
@@ -15,7 +15,7 @@
 import random
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Tuple
+from typing import Any, Literal
 
 import jax
 import numpy as np
@@ -45,7 +45,7 @@ class OpenPi0Config(Pi0Config):
     chunk_critic_input: bool = False
     add_value_head: bool = False
     noise_anneal: bool = False
-    noise_params: List = field(
+    noise_params: list = field(
         default_factory=lambda: [0.7, 0.3, 400]
     )  # noise_start, noise_end, noise_anneal_steps
     ignore_last: bool = False
@@ -194,7 +194,7 @@ class OpenPi0ForRLActionPrediction(PI0Pytorch):
         self,
         data: dict[str, torch.Tensor],
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         compute_values = kwargs.get("compute_values", False)
 
         chains = data["chains"]
@@ -274,7 +274,7 @@ class OpenPi0ForRLActionPrediction(PI0Pytorch):
 
     def predict_action_batch(
         self, env_obs, mode: Literal["train", "eval"] = "train", compute_values=True
-    ) -> Tuple[np.ndarray, Dict[str, Any]]:
+    ) -> tuple[np.ndarray, dict[str, Any]]:
         processed_obs = self.input_processor(env_obs)
         observation = _model.Observation.from_dict(processed_obs)
         outputs = self.sample_actions(

--- a/rlinf/models/embodiment/openvla_action_model.py
+++ b/rlinf/models/embodiment/openvla_action_model.py
@@ -17,7 +17,7 @@
 #
 # Expected `transformers==4.40.1` and `tokenizers==0.19.1`
 
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import Any, ClassVar, Optional, Union
 
 import numpy as np
 import torch
@@ -64,13 +64,13 @@ class OpenVLAForBatchActionPrediction(OpenVLAForActionPrediction):
         pixel_values: Optional[torch.FloatTensor] = None,
         labels: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        past_key_values: Optional[list[torch.FloatTensor]] = None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         output_projector_features: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[Tuple, PrismaticCausalLMOutputWithPast]:
+    ) -> Union[tuple, PrismaticCausalLMOutputWithPast]:
         """Run a forward pass through the VLM, returning a PrismaticCausalLMOutputWithPast instance."""
         output_attentions = (
             output_attentions
@@ -297,12 +297,12 @@ class OpenVLAForBatchActionPrediction(OpenVLAForActionPrediction):
     def prepare_inputs_for_generation(
         self,
         input_ids: Optional[torch.Tensor] = None,
-        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        past_key_values: Optional[list[torch.FloatTensor]] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         pixel_values: Optional[torch.FloatTensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         **kwargs: str,
-    ) -> Dict[str, torch.Tensor]:
+    ) -> dict[str, torch.Tensor]:
         """Borrowed from `LlamaForCausalLM` and simplified for batch size = 1; mirrors original PrismaticVLM logic."""
         # Handle `past_key_values` (cache) =>> assume `input_ids` just has unprocessed tokens
         if past_key_values is not None:
@@ -379,14 +379,14 @@ class PrismaticImageProcessor(PrismaticImageProcessorOrginal):
 
 
 class PrismaticProcessor(PrismaticProcessorOriginal):
-    attributes: ClassVar[List[str]] = ["image_processor", "tokenizer"]
+    attributes: ClassVar[list[str]] = ["image_processor", "tokenizer"]
     image_processor_class: str = "AutoImageProcessor"
     tokenizer_class: str = "AutoTokenizer"
 
     def __call__(
         self,
         text: Union[
-            TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]
+            TextInput, PreTokenizedInput, list[TextInput], list[PreTokenizedInput]
         ],
         images: torch.Tensor,
         proprio_states: torch.Tensor,
@@ -511,7 +511,7 @@ class OpenVLAForRLActionPrediction(OpenVLAForBatchActionPrediction):
         pixel_values: Optional[torch.FloatTensor] = None,
         labels: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        past_key_values: Optional[list[torch.FloatTensor]] = None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
@@ -604,7 +604,7 @@ class OpenVLAForRLActionPrediction(OpenVLAForBatchActionPrediction):
         calulate_logprobs=True,
         calulate_values=True,
         **kwargs,
-    ) -> Tuple[np.ndarray, Dict[str, Any]]:
+    ) -> tuple[np.ndarray, dict[str, Any]]:
         do_sample = kwargs.pop("do_sample")
 
         if env_obs is not None:
@@ -741,7 +741,7 @@ class OpenVLAForRLActionPrediction(OpenVLAForBatchActionPrediction):
         return chunk_actions, result
 
     def _check_unnorm_key(
-        self, norm_stats: Dict[str, Dict[str, Any]], unnorm_key: Optional[str]
+        self, norm_stats: dict[str, dict[str, Any]], unnorm_key: Optional[str]
     ) -> str:
         if unnorm_key is None:
             assert len(norm_stats) == 1, (
@@ -757,7 +757,7 @@ class OpenVLAForRLActionPrediction(OpenVLAForBatchActionPrediction):
         )
         return unnorm_key
 
-    def _get_action_stats(self) -> Dict[str, Any]:
+    def _get_action_stats(self) -> dict[str, Any]:
         """Get all the logged statistics for the given dataset."""
         unnorm_key = self._check_unnorm_key(self.norm_stats, self.unnorm_key)
         return self.norm_stats[unnorm_key]["action"]

--- a/rlinf/models/embodiment/openvla_oft_action_model.py
+++ b/rlinf/models/embodiment/openvla_oft_action_model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 import numpy as np
 import torch
@@ -118,7 +118,7 @@ class OpenVLAOFTForRLActionPrediction(OpenVLAOFTForActionPrediction):
 
         return multimodal_embeddings, multimodal_attention_mask
 
-    def _get_action_stats(self) -> Dict[str, Any]:
+    def _get_action_stats(self) -> dict[str, Any]:
         """Get all the logged statistics for the given dataset."""
         unnorm_key = self._check_unnorm_key(self.norm_stats, self.unnorm_key)
         return self.norm_stats[unnorm_key]["action"]
@@ -204,7 +204,7 @@ class OpenVLAOFTForRLActionPrediction(OpenVLAOFTForActionPrediction):
         calulate_logprobs=True,
         calulate_values=True,
         **kwargs,
-    ) -> Tuple[np.ndarray, Dict[str, Any]]:
+    ) -> tuple[np.ndarray, dict[str, Any]]:
         do_sample = kwargs.pop("do_sample")
 
         if env_obs is not None:

--- a/rlinf/models/embodiment/prismatic/processing_prismatic.py
+++ b/rlinf/models/embodiment/prismatic/processing_prismatic.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import ClassVar, Dict, List, Optional, Union
+from typing import ClassVar, Optional, Union
 
 import torch
 import torchvision.transforms.functional as TVF
@@ -94,14 +94,14 @@ class PrismaticImageProcessor(PrismaticImageProcessorOrginal):
 
 
 class PrismaticProcessor(PrismaticProcessorOriginal):
-    attributes: ClassVar[List[str]] = ["image_processor", "tokenizer"]
+    attributes: ClassVar[list[str]] = ["image_processor", "tokenizer"]
     image_processor_class: str = "AutoImageProcessor"
     tokenizer_class: str = "AutoTokenizer"
 
     def __call__(
         self,
         text: Union[
-            TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]
+            TextInput, PreTokenizedInput, list[TextInput], list[PreTokenizedInput]
         ],
         images: torch.Tensor,
         padding: Union[bool, str, PaddingStrategy] = False,
@@ -165,16 +165,16 @@ class PrismaticProcessor(PrismaticProcessorOriginal):
 
 
 class MultiInputPrismaticProcessor(PrismaticProcessorOriginal):
-    attributes: ClassVar[List[str]] = ["image_processor", "tokenizer"]
+    attributes: ClassVar[list[str]] = ["image_processor", "tokenizer"]
     image_processor_class: str = "AutoImageProcessor"
     tokenizer_class: str = "AutoTokenizer"
 
     def __call__(
         self,
         text: Union[
-            TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]
+            TextInput, PreTokenizedInput, list[TextInput], list[PreTokenizedInput]
         ],
-        images: Dict[str, torch.Tensor],
+        images: dict[str, torch.Tensor],
         proprio_states: torch.Tensor,
         padding: Union[bool, str, PaddingStrategy] = False,
         truncation: Optional[Union[bool, str, TruncationStrategy]] = None,

--- a/rlinf/runners/reasoning_runner.py
+++ b/rlinf/runners/reasoning_runner.py
@@ -15,7 +15,7 @@
 import logging
 import os
 import typing
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 import pandas as pd
 import torch
@@ -278,7 +278,7 @@ class ReasoningRunner:
     def epoch(self):
         return self.global_steps // self.num_steps_per_epoch
 
-    def _put_batch(self, batch: Dict[str, torch.Tensor]):
+    def _put_batch(self, batch: dict[str, torch.Tensor]):
         prompt_ids = batch["prompt"].tolist()
         lengths = batch["length"].tolist()
         answers = batch["answer"]

--- a/rlinf/scheduler/accelerator.py
+++ b/rlinf/scheduler/accelerator.py
@@ -15,7 +15,6 @@
 import os
 import warnings
 from enum import Enum
-from typing import Dict, List
 
 
 class AcceleratorType(Enum):
@@ -39,7 +38,7 @@ class Accelerator:
     CCL_SUPPORT_LIST = [AcceleratorType.NV_GPU, AcceleratorType.AMD_GPU]
 
     @staticmethod
-    def get_node_accelerator_type_and_num(node_info: Dict[str, int]):
+    def get_node_accelerator_type_and_num(node_info: dict[str, int]):
         """Get the type of accelerator and num of accelerators available on the current node.
 
         Args:
@@ -49,7 +48,7 @@ class Accelerator:
         Returns:
             Tuple[AcceleratorType, int]: A tuple containing the type of accelerator and num of accelerators.
         """
-        node_resources: Dict[str, str] = node_info.get("Resources", {})
+        node_resources: dict[str, str] = node_info.get("Resources", {})
 
         for unsupported in Accelerator.UNSUPPORTED_LIST:
             if unsupported in node_resources and node_resources[unsupported] > 0:
@@ -79,8 +78,8 @@ class Accelerator:
 
     @staticmethod
     def get_accelerator_env_var(
-        accelerator_type: AcceleratorType, visible_accelerators: List[str]
-    ) -> Dict[str, str]:
+        accelerator_type: AcceleratorType, visible_accelerators: list[str]
+    ) -> dict[str, str]:
         """Get the environment variables related to the accelerator.
 
         Args:
@@ -131,7 +130,7 @@ class Accelerator:
         return env_vars
 
     @staticmethod
-    def get_visible_devices(accelerator_type: AcceleratorType) -> List[int]:
+    def get_visible_devices(accelerator_type: AcceleratorType) -> list[int]:
         """Get the visible device environment variable based on accelerator type.
 
         Args:

--- a/rlinf/scheduler/channel/channel.py
+++ b/rlinf/scheduler/channel/channel.py
@@ -15,7 +15,7 @@
 import asyncio
 import time
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import ray
 import ray.actor
@@ -133,7 +133,7 @@ class Channel:
 
     """
 
-    local_channel_map: Dict[int, "LocalChannel"] = {}
+    local_channel_map: dict[int, "LocalChannel"] = {}
 
     @classmethod
     def create(
@@ -506,7 +506,7 @@ class Channel:
         target_weight: int = 0,
         key: Any = DEFAULT_KEY,
         async_op: bool = False,
-    ) -> AsyncWork | List[Any]:
+    ) -> AsyncWork | list[Any]:
         """Get a batch of items from the channel queue based on the set batch weight.
 
         It will try to get items until the total weight of the items is about to (i.e., the next item will) exceed the set batch weight.
@@ -579,7 +579,7 @@ class Channel:
         items = async_work.wait()
         return str(items)
 
-    def __setstate__(self, state_dict: Dict[str, Any]):
+    def __setstate__(self, state_dict: dict[str, Any]):
         """Set current worker when the channel is unpickled."""
         self.__dict__.update(state_dict)
         # Set local channel

--- a/rlinf/scheduler/channel/channel_worker.py
+++ b/rlinf/scheduler/channel/channel_worker.py
@@ -14,7 +14,7 @@
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any
 
 from ..worker import Worker, WorkerAddress
 from .channel import DEFAULT_KEY
@@ -79,7 +79,7 @@ class LocalChannel:
             maxsize (int): The maximum size of the default channel queue. Defaults to 0 (unbounded).
 
         """
-        self._queue_map: Dict[str, PeekQueue] = {}
+        self._queue_map: dict[str, PeekQueue] = {}
 
         self._queue_map[DEFAULT_KEY] = PeekQueue(maxsize=maxsize)
 
@@ -189,7 +189,7 @@ class LocalChannel:
         self,
         target_weight: int,
         key: Any = DEFAULT_KEY,
-    ) -> List[Any]:
+    ) -> list[Any]:
         """Get a batch of items from the channel queue based on the batch weight.
 
         Args:
@@ -200,7 +200,7 @@ class LocalChannel:
         self.create_queue(key, maxsize=self.maxsize())
         batch = []
         current_weight = 0
-        items: List[WeightedItem] = self._queue_map[key].peek_all()
+        items: list[WeightedItem] = self._queue_map[key].peek_all()
         for item in items:
             if current_weight + item.weight > target_weight:
                 break
@@ -212,7 +212,7 @@ class LocalChannel:
 
         return batch
 
-    def get_all(self, key: str = DEFAULT_KEY) -> List[Any]:
+    def get_all(self, key: str = DEFAULT_KEY) -> list[Any]:
         """Get all items from the channel queue without removing them.
 
         Args:
@@ -237,7 +237,7 @@ class ChannelWorker(Worker):
 
         """
         super().__init__()
-        self._queue_map: Dict[str, PeekQueue] = {}
+        self._queue_map: dict[str, PeekQueue] = {}
         self._queue_map[DEFAULT_KEY] = PeekQueue(maxsize=maxsize)
 
     def create_queue(self, key: Any, maxsize: int = 0):
@@ -400,7 +400,7 @@ class ChannelWorker(Worker):
         query_id: int,
         target_weight: int,
         key: str = DEFAULT_KEY,
-    ) -> List[Any]:
+    ) -> list[Any]:
         """Get a batch of items from the channel queue based on the batch weight.
 
         Args:
@@ -433,7 +433,7 @@ class ChannelWorker(Worker):
 
     async def get_batch_via_ray(
         self, target_weight: int, key: Any = DEFAULT_KEY
-    ) -> List[Any]:
+    ) -> list[Any]:
         """Get a batch of items from the channel queue via Ray's communication based on the batch weight.
 
         Args:
@@ -456,7 +456,7 @@ class ChannelWorker(Worker):
                 break
         return batch
 
-    def get_all(self, key: Any = DEFAULT_KEY) -> List[Any]:
+    def get_all(self, key: Any = DEFAULT_KEY) -> list[Any]:
         """Get all items from the channel queue without removing them.
 
         Args:

--- a/rlinf/scheduler/cluster.py
+++ b/rlinf/scheduler/cluster.py
@@ -20,7 +20,7 @@ import time
 import warnings
 from dataclasses import dataclass
 from importlib.metadata import version
-from typing import TYPE_CHECKING, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Optional
 
 import ray
 import ray.util.scheduling_strategies
@@ -166,7 +166,7 @@ class Cluster:
             )
             time.sleep(1)
 
-        self._nodes: List[NodeInfo] = []
+        self._nodes: list[NodeInfo] = []
         for node in ray.nodes():
             accelerator_type, num_accelerators = (
                 Accelerator.get_node_accelerator_type_and_num(node)
@@ -183,7 +183,7 @@ class Cluster:
             )
 
         # Sort nodes first by accelerator type, then by IP
-        nodes_group_by_accel_type: Dict[AcceleratorType, List[NodeInfo]] = {
+        nodes_group_by_accel_type: dict[AcceleratorType, list[NodeInfo]] = {
             accel_type: [] for accel_type in AcceleratorType
         }
         for node in self._nodes:
@@ -310,7 +310,7 @@ class Cluster:
         return sum(node.num_accelerators for node in self._nodes)
 
     @property
-    def node_accelerator_ids(self) -> List[List[int]]:
+    def node_accelerator_ids(self) -> list[list[int]]:
         """Get the global accelerator IDs for each node in the cluster."""
         node_start_accel_id = 0
         node_accel_ids = []
@@ -380,11 +380,11 @@ class Cluster:
 
     def allocate(
         self,
-        cls: Type["Worker"],
+        cls: type["Worker"],
         worker_name: str,
         node_id: int,
         env_vars: dict,
-        cls_args: List = [],
+        cls_args: list = [],
         cls_kwargs: dict = {},
     ) -> ActorHandle:
         """Allocate a ray remote class instance on a specific node and local rank.

--- a/rlinf/scheduler/collective/async_work.py
+++ b/rlinf/scheduler/collective/async_work.py
@@ -16,7 +16,7 @@ import asyncio
 import queue
 import threading
 import time
-from typing import Any, Callable, Dict, List, Optional, overload
+from typing import Any, Callable, Optional, overload
 
 import ray.actor
 import torch.distributed as dist
@@ -166,7 +166,7 @@ class AsyncCollWork(AsyncWork):
 
     def __init__(
         self,
-        works: List[dist.Work],
+        works: list[dist.Work],
     ):
         """Initialize the AsyncCollWork with a list of dist.Work objects.
 
@@ -175,7 +175,7 @@ class AsyncCollWork(AsyncWork):
 
         """
         super().__init__()
-        if not isinstance(works, List):
+        if not isinstance(works, list):
             works = [works]
         self._works = works
         self._next_work = None
@@ -247,7 +247,7 @@ class AsyncChannelWork(AsyncWork):
     # Operation queues used to communicate with the operation processing thread
     async_op_queue: queue.Queue["AsyncChannelWork"] = queue.Queue()
     # Operation queues for each channel-key combination
-    channel_op_queue_map: Dict[str, asyncio.Queue] = {}
+    channel_op_queue_map: dict[str, asyncio.Queue] = {}
     # Global thread lock
     lock: threading.Lock = None
     # Channel operation processing thread
@@ -368,7 +368,7 @@ class AsyncChannelWork(AsyncWork):
 class AsyncChannelCommWork(AsyncWork):
     """Asynchronous work for channel operations."""
 
-    channel_data_store: Dict[int, Future] = {}
+    channel_data_store: dict[int, Future] = {}
     store_lock = threading.Lock()  # Protect store access
 
     def __init__(self, async_comm_work: AsyncWork, query_id: int):

--- a/rlinf/scheduler/collective/collective.py
+++ b/rlinf/scheduler/collective/collective.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import time
-from typing import Dict, List, Optional
+from typing import Optional
 
 from ..cluster import Cluster
 from ..manager import CollectiveGroupInfo, CollectiveManager, WorkerInfo
@@ -31,14 +31,14 @@ class Collective:
             cur_worker (Worker): The current worker instance that will be used to manage collective groups.
 
         """
-        self._name_group_map: Dict[str, CollectiveGroup] = {}
+        self._name_group_map: dict[str, CollectiveGroup] = {}
         self._coll_manager = CollectiveManager.get_proxy()
         self._worker_manager = cur_worker.manager_proxy
         self._cur_worker_address = cur_worker.worker_address
         self._logger = cur_worker._logger
 
     def create_collective_group(
-        self, worker_addresses: List[WorkerAddress], group_name: Optional[str] = None
+        self, worker_addresses: list[WorkerAddress], group_name: Optional[str] = None
     ) -> CollectiveGroup:
         """Create a collective group with the given workers and name. If the group already exists, it will return the existing group.
 
@@ -64,7 +64,7 @@ class Collective:
         )
         return self._name_group_map[group_name]
 
-    def _get_group_name(self, workers: List[WorkerAddress]):
+    def _get_group_name(self, workers: list[WorkerAddress]):
         return "cg-" + "-".join([worker.get_name() for worker in workers])
 
     def _get_worker_info_safe(self, worker_address: WorkerAddress) -> WorkerInfo:

--- a/rlinf/scheduler/collective/collective_group.py
+++ b/rlinf/scheduler/collective/collective_group.py
@@ -20,7 +20,7 @@ import time
 from contextlib import nullcontext
 from pickle import Pickler, Unpickler
 from queue import Empty, Queue
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 import torch.distributed as dist
@@ -130,7 +130,7 @@ class CollectiveGroup:
         group_info: Optional[CollectiveGroupInfo],
         collective: "Collective",
         group_name: str,
-        worker_addresses: List[WorkerAddress],
+        worker_addresses: list[WorkerAddress],
         cur_worker_address: WorkerAddress,
     ):
         """Initialize the CollectiveGroup.
@@ -171,7 +171,7 @@ class CollectiveGroup:
 
     def send(
         self,
-        object: torch.Tensor | List[torch.Tensor] | Dict[str, torch.Tensor] | Any,
+        object: torch.Tensor | list[torch.Tensor] | dict[str, torch.Tensor] | Any,
         async_op: bool = False,
     ) -> Optional[AsyncWork]:
         """Implement the Worker's send method.
@@ -217,7 +217,7 @@ class CollectiveGroup:
 
     def _atomic_send(
         self,
-        object: torch.Tensor | List[torch.Tensor] | Dict[str, torch.Tensor] | Any,
+        object: torch.Tensor | list[torch.Tensor] | dict[str, torch.Tensor] | Any,
         comm_id: int,
         device_type: str,
         object_type: str,
@@ -248,7 +248,7 @@ class CollectiveGroup:
 
     def recv(
         self, async_op: bool = False
-    ) -> AsyncWork | torch.Tensor | List[torch.Tensor] | Dict[str, torch.Tensor] | Any:
+    ) -> AsyncWork | torch.Tensor | list[torch.Tensor] | dict[str, torch.Tensor] | Any:
         """Implement Worker's recv method.
 
         Similar as the send method above, it ensures the correct ordering of multiple communications of two recv calls.
@@ -276,7 +276,7 @@ class CollectiveGroup:
 
     def _atomic_recv(
         self, comm_id: int
-    ) -> AsyncWork | torch.Tensor | List[torch.Tensor] | Dict[str, torch.Tensor] | Any:
+    ) -> AsyncWork | torch.Tensor | list[torch.Tensor] | dict[str, torch.Tensor] | Any:
         """Atomic recv implementation."""
         # First recv object type
         self._init_p2p_process_group()
@@ -435,7 +435,7 @@ class CollectiveGroup:
             master_worker_address = self._worker_addresses[0]
             if self._cur_worker_address == master_worker_address:
                 # Create the group if I'm the master worker
-                workers: List[WorkerInfo] = []
+                workers: list[WorkerInfo] = []
                 for address in self._worker_addresses:
                     worker_info = self._collective._get_worker_info_safe(address)
                     workers.append(worker_info)
@@ -525,7 +525,7 @@ class CollectiveGroup:
                 # Avoid using the same master port for the next group
                 self._coll_manager.reset_master_port_info(self._group_info.group_name)
 
-    def _get_object_device_type(self, object: torch.Tensor | Any) -> Tuple[str, int]:
+    def _get_object_device_type(self, object: torch.Tensor | Any) -> tuple[str, int]:
         """Check the device type of the object. We also handle List of tensors, tuple of tensors, and Dict of tensors (all values must be tensors)."""
         device_type = CollectiveGroup.CPU
         object_type = CollectiveGroup.OBJECT
@@ -536,7 +536,7 @@ class CollectiveGroup:
                 else CollectiveGroup.CPU
             )
             object_type = CollectiveGroup.TENSOR
-        elif (isinstance(object, List) or isinstance(object, Tuple)) and all(
+        elif (isinstance(object, list) or isinstance(object, tuple)) and all(
             isinstance(item, torch.Tensor) for item in object
         ):
             device_type = (
@@ -549,7 +549,7 @@ class CollectiveGroup:
                     "All tensors in the list or tuple must be on the same device"
                 )
             object_type = CollectiveGroup.TENSOR_LIST
-        elif isinstance(object, Dict) and all(
+        elif isinstance(object, dict) and all(
             isinstance(item, torch.Tensor) for item in object.values()
         ):
             device_type = (
@@ -783,7 +783,7 @@ class CollectiveGroup:
 
     def _send_cuda_tensor_list_via_ipc(
         self,
-        tensors: List[torch.Tensor],
+        tensors: list[torch.Tensor],
         comm_id: int,
         async_op: bool = False,
     ) -> Optional[AsyncWork]:
@@ -812,7 +812,7 @@ class CollectiveGroup:
         if async_op:
             return work
 
-    def _recv_cuda_tensor_list_via_ipc(self, comm_id: int) -> List[torch.Tensor]:
+    def _recv_cuda_tensor_list_via_ipc(self, comm_id: int) -> list[torch.Tensor]:
         self._logger.debug(
             f"Receiving tensors via IPC in worker {self._cur_worker_address.get_name()}"
         )
@@ -845,7 +845,7 @@ class CollectiveGroup:
 
     def _send_cuda_tensor_list_to_uncertain_peer(
         self,
-        tensors: List[torch.Tensor],
+        tensors: list[torch.Tensor],
         comm_id: int,
         async_op: bool = False,
     ):
@@ -971,7 +971,7 @@ class CollectiveGroup:
 
     def _send_tensor_list(
         self,
-        tensors: List[torch.Tensor],
+        tensors: list[torch.Tensor],
         device_type: str,
         comm_id: int,
         async_op: bool = False,
@@ -1040,7 +1040,7 @@ class CollectiveGroup:
         if async_op:
             return work
 
-    def _recv_tensor_list(self, comm_id: int) -> List[torch.Tensor]:
+    def _recv_tensor_list(self, comm_id: int) -> list[torch.Tensor]:
         """Receive a list of tensors from the specified source address in the collective group.
 
             NOTE: Do not mix CPU and GPU tensors in the same list.
@@ -1106,7 +1106,7 @@ class CollectiveGroup:
 
     def _send_tensor_dict(
         self,
-        tensor_dict: Dict[str, torch.Tensor],
+        tensor_dict: dict[str, torch.Tensor],
         device_type: str,
         comm_id: int,
         async_op: bool = False,
@@ -1151,7 +1151,7 @@ class CollectiveGroup:
         if async_op:
             return value_work
 
-    def _recv_tensor_dict(self, comm_id: int) -> Dict[str, torch.Tensor]:
+    def _recv_tensor_dict(self, comm_id: int) -> dict[str, torch.Tensor]:
         """Receive a dictionary of tensors from the specified source address in the collective group.
 
         Args:

--- a/rlinf/scheduler/collective/multi_channel_pg.py
+++ b/rlinf/scheduler/collective/multi_channel_pg.py
@@ -14,7 +14,7 @@
 
 import logging
 from datetime import timedelta
-from typing import List, Optional
+from typing import Optional
 
 import torch
 import torch.distributed as dist
@@ -75,16 +75,16 @@ class MultiChannelProcessGroup:
             Accelerator.get_ccl_backend(accel_type) if not self._no_accel_ccl else None
         )
 
-        self._send_accel_ccl_process_groups: List[dist.ProcessGroup] = [
+        self._send_accel_ccl_process_groups: list[dist.ProcessGroup] = [
             None for _ in range(num_channels)
         ]
-        self._recv_accel_ccl_process_groups: List[dist.ProcessGroup] = [
+        self._recv_accel_ccl_process_groups: list[dist.ProcessGroup] = [
             None for _ in range(num_channels)
         ]
-        self._send_gloo_process_groups: List[dist.ProcessGroup] = [
+        self._send_gloo_process_groups: list[dist.ProcessGroup] = [
             None for _ in range(num_channels)
         ]
-        self._recv_gloo_process_groups: List[dist.ProcessGroup] = [
+        self._recv_gloo_process_groups: list[dist.ProcessGroup] = [
             None for _ in range(num_channels)
         ]
 

--- a/rlinf/scheduler/dynamic_scheduler/scheduler_worker.py
+++ b/rlinf/scheduler/dynamic_scheduler/scheduler_worker.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
 
 from omegaconf import DictConfig
 
@@ -35,7 +34,7 @@ class SchedulerWorker(Worker):
         self,
         config: DictConfig,
         component_placement: ComponentPlacement,
-        workflow: List[str] = ["rollout", "inference", "actor"],
+        workflow: list[str] = ["rollout", "inference", "actor"],
     ):
         """Initialize the SchedulerWorker."""
         super().__init__()
@@ -70,7 +69,7 @@ class SchedulerWorker(Worker):
             "_logger": self._logger,
             "channel_factory": self.create_channel,
         }
-        self.component_managers: Dict[str, ComponentManager] = {}
+        self.component_managers: dict[str, ComponentManager] = {}
         for component in self.components:
             if component == "reward":
                 continue

--- a/rlinf/scheduler/dynamic_scheduler/utils.py
+++ b/rlinf/scheduler/dynamic_scheduler/utils.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING
 
 from omegaconf import DictConfig
 
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from rlinf.scheduler.dynamic_scheduler.manager import ComponentManager
 
 
-def get_valid_dp_sizes(cfg, total_gpus, model_parallel_size_with_cp) -> List[int]:
+def get_valid_dp_sizes(cfg, total_gpus, model_parallel_size_with_cp) -> list[int]:
     """This function is used to get the valid data parallel sizes for the Actor based on the constraints of batch and group size.
 
     Returns:
@@ -94,7 +94,7 @@ class RolloutScheduleInfo:
     """Rollout schedule info."""
 
     instance_id: int = -1
-    data: List["SeqGroupInfo"] = None
+    data: list["SeqGroupInfo"] = None
     report: RolloutReport = None
     action: RolloutAction = RolloutAction.Default
 
@@ -106,20 +106,20 @@ class _DynamicSchedulerState:
         self,
         cfg: DictConfig,
         total_gpus: int,
-        component_managers: Dict[str, "ComponentManager"],
+        component_managers: dict[str, "ComponentManager"],
     ):
         """Initialize the dynamic scheduler state."""
         self.total_gpus = total_gpus
         self.available_gpu_num = 0
         self.component_managers = component_managers
 
-        self.components_instance_num: Dict[str, int] = {}
-        self.components_model_parallel_size: Dict[str, int] = {}
+        self.components_instance_num: dict[str, int] = {}
+        self.components_model_parallel_size: dict[str, int] = {}
         for component, manager in self.component_managers.items():
             self.components_instance_num[component] = manager.current_instance_num
             self.components_model_parallel_size[component] = manager.model_parallel_size
 
-        self.actor_valid_dp_sizes: List[int] = get_valid_dp_sizes(
+        self.actor_valid_dp_sizes: list[int] = get_valid_dp_sizes(
             cfg, total_gpus, self.components_model_parallel_size["actor"]
         )
 
@@ -148,7 +148,7 @@ DynamicSchedulerState = None
 
 
 def set_global_scheduer_state(
-    cfg: DictConfig, total_gpus: int, component_managers: Dict[str, "ComponentManager"]
+    cfg: DictConfig, total_gpus: int, component_managers: dict[str, "ComponentManager"]
 ):
     """Set DynamicSchedulerState."""
     global DynamicSchedulerState

--- a/rlinf/scheduler/manager/coll_manager.py
+++ b/rlinf/scheduler/manager/coll_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional
+from typing import Optional
 
 from .manager import Manager
 from .worker_manager import WorkerInfo
@@ -63,7 +63,7 @@ class CollectiveManager(Manager):
 
     def __init__(self):
         """Initialize the CollectiveManager."""
-        self._name_info_map: Dict[str, CollectiveGroupInfo] = {}
+        self._name_info_map: dict[str, CollectiveGroupInfo] = {}
 
     def register_collective_group(self, group_info: CollectiveGroupInfo):
         """Create a collective group with the given name and workers.

--- a/rlinf/scheduler/manager/lock_manager.py
+++ b/rlinf/scheduler/manager/lock_manager.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import collections
-from typing import List
 
 from ..cluster import Cluster
 from .manager import Manager
@@ -100,7 +99,7 @@ class DeviceLockManager(Manager):
         ]
 
     async def acquire_devices(
-        self, worker_address: WorkerAddress, accel_ids: List[int]
+        self, worker_address: WorkerAddress, accel_ids: list[int]
     ):
         """Lock the specified accelerator device IDs.
 
@@ -116,7 +115,7 @@ class DeviceLockManager(Manager):
         )
 
     async def release_devices(
-        self, worker_address: WorkerAddress, accel_ids: List[int]
+        self, worker_address: WorkerAddress, accel_ids: list[int]
     ):
         """Release the specified accelerator device IDs.
 

--- a/rlinf/scheduler/manager/manager.py
+++ b/rlinf/scheduler/manager/manager.py
@@ -14,7 +14,7 @@
 
 import os
 import time
-from typing import Type, TypeVar
+from typing import TypeVar
 
 import ray
 from ray._private import worker
@@ -27,7 +27,7 @@ ManagerClsType = TypeVar("ManagerClsType")
 class ManagerProxy:
     """Singleton proxy for the Manager class to handle remote calls."""
 
-    def __init__(self, manager_cls: "Type[Manager]"):
+    def __init__(self, manager_cls: "type[Manager]"):
         """Launch the Manager class as a remote actor if not already running."""
         from ..worker import Worker
 
@@ -89,7 +89,7 @@ class Manager:
     PID = None
 
     @classmethod
-    def get_proxy(cls: Type[ManagerClsType]) -> Type[ManagerClsType]:
+    def get_proxy(cls: type[ManagerClsType]) -> type[ManagerClsType]:
         """Get the singleton proxy for the Manager class.
 
         Returns:

--- a/rlinf/scheduler/manager/worker_manager.py
+++ b/rlinf/scheduler/manager/worker_manager.py
@@ -14,7 +14,6 @@
 
 import bisect
 from dataclasses import dataclass
-from typing import List
 
 from ..accelerator import AcceleratorType
 from .manager import Manager
@@ -23,7 +22,7 @@ from .manager import Manager
 class WorkerAddress:
     """A class that describes the path to a worker in a WorkerGroup."""
 
-    def __init__(self, root_group_name: str, ranks: int | List[int] = []):
+    def __init__(self, root_group_name: str, ranks: int | list[int] = []):
         """Initialize the WorkerAddress.
 
         Args:
@@ -156,7 +155,7 @@ class WorkerInfo:
     node_port: int
     """Port of the node where the worker is placed."""
 
-    available_accelerators: List[int]
+    available_accelerators: list[int]
     """List of global accelerator IDs available to the worker."""
 
     def __hash__(self):
@@ -177,7 +176,7 @@ class WorkerNode:
         """
         self._worker_address = worker_address
         self._worker_info = worker_info
-        self._nodes: List[WorkerNode] = []
+        self._nodes: list[WorkerNode] = []
 
     @classmethod
     def find_node(
@@ -256,7 +255,7 @@ class WorkerManager(Manager):
 
     def __init__(self):
         """Initialize the WorkerManager."""
-        self._root_workers: List[WorkerNode] = []
+        self._root_workers: list[WorkerNode] = []
 
     def register_worker(self, worker_address: WorkerAddress, worker_info: WorkerInfo):
         """Register a new worker in the worker manager.

--- a/rlinf/scheduler/placement/flexible.py
+++ b/rlinf/scheduler/placement/flexible.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-from typing import Dict, List, Tuple
-
 from ..cluster import Cluster
 from .placement import Placement, PlacementStrategy
 
@@ -64,7 +62,7 @@ class FlexiblePlacementStrategy(PlacementStrategy):
 
     """
 
-    def __init__(self, accelerator_ids_list: List[List[int]]):
+    def __init__(self, accelerator_ids_list: list[list[int]]):
         """Initialize the FlexiblePlacementStrategy.
 
         .. note::
@@ -113,7 +111,7 @@ class FlexiblePlacementStrategy(PlacementStrategy):
 
     def _verify_accelerator_ids_for_process(
         self,
-        accel_ids: List[int],
+        accel_ids: list[int],
         cluster: Cluster,
     ):
         """Verify that the accelerator IDs for a process are valid."""
@@ -140,7 +138,7 @@ class FlexiblePlacementStrategy(PlacementStrategy):
         self,
         cluster: Cluster,
         isolate_accelerator: bool = True,
-    ) -> List[Placement]:
+    ) -> list[Placement]:
         """Generate a list of placements based on the flexible strategy.
 
         Args:
@@ -162,11 +160,11 @@ class FlexiblePlacementStrategy(PlacementStrategy):
             cluster.get_node_id_from_accel_id(accel_ids[0])
             for accel_ids in self._accel_ids_list
         ]
-        node_id_accel_ids: List[Tuple[int, List[int]]] = list(
+        node_id_accel_ids: list[tuple[int, list[int]]] = list(
             zip(node_ids, self._accel_ids_list)
         )
 
-        placements: List[Placement] = []
+        placements: list[Placement] = []
         for rank, (node_id, accel_ids) in enumerate(node_id_accel_ids):
             local_accelerator_ids = [
                 cluster.global_accel_id_to_local_accel_id(accel_id)
@@ -199,7 +197,7 @@ class FlexiblePlacementStrategy(PlacementStrategy):
         local_rank = 0
         local_world_size = 0
         current_node_id = placements[0].node_id
-        node_local_world_size: Dict[int, int] = {}
+        node_local_world_size: dict[int, int] = {}
         for placement in placements:
             if placement.node_id != current_node_id:
                 assert placement.node_id > current_node_id, (

--- a/rlinf/scheduler/placement/node.py
+++ b/rlinf/scheduler/placement/node.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-from typing import Dict, List
-
 from ..cluster import Cluster
 from .placement import Placement, PlacementStrategy
 
@@ -54,7 +52,7 @@ class NodePlacementStrategy(PlacementStrategy):
 
     """
 
-    def __init__(self, node_ids: List[int]):
+    def __init__(self, node_ids: list[int]):
         """Initialize the NodePlacementStrategy.
 
         .. note::
@@ -77,7 +75,7 @@ class NodePlacementStrategy(PlacementStrategy):
         self,
         cluster: Cluster,
         isolate_accelerator: bool = True,
-    ) -> List[Placement]:
+    ) -> list[Placement]:
         """Generate a list of placements based on the node placement strategy.
 
         Args:
@@ -88,7 +86,7 @@ class NodePlacementStrategy(PlacementStrategy):
             List[Placement]: A list of Placement objects representing the placements of processes on accelerators.
 
         """
-        placements: List[Placement] = []
+        placements: list[Placement] = []
         for rank, node_id in enumerate(self._node_ids):
             assert node_id < cluster.num_nodes, (
                 f"Node ID {node_id} exceeds number of available nodes {cluster.num_nodes}"
@@ -115,7 +113,7 @@ class NodePlacementStrategy(PlacementStrategy):
         local_rank = 0
         local_world_size = 0
         current_node_id = placements[0].node_id
-        node_local_world_size: Dict[int, int] = {}
+        node_local_world_size: dict[int, int] = {}
         for placement in placements:
             if placement.node_id != current_node_id:
                 assert placement.node_id > current_node_id, (

--- a/rlinf/scheduler/placement/packed.py
+++ b/rlinf/scheduler/placement/packed.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
 
 from ..cluster import Cluster
 from .placement import Placement, PlacementStrategy
@@ -139,7 +138,7 @@ class PackedPlacementStrategy(PlacementStrategy):
         self,
         cluster: Cluster,
         isolate_accelerator: bool = True,
-    ) -> List[Placement]:
+    ) -> list[Placement]:
         """Generate a list of placements based on the packed strategy.
 
         Args:
@@ -151,9 +150,9 @@ class PackedPlacementStrategy(PlacementStrategy):
 
         """
         rank = 0
-        placements: List[Placement] = []
+        placements: list[Placement] = []
         start_node = cluster.get_node_id_from_accel_id(self._start_accel_id)
-        accel_usage_map: Dict[int, bool] = dict.fromkeys(
+        accel_usage_map: dict[int, bool] = dict.fromkeys(
             range(self._start_accel_id, self._end_accel_id + 1), False
         )
 

--- a/rlinf/scheduler/placement/placement.py
+++ b/rlinf/scheduler/placement/placement.py
@@ -14,7 +14,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import List, overload
+from typing import overload
 
 from ..accelerator import AcceleratorType
 from ..cluster import Cluster
@@ -45,7 +45,7 @@ class Placement:
     local_world_size: int
     """Local world size (number of workers) on the node."""
 
-    visible_accelerators: List[str]
+    visible_accelerators: list[str]
     """List of CUDA visible devices for the worker."""
 
     isolate_accelerator: bool
@@ -76,5 +76,5 @@ class PlacementStrategy:
         self,
         cluster: Cluster,
         isolate_accelerator: bool = True,
-    ) -> List[Placement]:
+    ) -> list[Placement]:
         return None

--- a/rlinf/scheduler/worker/worker.py
+++ b/rlinf/scheduler/worker/worker.py
@@ -26,11 +26,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
     Optional,
-    Tuple,
-    Type,
     TypeVar,
 )
 
@@ -51,7 +47,7 @@ WorkerClsType = TypeVar("WorkerClsType")
 class WorkerMeta(type):
     """Metaclass to capture failures in worker classes."""
 
-    def __new__(cls, name: str, bases: Tuple[Type], attrs: Dict[str, Any]):
+    def __new__(cls, name: str, bases: tuple[type], attrs: dict[str, Any]):
         """Wrap the function to catch SystemExit exceptions."""
         for attr_name, attr_value in attrs.items():
             if callable(attr_value):
@@ -361,7 +357,7 @@ class Worker(metaclass=WorkerMeta):
 
         self._actor = None
         self._has_initialized = False
-        self._timer_metrics: Dict[str, float] = {}
+        self._timer_metrics: dict[str, float] = {}
         self._set_new_omegaconf_resolvers()
 
     def __init__(
@@ -468,7 +464,7 @@ class Worker(metaclass=WorkerMeta):
 
     @classmethod
     def create_group(
-        cls: Type[WorkerClsType], *args, **kwargs
+        cls: type[WorkerClsType], *args, **kwargs
     ) -> "WorkerGroup[WorkerClsType]":
         """Create a worker group with the class arguments.
 
@@ -482,9 +478,9 @@ class Worker(metaclass=WorkerMeta):
 
     def send(
         self,
-        object: torch.Tensor | List[torch.Tensor] | Dict[str, torch.Tensor] | Any,
+        object: torch.Tensor | list[torch.Tensor] | dict[str, torch.Tensor] | Any,
         dst_group_name: str,
-        dst_rank: int | List[int],
+        dst_rank: int | list[int],
         async_op: bool = False,
     ):
         """Send an object to a specific worker address in the collective group.
@@ -521,7 +517,7 @@ class Worker(metaclass=WorkerMeta):
         return group.send(object=object, async_op=async_op)
 
     def recv(
-        self, src_group_name: str, src_rank: int | List[int], async_op: bool = False
+        self, src_group_name: str, src_rank: int | list[int], async_op: bool = False
     ):
         """Out-of-place receive of an object from a specific worker address in the collective group.
 
@@ -551,7 +547,7 @@ class Worker(metaclass=WorkerMeta):
         self,
         tensor: torch.Tensor,
         dst_group_name: str,
-        dst_rank: int | List[int],
+        dst_rank: int | list[int],
         async_op: bool = False,
     ):
         """Send a tensor to a specific worker address in the collective group. This function is optimized for sending a single tensor and does not introduce metadata communication overhead like send. But it needs to be paired with the in-place recv_tensor function which requires apriori knowledge of the tensor shape and dtype.
@@ -583,7 +579,7 @@ class Worker(metaclass=WorkerMeta):
         self,
         tensor: torch.Tensor,
         src_group_name: str,
-        src_rank: int | List[int],
+        src_rank: int | list[int],
         async_op: bool = False,
     ):
         """In-place receive of a tensor from a specific worker address in the collective group. This function is optimized for receiving a single tensor and does not introduce metadata communication overhead like recv. But it requires preallocation of the tensor with the correct shape and dtype.
@@ -650,7 +646,7 @@ class Worker(metaclass=WorkerMeta):
 
         return Channel.connect(channel_name=channel_name, current_worker=self)
 
-    def broadcast(self, object: Optional[Any], ranks: List[int]):
+    def broadcast(self, object: Optional[Any], ranks: list[int]):
         """Broadcast an object inside the current worker group.
 
         Args:

--- a/rlinf/scheduler/worker/worker_group.py
+++ b/rlinf/scheduler/worker/worker_group.py
@@ -18,7 +18,7 @@ import signal
 import sys
 import threading
 from dataclasses import dataclass
-from typing import Generic, List, Optional, Type
+from typing import Generic, Optional
 
 import numpy as np
 import ray
@@ -38,7 +38,7 @@ from .worker import Worker, WorkerAddress, WorkerClsType
 class WorkerGroup(Generic[WorkerClsType]):
     """The class that enables a worker to become a group of workers that can be executed collectively."""
 
-    def __init__(self, worker_cls: Type[Worker], args, kwargs):
+    def __init__(self, worker_cls: type[Worker], args, kwargs):
         """Initialize the WorkerGroup with a worker class. Used as a decorator to create a worker group.
 
         Args:
@@ -75,7 +75,7 @@ class WorkerGroup(Generic[WorkerClsType]):
         return self._worker_group_name
 
     @property
-    def worker_info_list(self) -> List[WorkerInfo]:
+    def worker_info_list(self) -> list[WorkerInfo]:
         """Get the list of workers in the group."""
         return self._workers
 
@@ -86,7 +86,7 @@ class WorkerGroup(Generic[WorkerClsType]):
         name: Optional[str] = None,
         isolate_gpu: bool = True,
         catch_system_failure: Optional[bool] = None,
-    ) -> "Type[WorkerGroup | WorkerClsType]":
+    ) -> "type[WorkerGroup | WorkerClsType]":
         """Create a worker group with the specified cluster and options.
 
         Args:
@@ -367,7 +367,7 @@ class WorkerGroupFuncResult:
     def __init__(
         self,
         worker_group: WorkerGroup,
-        results: List[ray.remote_function.RemoteFunction],
+        results: list[ray.remote_function.RemoteFunction],
         func_name: str,
         cls_name: str,
     ):

--- a/rlinf/utils/convertor/utils.py
+++ b/rlinf/utils/convertor/utils.py
@@ -14,7 +14,7 @@
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Optional
 
 import torch
 
@@ -29,7 +29,7 @@ class TransformType(Enum):
 class TransformFunc:
     @staticmethod
     def _split_gqa_tensor(
-        tensor: torch.Tensor, new_statedict: dict, weight_names: List[str], config
+        tensor: torch.Tensor, new_statedict: dict, weight_names: list[str], config
     ) -> None:
         hidden_size = config.model_config.hidden_size
         num_attention_heads = config.model_config.num_attention_heads
@@ -90,7 +90,7 @@ class TransformFunc:
 
     @staticmethod
     def split_fc1(
-        linear_fc1: torch.Tensor, new_statedict: dict, weight_names: List[str], config
+        linear_fc1: torch.Tensor, new_statedict: dict, weight_names: list[str], config
     ) -> None:
         assert weight_names is not None and len(weight_names) == 2, (
             f"split_fc1 transform expects two weight names, got {weight_names}"
@@ -118,7 +118,7 @@ class TransformFunc:
 
     @staticmethod
     def split_none(
-        tensor: torch.Tensor, new_statedict: dict, weight_names: List[str]
+        tensor: torch.Tensor, new_statedict: dict, weight_names: list[str]
     ) -> None:
         assert weight_names is not None and len(weight_names) == 1, (
             f"split_none transform expects one weight name, got {weight_names}"
@@ -130,7 +130,7 @@ class TransformFunc:
 class ConvertorRule:
     pattern: re.Pattern
     transform: TransformType
-    targets: List[str]
+    targets: list[str]
     post: Optional[Callable] = None
 
 
@@ -140,7 +140,7 @@ class BaseConvertor:
         self.strict = strict
         self.rules = self.build_rules()
 
-    def map_name(self, name: str) -> Optional[Tuple[TransformType, List[str]]]:
+    def map_name(self, name: str) -> Optional[tuple[TransformType, list[str]]]:
         def _get_targets_from_match(templates: list[str], m: re.Match) -> list[str]:
             gd = m.groupdict()
             out = []
@@ -162,7 +162,7 @@ class BaseConvertor:
             return r.transform, full_names
         return None
 
-    def convert(self, state_dict: Dict) -> Dict:
+    def convert(self, state_dict: dict) -> dict:
         converted = {}
         for k, v in state_dict.items():
             mapped = self.map_name(k)
@@ -181,7 +181,7 @@ class BaseConvertor:
                 raise ValueError(f"Unknown transform type {transform}")
         return converted
 
-    def build_rules(self) -> List[ConvertorRule]:
+    def build_rules(self) -> list[ConvertorRule]:
         """
         Should be implemented in subclass to build the conversion rules.
         """
@@ -189,7 +189,7 @@ class BaseConvertor:
 
 
 class Qwen2_5Convertor(BaseConvertor):
-    def build_rules(self) -> List[ConvertorRule]:
+    def build_rules(self) -> list[ConvertorRule]:
         LID = r"(?P<i>\d+)"
         WB = r"(?P<wb>weight|bias)"
 
@@ -267,7 +267,7 @@ class Qwen2_5Convertor(BaseConvertor):
 
 
 class Qwen2_5VLConvertor(BaseConvertor):
-    def _build_vision_rules(self) -> List[ConvertorRule]:
+    def _build_vision_rules(self) -> list[ConvertorRule]:
         B = r"(?P<i>\d+)"
         WB = r"(?P<wb>weight|bias)"
         HF_V_PREFIX = "model.visual"
@@ -338,7 +338,7 @@ class Qwen2_5VLConvertor(BaseConvertor):
         ]
         return vision_rules
 
-    def _build_llm_rules(self) -> List[ConvertorRule]:
+    def _build_llm_rules(self) -> list[ConvertorRule]:
         B = r"(?P<i>\d+)"
         WB = r"(?P<wb>weight|bias)"
         HF_LLM_PREFIX = "model.language_model"
@@ -418,7 +418,7 @@ class Qwen2_5VLConvertor(BaseConvertor):
         ]
         return llm_rules
 
-    def _build_projector_rules(self) -> List[ConvertorRule]:
+    def _build_projector_rules(self) -> list[ConvertorRule]:
         HF_PROJECTOR_PREFIX = "model.visual.merger"
         MG_PROJECTOR_PREFIX = "vision_model.protection.encoder"
         WB = r"(?P<wb>weight|bias)"
@@ -439,7 +439,7 @@ class Qwen2_5VLConvertor(BaseConvertor):
         ]
         return projector_rules
 
-    def build_rules(self) -> List[ConvertorRule]:
+    def build_rules(self) -> list[ConvertorRule]:
         rules = []
         rules.extend(self._build_vision_rules())
         rules.extend(self._build_llm_rules())

--- a/rlinf/utils/data_iter_utils.py
+++ b/rlinf/utils/data_iter_utils.py
@@ -17,14 +17,14 @@ import heapq
 import itertools
 import logging
 from collections import UserDict
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Iterator, Optional, Union
 
 import numpy as np
 import torch
 from torch import distributed as dist
 
 
-def concat_dict_list(list_of_dicts: List[Dict[str, Any]]) -> Dict[str, Any]:
+def concat_dict_list(list_of_dicts: list[dict[str, Any]]) -> dict[str, Any]:
     """
     Concatenates torch.Tensor or np.ndarray objects corresponding to the same keys in a list of dictionaries.
     Values of other types are collected into lists.
@@ -61,7 +61,7 @@ def concat_dict_list(list_of_dicts: List[Dict[str, Any]]) -> Dict[str, Any]:
 
 
 def split_list(
-    inputs: List, num_chunks: int, enforce_divisible_batch: Optional[bool] = True
+    inputs: list, num_chunks: int, enforce_divisible_batch: Optional[bool] = True
 ):
     """
     Split a list into equal sized chunks
@@ -81,7 +81,7 @@ def split_list(
 
 
 def get_iterator_k_split(
-    batch: Union[Dict, List[torch.Tensor]],
+    batch: Union[dict, list[torch.Tensor]],
     num_splits: int,
     enforce_divisible_batch: Optional[bool] = True,
     shuffle: bool = False,
@@ -249,7 +249,7 @@ def roundup_divisible(a, b):
     return ((a + b - 1) // b) * b
 
 
-def karmarkar_karp(seqlen_list: List[int], k_partitions: int, equal_size: bool):
+def karmarkar_karp(seqlen_list: list[int], k_partitions: int, equal_size: bool):
     # see: https://en.wikipedia.org/wiki/Largest_differencing_method
     class Set:
         def __init__(self) -> None:
@@ -273,7 +273,7 @@ def karmarkar_karp(seqlen_list: List[int], k_partitions: int, equal_size: bool):
             return self.items < other.items
 
     class State:
-        def __init__(self, items: List[Tuple[int, int]], k: int) -> None:
+        def __init__(self, items: list[tuple[int, int]], k: int) -> None:
             self.k = k
             # sets should always be decreasing order
             self.sets = [Set() for _ in range(k)]
@@ -356,7 +356,7 @@ def karmarkar_karp(seqlen_list: List[int], k_partitions: int, equal_size: bool):
 
 
 def get_seqlen_balanced_partitions(
-    seqlen_list: List[int], k_partitions: int, equal_size: bool
+    seqlen_list: list[int], k_partitions: int, equal_size: bool
 ):
     """get order of seq lengths to make partitions balanced, this is
         used in balacing sum of seqlength across dp ranks and microbatches
@@ -454,7 +454,7 @@ def get_seqlen_BFD_partitions(seq_len_list, max_tokens_per_mbs):
 
 
 def get_iterator_dynamic(
-    batch: Union[Dict, List[torch.Tensor]],
+    batch: Union[dict, list[torch.Tensor]],
     max_tokens_per_mbs: Optional[int] = None,
     dp_group=None,
     num_batches_divided_by=None,
@@ -575,7 +575,7 @@ def get_iterator_dynamic(
 
 
 def split_dynamic_batch_size(
-    batch: Dict[str, torch.Tensor],
+    batch: dict[str, torch.Tensor],
     cp_world_size: int,
     vpp_world_size: int,
     max_tokens_per_mbs: int,

--- a/rlinf/utils/metric_utils.py
+++ b/rlinf/utils/metric_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-from typing import Dict
 
 import torch
 import torch.distributed
@@ -43,7 +42,7 @@ def compute_evaluate_metrics(eval_metrics_list):
     return all_eval_metrics
 
 
-def compute_rollout_metrics(data_buffer: Dict) -> Dict:
+def compute_rollout_metrics(data_buffer: dict) -> dict:
     rollout_metrics = {}
 
     if "rewards" in data_buffer:

--- a/rlinf/utils/patcher.py
+++ b/rlinf/utils/patcher.py
@@ -16,13 +16,13 @@ import importlib
 import inspect
 import sys
 import types
-from typing import Callable, List
+from typing import Callable
 
 
 class _Patcher:
     def __init__(self):
         self._mappings_dict: dict[str, str] = {}
-        self._wrappers_dict: dict[str, List[Callable]] = {}
+        self._wrappers_dict: dict[str, list[Callable]] = {}
 
     def clear(self):
         self._mappings_dict = {}

--- a/rlinf/utils/placement.py
+++ b/rlinf/utils/placement.py
@@ -14,7 +14,7 @@
 
 import logging
 from enum import Enum, auto
-from typing import Dict, List, overload
+from typing import overload
 
 from omegaconf import DictConfig
 
@@ -45,8 +45,8 @@ class ComponentPlacement:
         self._config = config
         self._placement_config: DictConfig = config.cluster.component_placement
         self._cluster_num_gpus = cluster.num_accelerators_in_cluster
-        self._components: List[str] = []
-        self._component_gpu_map: Dict[str, List[int]] = {}
+        self._components: list[str] = []
+        self._component_gpu_map: dict[str, list[int]] = {}
 
         # Each line of component placement config looks like:
         # actor,inference: 0-4, which means both the actor and inference groups occupy GPU 0 to 4
@@ -61,12 +61,12 @@ class ComponentPlacement:
                 self._components.append(component)
                 self._component_gpu_map[component] = components_gpus
 
-            self._placements: Dict[str, PlacementStrategy] = {}
+            self._placements: dict[str, PlacementStrategy] = {}
             self._placement_mode: PlacementMode = None
 
     def _parse_gpu_ids(
-        self, components_gpus: str, component_names: List[str]
-    ) -> List[int]:
+        self, components_gpus: str, component_names: list[str]
+    ) -> list[int]:
         """Parse a string of GPU IDs into a list of integers.
 
         Args:
@@ -76,7 +76,7 @@ class ComponentPlacement:
         Returns:
             List[int]: A list of GPU IDs as integers.
         """
-        gpu_ids: List[int] = []
+        gpu_ids: list[int] = []
         if components_gpus == "all":
             gpu_ids = list(range(0, self._cluster_num_gpus))
         else:

--- a/rlinf/utils/profiler.py
+++ b/rlinf/utils/profiler.py
@@ -14,7 +14,7 @@
 
 
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Optional
 
 import torch
 from torch.profiler import (
@@ -48,7 +48,7 @@ class PyTorchProfiler:
     def __init__(
         self,
         output_dir: str = "./profiler_output",
-        activities: List[str] = ["cpu", "cuda"],
+        activities: list[str] = ["cpu", "cuda"],
         schedule_warmup: int = 1,
         schedule_active: int = 3,
         schedule_repeat: int = 2,
@@ -97,7 +97,7 @@ class PyTorchProfiler:
         self.schedule_warmup = schedule_warmup
         self.schedule_wait = 0
 
-    def _parse_activities(self, activity_strs: List[str]) -> List[ProfilerActivity]:
+    def _parse_activities(self, activity_strs: list[str]) -> list[ProfilerActivity]:
         valid_activities = set()
         activity_map = {"cpu": ProfilerActivity.CPU, "cuda": ProfilerActivity.CUDA}
         for act_str in activity_strs:
@@ -213,7 +213,7 @@ class PyTorchProfiler:
 
     @classmethod
     def from_config(
-        cls, profiler_config: Optional[Dict[str, Any]]
+        cls, profiler_config: Optional[dict[str, Any]]
     ) -> "PyTorchProfiler":
         required_params = {
             "output_dir",

--- a/rlinf/workers/actor/fsdp_actor_worker.py
+++ b/rlinf/workers/actor/fsdp_actor_worker.py
@@ -15,7 +15,6 @@
 import gc
 import os
 from contextlib import nullcontext
-from typing import Dict, Tuple
 
 import numpy as np
 import torch
@@ -173,7 +172,7 @@ class FSDPActor(FSDPModelManager, Worker):
 
     def get_batch(
         self, channel: Channel
-    ) -> Tuple[Dict[str, torch.Tensor], RolloutResult]:
+    ) -> tuple[dict[str, torch.Tensor], RolloutResult]:
         result: RolloutResult = channel.get()
 
         batch = result.to_actor_batch(
@@ -201,7 +200,7 @@ class FSDPActor(FSDPModelManager, Worker):
                 self.load_fsdp_optimizer(self.device)
 
     @torch.no_grad()
-    def inference_step(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
+    def inference_step(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
         self.model.eval()
         input_ids = batch["input_ids"]
         attention_mask = batch["attention_mask"]
@@ -291,7 +290,7 @@ class FSDPActor(FSDPModelManager, Worker):
             f"Expected {self.total_batch_size_per_dp} sequences from channel, but got {recv_batch_size}"
         )
 
-    def run_training(self, input_channel: Channel) -> Tuple[Dict, list]:
+    def run_training(self, input_channel: Channel) -> tuple[dict, list]:
         # Get all batches for this DP
         batches = []
         recv_batch_size = 0
@@ -510,7 +509,7 @@ class FSDPActor(FSDPModelManager, Worker):
         torch.distributed.barrier()
 
     # Advantages and returns
-    def compute_advantages_and_returns(self, batch: Dict[str, torch.Tensor]):
+    def compute_advantages_and_returns(self, batch: dict[str, torch.Tensor]):
         """Compute the advantages and returns.
 
         Args:

--- a/rlinf/workers/env/env_worker.py
+++ b/rlinf/workers/env/env_worker.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import numpy as np
 import torch
@@ -208,7 +208,7 @@ class EnvWorker(Worker):
 
     def env_interact_step(
         self, chunk_actions: torch.Tensor, stage_id: int
-    ) -> Tuple[EnvOutput, Dict[str, Any]]:
+    ) -> tuple[EnvOutput, dict[str, Any]]:
         """
         This function is used to interact with the environment.
         """
@@ -255,7 +255,7 @@ class EnvWorker(Worker):
 
     def env_evaluate_step(
         self, raw_actions: torch.Tensor, stage_id: int
-    ) -> Tuple[EnvOutput, Dict[str, Any]]:
+    ) -> tuple[EnvOutput, dict[str, Any]]:
         """
         This function is used to evaluate the environment.
         """

--- a/rlinf/workers/reward/reward_worker.py
+++ b/rlinf/workers/reward/reward_worker.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Tuple
 
 import torch
 from omegaconf import DictConfig
@@ -44,7 +43,7 @@ class RewardWorker(Worker):
 
     def get_batch(
         self, channel: Channel
-    ) -> Tuple[Dict[str, torch.Tensor], RolloutResult]:
+    ) -> tuple[dict[str, torch.Tensor], RolloutResult]:
         result: RolloutResult = channel.get()
         batch = result.to_actor_batch(
             self.cfg.data.max_prompt_length,
@@ -105,5 +104,5 @@ class RewardWorker(Worker):
             .flatten()
         )
 
-    def compute_batch_rewards_with_model(self, batch: Dict[str, torch.Tensor]):
+    def compute_batch_rewards_with_model(self, batch: dict[str, torch.Tensor]):
         raise NotImplementedError("Reward model is not implemented yet.")

--- a/rlinf/workers/rollout/server/online_router_worker.py
+++ b/rlinf/workers/rollout/server/online_router_worker.py
@@ -18,7 +18,7 @@ import json
 import random
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import uvicorn
 from fastapi import FastAPI
@@ -41,7 +41,7 @@ class CompleteRequest(BaseModel):
     top_p: Optional[float] = 0.9
     top_k: Optional[int] = 50
     repetition_penalty: Optional[float] = 1.0
-    stop: Optional[List[str]] = None
+    stop: Optional[list[str]] = None
     stream: Optional[bool] = False
 
 
@@ -49,7 +49,7 @@ class CompleteResponse(BaseModel):
     """Complete response model."""
 
     id: str
-    choices: List[Dict[str, Any]]
+    choices: list[dict[str, Any]]
     model: str
     created: int
     object: str = "text_completion"
@@ -74,17 +74,17 @@ class OnlineRouterWorker(Worker):
         # Sync weight state management
         self._sync_model_lock = asyncio.Lock()
         self._sync_model_in_progress = False
-        self._pending_requests: List[asyncio.Future] = []
+        self._pending_requests: list[asyncio.Future] = []
 
         # Request synchronization state
         self._sync_in_progress = False
         self._old_requests_complete = asyncio.Event()
         self._new_requests_blocked = asyncio.Event()
         self._new_requests_blocked.set()  # Initially allow new requests
-        self._blocked_requests: List[asyncio.Future] = []
+        self._blocked_requests: list[asyncio.Future] = []
 
         # Request tracking
-        self._active_requests: Dict[str, asyncio.Future] = {}
+        self._active_requests: dict[str, asyncio.Future] = {}
 
         # Setup FastAPI routes
         self._setup_routes()

--- a/rlinf/workers/rollout/server/server_rollout_worker.py
+++ b/rlinf/workers/rollout/server/server_rollout_worker.py
@@ -17,7 +17,7 @@ import json
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import torch
 import uvicorn
@@ -34,7 +34,7 @@ from rlinf.scheduler import Channel, Worker
 class TrainingDataStorage:
     """Storage manager for training data received via HTTP API."""
 
-    def __init__(self, storage_config: Optional[Dict[str, Any]] = None):
+    def __init__(self, storage_config: Optional[dict[str, Any]] = None):
         """
         Initialize storage manager.
 
@@ -61,7 +61,7 @@ class TrainingDataStorage:
         self._current_file_path = None
         self._entries_in_current_file = 0
 
-    def store_training_data(self, training_data: Dict[str, Any]) -> Optional[str]:
+    def store_training_data(self, training_data: dict[str, Any]) -> Optional[str]:
         """
         Store training data to file.
 
@@ -109,7 +109,7 @@ class TrainingDataStorage:
 
         return self._current_file_path
 
-    def _write_jsonl_entry(self, file_path: Path, entry: Dict[str, Any]):
+    def _write_jsonl_entry(self, file_path: Path, entry: dict[str, Any]):
         """Write entry to JSONL file (one JSON per line)."""
         # JSONL is more efficient for appending
         with open(file_path, "a", encoding="utf-8") as f:
@@ -118,7 +118,7 @@ class TrainingDataStorage:
 
         self._entries_in_current_file += 1
 
-    def get_storage_stats(self) -> Dict[str, Any]:
+    def get_storage_stats(self) -> dict[str, Any]:
         """Get storage statistics."""
         if not self.enabled:
             return {"enabled": False}
@@ -264,7 +264,7 @@ class ServerRolloutWorker(Worker):
         )
 
     def _convert_training_data_to_rollout_result(
-        self, training_data: Dict[str, Any]
+        self, training_data: dict[str, Any]
     ) -> RolloutResult:
         """Convert training data from HTTP request into RolloutResult format."""
         # Extract text data

--- a/rlinf/workers/rollout/sglang/sglang_worker.py
+++ b/rlinf/workers/rollout/sglang/sglang_worker.py
@@ -15,7 +15,7 @@
 import asyncio
 import copy
 import dataclasses
-from typing import Any, Dict, List
+from typing import Any
 
 from omegaconf import DictConfig
 from sglang.srt.managers.io_struct import ReleaseMemoryOccupationReqInput
@@ -93,7 +93,7 @@ class SGLangWorker(Worker):
         self.async_meta_stats_collector = MetaInfoStatsCollector(async_stats_file)
         self.async_batch_counter = 0
 
-    def _collect_stats(self, engine_results: List[Dict]):
+    def _collect_stats(self, engine_results: list[dict]):
         self.async_meta_stats_collector.collect_batch_stats(
             engine_results, self.async_batch_counter
         )
@@ -190,11 +190,11 @@ class SGLangWorker(Worker):
 
     async def async_generate(
         self,
-        prompt: List[str] | str | None = None,
-        sampling_params: List[Dict] | Dict | None = None,
-        input_ids: List[List[int]] | List[int] | None = None,
-        image_data: List | None = None,
-        return_logprob: List[bool] | bool | None = False,
+        prompt: list[str] | str | None = None,
+        sampling_params: list[dict] | dict | None = None,
+        input_ids: list[list[int]] | list[int] | None = None,
+        image_data: list | None = None,
+        return_logprob: list[bool] | bool | None = False,
         request_info: Any | None = None,
     ):
         """
@@ -287,13 +287,13 @@ class SGLangWorker(Worker):
             # Have aborted sequences (e.g., migrated from other engines)
             # Continue generation for the aborted group
             idx_aborted = seq_group_info.idx_aborted.copy()
-            seq_idx_list: List[int] = []
+            seq_idx_list: list[int] = []
             seq_group_info.idx_aborted.clear()
-            input_batch: List[List[int]] = []
-            sampling_params_list: List[Dict] = []
-            image_data_list: List = []
+            input_batch: list[list[int]] = []
+            sampling_params_list: list[dict] = []
+            image_data_list: list = []
             for idx in idx_aborted:
-                generated_ids: List[int] = seq_group_info.results[idx]["output_ids"]
+                generated_ids: list[int] = seq_group_info.results[idx]["output_ids"]
                 if len(generated_ids) >= self._sampling_params["max_new_tokens"]:
                     # avoid genererating for sequences that have already meet their max_new_tokens
                     self.log_warning(
@@ -364,7 +364,7 @@ class SGLangWorker(Worker):
             all_rollout_results = []
             while pending := self.status_manager.get_running_tasks():
                 done, pending = await asyncio.wait(pending, return_when=async_wait_type)
-                returned_seq_groups: List[SeqGroupInfo] = [
+                returned_seq_groups: list[SeqGroupInfo] = [
                     task.result() for task in done
                 ]
                 for group in returned_seq_groups:

--- a/rlinf/workers/rollout/utils.py
+++ b/rlinf/workers/rollout/utils.py
@@ -19,7 +19,6 @@ import time
 import typing
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
 
 from omegaconf import DictConfig
 
@@ -49,7 +48,7 @@ def sharp_cover(header_text: str, prelen: int = 30, color="\033[32m"):
         print("#" * prelen + f" {color}>>> {header_text}{COLOR_END} " + "#" * prelen)
 
 
-def print_vllm_outputs(outputs: List["RequestOutput"]):
+def print_vllm_outputs(outputs: list["RequestOutput"]):
     for output in outputs:
         prompt = output.prompt
         generated_text = output.outputs[0].text
@@ -62,13 +61,13 @@ def print_vllm_outputs(outputs: List["RequestOutput"]):
         )
 
 
-def print_multi_outputs(resps_all: List[List["RequestOutput"]]):
+def print_multi_outputs(resps_all: list[list["RequestOutput"]]):
     for i, resps in enumerate(resps_all):
         with sharp_cover(f"vllm dp {i}"):
             print_vllm_outputs(resps)
 
 
-def print_sglang_outputs(prompts, outputs: List[Dict], tokenizer):
+def print_sglang_outputs(prompts, outputs: list[dict], tokenizer):
     output_ids = [output["output_ids"] for output in outputs]
     output_texts = tokenizer.batch_decode(output_ids)
     for p, t, ids in zip(prompts, output_texts, output_ids):
@@ -80,7 +79,7 @@ def print_sglang_outputs(prompts, outputs: List[Dict], tokenizer):
         )
 
 
-def print_multi_sglang_outputs(prompts, outputs: List[List[Dict]], tokenizer):
+def print_multi_sglang_outputs(prompts, outputs: list[list[dict]], tokenizer):
     for i, resps in enumerate(outputs):
         with sharp_cover(f"sglang dp {i}"):
             print_sglang_outputs(prompts, resps, tokenizer)
@@ -91,7 +90,7 @@ class RankMapper:
     def get_actor_rank_to_rollout_rank_map(
         cls,
         placement: ModelParallelComponentPlacement,
-    ) -> Dict[int, List[Tuple[int, int]]]:
+    ) -> dict[int, list[tuple[int, int]]]:
         return cls._get_rank_mapper(
             placement.placement_mode
         ).get_actor_rank_to_rollout_rank_map(
@@ -105,7 +104,7 @@ class RankMapper:
     @classmethod
     def get_rollout_rank_to_actor_rank_map(
         cls, placement: ModelParallelComponentPlacement
-    ) -> Dict[Tuple[int, int], int]:
+    ) -> dict[tuple[int, int], int]:
         return cls._get_rank_mapper(
             placement.placement_mode
         ).get_rollout_rank_to_actor_rank_map(
@@ -140,7 +139,7 @@ class CollocateRankMapper(RankMapper):
         actor_world_size: int,
         rollout_tp_size: int,
         rollout_world_size: int,
-    ) -> Dict[int, Tuple[int, int]]:
+    ) -> dict[int, tuple[int, int]]:
         """
         Get the global mapping from actor 1D rank to rollout 2D rank as dict.
         """
@@ -226,7 +225,7 @@ class DisaggRankMapper(RankMapper):
         actor_world_size: int,
         rollout_tp_size: int,
         rollout_world_size: int,
-    ) -> Dict[int, List[Tuple[int, int]]]:
+    ) -> dict[int, list[tuple[int, int]]]:
         """
         Only ranks in dp=0 actor dp group will send weights to rollout LLM.
         """
@@ -269,7 +268,7 @@ class DisaggRankMapper(RankMapper):
         actor_world_size: int,
         rollout_tp_size: int,
         rollout_world_size: int,
-    ) -> Dict[Tuple[int, int], int]:
+    ) -> dict[tuple[int, int], int]:
         rank_map = cls.get_actor_rank_to_rollout_rank_map(
             actor_tp_size,
             actor_pp_size,
@@ -288,7 +287,7 @@ class DisaggRankMapper(RankMapper):
         actor_rank: int,
         actor_tp_size: int,
         rollout_tp_size: int,
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         assert actor_tp_size % rollout_tp_size == 0, (
             "actor_tp_size must be a multiple of rollout_tp_size"
         )
@@ -339,11 +338,11 @@ def get_rollout_backend_worker(
 
 class RunningStatusManager:
     def __init__(self):
-        self._running_seq_group: Dict[SeqGroupInfo, asyncio.Task] = {}
-        self._aborted_seq_group: List[SeqGroupInfo] = []
+        self._running_seq_group: dict[SeqGroupInfo, asyncio.Task] = {}
+        self._aborted_seq_group: list[SeqGroupInfo] = []
         # SeqGroupInfo that have been completed and sent to actor/inference
         # only retained for debugging
-        self._done_seq_group: List[SeqGroupInfo] = []
+        self._done_seq_group: list[SeqGroupInfo] = []
 
         # asyncio Events
         # set by scheduler coroutine to prevent rollout coroutine from exiting before potential migrations
@@ -486,7 +485,7 @@ class MetaInfoStatsCollector:
             with open(self.output_file, "w") as f:
                 f.write("")  # Create empty file
 
-    def collect_batch_stats(self, outputs: List[Dict], batch_id: int) -> None:
+    def collect_batch_stats(self, outputs: list[dict], batch_id: int) -> None:
         """Collect statistics from a batch of SGLang outputs
 
         Args:

--- a/rlinf/workers/rollout/vllm/vllm_worker.py
+++ b/rlinf/workers/rollout/vllm/vllm_worker.py
@@ -16,7 +16,7 @@ import asyncio
 import io
 import os
 from functools import partial
-from typing import AsyncGenerator, List, Optional, Union
+from typing import AsyncGenerator, Optional, Union
 
 import requests
 from omegaconf import DictConfig
@@ -108,8 +108,8 @@ class VLLMWorker(Worker):
         return sampling_params
 
     def _process_image_data(
-        self, image_data: Optional[List[Union[bytes, str]]]
-    ) -> Optional[List[Image]]:
+        self, image_data: Optional[list[Union[bytes, str]]]
+    ) -> Optional[list[Image]]:
         """
         Process the batch image data which can be bytes or image paths.
 
@@ -186,13 +186,13 @@ class VLLMWorker(Worker):
 
     async def generate(
         self,
-        input_ids: Union[List[List[int]], List[int]],
+        input_ids: Union[list[list[int]], list[int]],
         sampling_params: SamplingParams,
-        prompt_texts: Optional[Union[List[str], str]] = None,
+        prompt_texts: Optional[Union[list[str], str]] = None,
         image_data: Optional[
-            Union[List[List[Union[bytes, str]]], List[Union[bytes, str]]]
+            Union[list[list[Union[bytes, str]]], list[Union[bytes, str]]]
         ] = None,
-    ) -> List[RequestOutput]:
+    ) -> list[RequestOutput]:
         """
         Do Generate Task using the vllm async engine.
 
@@ -210,7 +210,7 @@ class VLLMWorker(Worker):
             List[RequestOutput]: A list of RequestOutput from vllm engine.
         """
 
-        def check_input_ids() -> List[List[int]]:
+        def check_input_ids() -> list[list[int]]:
             assert isinstance(input_ids, list), (
                 "input_ids should be a list or list of list of int."
             )
@@ -220,7 +220,7 @@ class VLLMWorker(Worker):
             else:
                 return input_ids
 
-        def check_prompt_text() -> Optional[List[str]]:
+        def check_prompt_text() -> Optional[list[str]]:
             if prompt_texts is None:
                 return None
             assert isinstance(prompt_texts, list) or isinstance(prompt_texts, str), (
@@ -232,7 +232,7 @@ class VLLMWorker(Worker):
                 assert len(prompt_texts) > 0, "prompt_text should not be empty."
                 return prompt_texts
 
-        def check_image_data() -> Optional[List[List[Image.Image]]]:
+        def check_image_data() -> Optional[list[list[Image.Image]]]:
             if image_data is None or not any(image_data):
                 return None
             assert isinstance(image_data, list), "image_data should be a list."
@@ -245,8 +245,8 @@ class VLLMWorker(Worker):
         prompt_texts = check_prompt_text()
         image_list = check_image_data()
 
-        inputs: List[PromptType] = []
-        outputs: List[RequestOutput] = []
+        inputs: list[PromptType] = []
+        outputs: list[RequestOutput] = []
         if prompt_texts is not None:
             for i, prompt_text in enumerate(prompt_texts):
                 if image_list is not None:
@@ -375,7 +375,7 @@ class VLLMWorker(Worker):
             seq_info: The SeqGroupInfo to process.
             output_channel: The output channel to send results to.
         """
-        vllm_results: List[RequestOutput] = await self.generate(
+        vllm_results: list[RequestOutput] = await self.generate(
             input_ids=seq_info.input_ids,
             image_data=seq_info.image_data,
             sampling_params=self._sampling_params,

--- a/toolkits/auto_placement/resource_allocator.py
+++ b/toolkits/auto_placement/resource_allocator.py
@@ -15,7 +15,6 @@
 import bisect
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Dict, List
 
 
 @dataclass
@@ -31,7 +30,7 @@ class ComponentParallelState:
         )
         self.valid_dp_sizes = []
 
-    def set_valid_dp_sizes(self, valid_dp_sizes: List[int]):
+    def set_valid_dp_sizes(self, valid_dp_sizes: list[int]):
         self.valid_dp_sizes = valid_dp_sizes
 
     def allocation(self, available_gpus: int) -> int:
@@ -75,7 +74,7 @@ class ComponentParallelState:
         self.data_parallel_size += incremental_dp_size
         return idle_gpus
 
-    def to_dict(self) -> Dict[str, int]:
+    def to_dict(self) -> dict[str, int]:
         return {
             "world_size": self.world_size,
             "tensor_model_parallel_size": self.tensor_model_parallel_size,
@@ -98,7 +97,7 @@ class ComponentParallelState:
 
 
 class AllocationStates:
-    def __init__(self, components_config: Dict[str, Dict[str, int]]):
+    def __init__(self, components_config: dict[str, dict[str, int]]):
         self.states = {}
         for component_name, component_config in components_config.items():
             self.states[component_name] = ComponentParallelState(
@@ -132,10 +131,10 @@ class ResourcePlanner:
 
     def __init__(
         self,
-        components_config: Dict[str, Dict[str, int]],
+        components_config: dict[str, dict[str, int]],
         total_gpus: int,
-        valid_actor_dp_sizes: List[int],
-        valid_inference_dp_sizes: List[int],
+        valid_actor_dp_sizes: list[int],
+        valid_inference_dp_sizes: list[int],
     ):
         self.components_config = components_config
         self.initial_allocation = AllocationStates(components_config)
@@ -154,15 +153,15 @@ class ResourcePlanner:
             self.valid_components.append(component)
         assert len(self.valid_components) in [1, 2, 3]
 
-    def generate_all_states(self) -> List[AllocationStates]:
+    def generate_all_states(self) -> list[AllocationStates]:
         """Generate all possible resource allocation states during training progression."""
 
         self.all_states = []
 
         def trace_recursive(
             current_allocation: AllocationStates,
-            components: List[str],
-        ) -> List[AllocationStates]:
+            components: list[str],
+        ) -> list[AllocationStates]:
             if not components:
                 self.all_states.append(current_allocation)
                 return
@@ -181,7 +180,7 @@ class ResourcePlanner:
         self,
         init_allocation: AllocationStates,
         component: str,
-    ) -> List[AllocationStates]:
+    ) -> list[AllocationStates]:
         avaliable_gpus = self.total_gpus - init_allocation.used_gpus()
         if (
             avaliable_gpus
@@ -209,7 +208,7 @@ class ResourcePlanner:
 
         return states
 
-    def generate_static_states(self) -> List[AllocationStates]:
+    def generate_static_states(self) -> list[AllocationStates]:
         if not hasattr(self, "all_states"):
             self.generate_all_states()
 
@@ -229,11 +228,11 @@ class ResourcePlanner:
 
 def get_valid_dp_sizes(
     total_gpus: int,
-    parallel_config: Dict[str, int],
+    parallel_config: dict[str, int],
     group_size: int,
     rollout_batch_size: int,
     n_minibatches: int,
-) -> List[int]:
+) -> list[int]:
     """This function is used to get the valid data parallel sizes for the Actor and Inference based on the constraints of batch and group size.
 
     Args:
@@ -267,13 +266,13 @@ def get_valid_dp_sizes(
 
 
 def resource_allocate(
-    components_config: Dict[str, Dict[str, int]],
+    components_config: dict[str, dict[str, int]],
     total_gpus: int,
     group_size: int,
     rollout_batch_size: int,
     n_minibatches: int,
     inference_instance_max_num: int = 2,
-) -> List[AllocationStates]:
+) -> list[AllocationStates]:
     """Based on the configuration, derive all possible GPU resource allocations for the components.
 
     Args:
@@ -298,11 +297,11 @@ def resource_allocate(
         )
 
     # Generate valid DP sizes for Inference and Actor
-    valid_inference_dp_sizes: List[int] = []
-    valid_actor_dp_sizes: List[int] = []
+    valid_inference_dp_sizes: list[int] = []
+    valid_actor_dp_sizes: list[int] = []
 
     if components_config.get("actor", None) is not None:
-        valid_actor_dp_sizes: List[int] = get_valid_dp_sizes(
+        valid_actor_dp_sizes: list[int] = get_valid_dp_sizes(
             total_gpus,
             components_config["actor"],
             group_size,
@@ -310,7 +309,7 @@ def resource_allocate(
             n_minibatches,
         )
     if components_config.get("inference", None) is not None:
-        valid_inference_dp_sizes: List[int] = get_valid_dp_sizes(
+        valid_inference_dp_sizes: list[int] = get_valid_dp_sizes(
             total_gpus,
             components_config["inference"],
             group_size,

--- a/toolkits/auto_placement/scheduler_task.py
+++ b/toolkits/auto_placement/scheduler_task.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional
+from typing import Optional
 
 import hydra
 from omegaconf.omegaconf import OmegaConf
@@ -28,7 +28,7 @@ class SchedulerTask:
         self,
         cfg,
         cluster,
-        workflow_graph: Optional[Dict[ComponentNode, List[ComponentNode]]] = None,
+        workflow_graph: Optional[dict[ComponentNode, list[ComponentNode]]] = None,
     ):
         self.cfg = cfg
         self.is_reasoning = cfg.runner.task_type == "reasoning"
@@ -98,7 +98,7 @@ class SchedulerTask:
         self.workflow = Workflow(workflow_graph)
         self.profile_data_registed = False
 
-    def register_profile_data(self, profile_data: Dict[str, float]):
+    def register_profile_data(self, profile_data: dict[str, float]):
         for component_node in self.workflow.nodes:
             component_node_name = component_node.name
             instance_num, signle_iter_cost = profile_data[component_node_name]
@@ -114,7 +114,7 @@ class SchedulerTask:
 
     def run(self) -> str:
         assert self.profile_data_registed, "Profile data not registered"
-        partitions: List[Dict[str, Workflow]] = self.time_division_multiplexing()
+        partitions: list[dict[str, Workflow]] = self.time_division_multiplexing()
 
         min_partition_cost = float("inf")
         min_partition_allocations = None
@@ -139,7 +139,7 @@ class SchedulerTask:
         return best_placement
 
     def parse_partition_allocation_to_cfg(
-        self, partition_allocation: Dict[Workflow, AllocationStates]
+        self, partition_allocation: dict[Workflow, AllocationStates]
     ) -> str:
         new_cfg = OmegaConf.create()
         new_cfg.cluster = {}
@@ -179,8 +179,8 @@ class SchedulerTask:
 
         raise NotImplementedError("hybrid mode is not supported")
 
-    def time_division_multiplexing(self) -> List[Dict[str, Workflow]]:
-        partitions: List[Dict[str, Workflow]] = get_workflow_partition(self.workflow)
+    def time_division_multiplexing(self) -> list[dict[str, Workflow]]:
+        partitions: list[dict[str, Workflow]] = get_workflow_partition(self.workflow)
         if self.is_reasoning:
             valid_partitions = [
                 i for i in partitions if len(i) in [1, len(self.components_config)]
@@ -208,7 +208,7 @@ class SchedulerTask:
         else:
             inference_instance_max_num = 2
 
-        allocations: List[AllocationStates] = resource_allocate(
+        allocations: list[AllocationStates] = resource_allocate(
             sub_components_config,
             self.total_gpus,
             self.group_size,

--- a/toolkits/auto_placement/workflow.py
+++ b/toolkits/auto_placement/workflow.py
@@ -15,7 +15,6 @@
 import itertools
 import math
 from collections import defaultdict, deque
-from typing import Dict, List
 
 
 class Node:
@@ -47,7 +46,7 @@ class ComponentNode(Node):
 class SccComponentNode(Node):
     """The SccComponentNode denotes a strongly connected component (SCC) and is comprised of multiple constituent ComponentNodes."""
 
-    def __init__(self, Components: List[ComponentNode]):
+    def __init__(self, Components: list[ComponentNode]):
         super().__init__(" - ".join([component.name for component in Components]))
         self.components = Components
 
@@ -56,7 +55,7 @@ class SccComponentNode(Node):
 
 
 class Workflow:
-    def __init__(self, workflow: Dict[Node, List[Node]]):
+    def __init__(self, workflow: dict[Node, list[Node]]):
         self.nodes = list(set(workflow.keys()))
         for neighbors in workflow.values():
             for neighbor in neighbors:
@@ -69,7 +68,7 @@ class Workflow:
 
         self.topological_order = None
 
-    def find_sccs(self) -> List[List[Node]]:
+    def find_sccs(self) -> list[list[Node]]:
         """Find strongly connected components (SCCs) using Tarjan's algorithm."""
 
         def tarjan_dfs(node, disc, low, stack, in_stack, time):
@@ -160,7 +159,7 @@ class Workflow:
 
         return Workflow(compressed_workflow)
 
-    def topological_sort(self) -> List[Node]:
+    def topological_sort(self) -> list[Node]:
         """Perform topological sort on the workflow(graph)"""
         if self.topological_order is not None:
             return self.topological_order
@@ -189,7 +188,7 @@ class WorkflowPartitioner:
     def __init__(self, workflow: Workflow):
         self.workflow = workflow.compress_sccs()
 
-    def partition(self) -> List[Dict[str, Workflow]]:
+    def partition(self) -> list[dict[str, Workflow]]:
         """Enumerate possible partitioning ways
 
         Returns:
@@ -198,7 +197,7 @@ class WorkflowPartitioner:
         if self.workflow.topological_order is None:
             self.workflow.topological_sort()
 
-        partitions: List[Dict[str, Workflow]] = []
+        partitions: list[dict[str, Workflow]] = []
 
         # Try different numbers of partitions
         for num_partitions in range(1, len(self.workflow.sccs) + 1):
@@ -251,7 +250,7 @@ class WorkflowPartitioner:
 
         return partitions
 
-    def _extract_nodes_from_compressed_workflow(self) -> List[Node]:
+    def _extract_nodes_from_compressed_workflow(self) -> list[Node]:
         """Extract all original nodes from the compressed workflow"""
         nodes = []
         for compressed_node in self.workflow.topological_order:
@@ -261,7 +260,7 @@ class WorkflowPartitioner:
                 nodes.append(compressed_node)
         return nodes
 
-    def _create_subgraph_workflow(self, nodes: List[Node]) -> Workflow:
+    def _create_subgraph_workflow(self, nodes: list[Node]) -> Workflow:
         """
         Create subgraph Workflow from node list
 
@@ -402,6 +401,6 @@ def get_workflow_cost(
     ]
 
 
-def get_workflow_partition(workflow: Workflow) -> List[Dict[str, Workflow]]:
+def get_workflow_partition(workflow: Workflow) -> list[dict[str, Workflow]]:
     """Get workflow partitions"""
     return WorkflowPartitioner(workflow).partition()

--- a/toolkits/ckpt_convertor/config.py
+++ b/toolkits/ckpt_convertor/config.py
@@ -15,7 +15,7 @@
 
 import os
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 import torch
 import yaml
@@ -57,11 +57,11 @@ class ConvertorConfig:
     ep_size: int = 1
     pp_size: int = 1
     schedular: str = "1f1b"
-    pp_stages: Optional[List[int]] = None
+    pp_stages: Optional[list[int]] = None
 
     # from runtime parameters
     use_gpu_num: int = 0
-    use_gpu_index: Optional[List[int]] = None
+    use_gpu_index: Optional[list[int]] = None
 
     # precision
     linear_trans: str = "auto"

--- a/toolkits/ckpt_convertor/convert_middle_file_to_mg.py
+++ b/toolkits/ckpt_convertor/convert_middle_file_to_mg.py
@@ -22,7 +22,6 @@ import gc
 import os
 import shutil
 from collections import OrderedDict
-from typing import List, Tuple
 
 import torch
 
@@ -54,7 +53,7 @@ def get_megatron_iteration(convert_config: ConvertorConfig) -> int:
 
 def get_hetero_pp_rank(
     convert_config: ConvertorConfig, num_layers: int, layer_idx: int
-) -> Tuple[int, int, int]:
+) -> tuple[int, int, int]:
     if convert_config.schedular == "1f1b":
         if convert_config.pp_stages is not None:
             pp_stages = convert_config.pp_stages
@@ -259,9 +258,9 @@ def merge_checkpoint_dict(full_checkpoints, to_cpu=False):
 
 def convert_layer_load(
     convert_config: ConvertorConfig,
-    layer_info: Tuple[str, int, int, int],
+    layer_info: tuple[str, int, int, int],
     pp_rank: int,
-    full_checkpoint: List,
+    full_checkpoint: list,
 ):
     pp_saver = CKPTSaver(pp_rank, full_checkpoint)
     model_key_vpp, layer, local_layer, local_num_layer = layer_info

--- a/toolkits/ckpt_convertor/utils/fp8_utils.py
+++ b/toolkits/ckpt_convertor/utils/fp8_utils.py
@@ -14,7 +14,7 @@
 
 # use a fp8Tensor class to package fp8 operations
 
-from typing import List, Literal, Tuple, Union
+from typing import Literal, Union
 
 import torch
 
@@ -26,7 +26,7 @@ def ceil_div(x: int, y: int) -> int:
 inductor_optimizer = torch._dynamo.optimize("inductor")
 
 
-def per_block_cast_to_fp8_cpu(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+def per_block_cast_to_fp8_cpu(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     assert x.dim() == 2
     m, n = x.shape
     x_padded = torch.zeros(
@@ -66,7 +66,7 @@ per_block_cast_to_bf16_gpu = inductor_optimizer(per_block_cast_to_bf16_cpu)
 
 def per_block_cast_to_fp8(
     x: torch.Tensor, device: torch.device = None
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     if device is None:
         device = x.device
     if torch.device(device).type == "cpu":
@@ -101,7 +101,7 @@ class fp8Tensor:
 
     @staticmethod
     def group(
-        tensors: List["fp8Tensor"], fc1orfc2: Literal["fc1", "fc2"]
+        tensors: list["fp8Tensor"], fc1orfc2: Literal["fc1", "fc2"]
     ) -> "fp8Tensor":
         # TODO:
         raise NotImplementedError()

--- a/toolkits/code_verifier/verify.py
+++ b/toolkits/code_verifier/verify.py
@@ -15,7 +15,7 @@
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Dict, Final, List, Optional
+from typing import Any, Final, Optional
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -25,10 +25,10 @@ DEFAULT_REWARD: Final[float] = 0.4
 
 
 def fim_llm_as_judge_verify_call(
-    responses: List[str],
-    references: List[str],
-    prompts: List[str],
-) -> List:
+    responses: list[str],
+    references: list[str],
+    prompts: list[str],
+) -> list:
     assert len(responses) == len(references) == len(prompts), (
         len(responses),
         len(references),
@@ -37,7 +37,7 @@ def fim_llm_as_judge_verify_call(
 
     # Deduplicate keys
     unique_keys = []
-    key_to_indices: Dict[str, List[int]] = {}
+    key_to_indices: dict[str, list[int]] = {}
     for i, (rp, rs, rf) in enumerate(zip(prompts, responses, references)):
         key = json.dumps([rp, rs, rf], ensure_ascii=False, sort_keys=True)
         unique_keys.append(key)
@@ -51,8 +51,8 @@ def fim_llm_as_judge_verify_call(
             rp, rs, rf = prompts[0], responses[0], references[0]
         unique_requests.append((rp, rs, rf))
 
-    results: List[Optional[Dict[str, Any]]] = [None] * len(responses)
-    rewards: List[float] = []
+    results: list[Optional[dict[str, Any]]] = [None] * len(responses)
+    rewards: list[float] = []
     success_cnt = 0
     fail_cnt = 0
 
@@ -157,7 +157,7 @@ def send_reward_request(
     reference: str,
     session: Optional[requests.Session] = None,
     timeout: int = 60,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     url = os.getenv(
         "LLMASJUDGE_API_URL", "https://cloud.infini-ai.com/maas/v1/chat/completions"
     )
@@ -224,7 +224,7 @@ def send_reward_request(
         }
 
 
-def process_single_request(args: tuple) -> Dict[str, Any]:
+def process_single_request(args: tuple) -> dict[str, Any]:
     raw_prompt, response, reference = args
     reward_response = send_reward_request(raw_prompt, response, reference)
     return reward_response

--- a/toolkits/math_verifier/verify.py
+++ b/toolkits/math_verifier/verify.py
@@ -18,7 +18,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from concurrent.futures import (
     TimeoutError as FuturesTimeoutError,
 )
-from typing import List, Union
+from typing import Union
 
 import regex
 from latex2sympy2 import latex2sympy
@@ -385,11 +385,11 @@ def verify_math_solution(answer: str, solution: str):
 
 
 def math_verify_call(
-    responses: List[str],
-    references: List[List[str]],
+    responses: list[str],
+    references: list[list[str]],
     timeout: int = 10,
     check_xml_format=False,
-) -> List[bool]:
+) -> list[bool]:
     assert len(responses) == len(references), (
         len(responses),
         len(references),
@@ -403,7 +403,7 @@ def math_verify_call(
             jobs.append(job)
         all_jobs.append(jobs)
 
-    is_correct_list: List[bool] = []
+    is_correct_list: list[bool] = []
     has_timeout = False
     for jobs in all_jobs:
         is_correct = False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Since current python environments are all 3.10.x and higher(3.11.x), it might be better to use builtin annotations(`list`,`tuple`,`dict`) to replace former `typing`'s annotations(`List`,`Tuple`,`Dict`) which will be depreciated in future python versions. I turn on the ruff check of `UP006` as @andylin-hao  recommended before.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.