### PR TITLE
docs: add explanations and solutions for value_head related problem encountered during rollout

### DIFF
--- a/docs/source-zh/rst_source/start/vla-eval.rst
+++ b/docs/source-zh/rst_source/start/vla-eval.rst
@@ -140,6 +140,37 @@ RLinf 提供了 **即开即用的评估脚本**，用于在 *训练分布内* �
 ``num_envs``                并行评估环境数量（例如 500）
 ==========================  =============================================
 
+**可能遇到的问题**
+
+在最新的RLinf代码中进行训练并rollout不会出现报错，但是如果使用早期RLinf训练得到的中间模型（GRPO算法）并在新版本RLinf框架代码中运行，可能会遇到调用的模型包含多余keys（以 ``value_head.`` 开头的keys）的情况，例如：
+
+.. code-block:: console
+
+   RuntimeError: Error(s) in loading state_dict for OpenVLAOFTForRLActionPrediction:
+	Unexpected key(s) in state_dict: "value_head.head_l1.weight", "value_head.head_l1.bias", "value_head.head_l2.weight", "value_head.head_l2.bias", "value_head.head_l3.weight".
+
+此时，可以修改： ``rlinf/models/__init__.py`` 文件最末端的代码（ ``get_model`` 函数里）。将：
+
+.. code-block:: python
+
+   if hasattr(cfg, "ckpt_path") and cfg.ckpt_path is not None:
+        model_dict = torch.load(cfg.ckpt_path)
+        model.load_state_dict(model_dict)
+    return model
+
+修改为：
+
+.. code-block:: python
+
+   if hasattr(cfg, "ckpt_path") and cfg.ckpt_path is not None:
+        model_dict = torch.load(cfg.ckpt_path)
+        filtered_dict = {k: v for k, v in model_dict.items() if not k.startswith('value_head')}
+        model.load_state_dict(filtered_dict, strict=False)
+    return model
+
+修改后可以正常运行命令。
+
+
 评估结果
 --------
 


### PR DESCRIPTION
add explanations and solutions for potential problems (value_head related) encountered during evaluation (rollout) of embodied agents scenario

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

I added explanations and solutions for potential problems (value_head related) encountered during evaluation (rollout) of embodied agents scenario to docs (both [zh](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/start/vla-eval.html#id4) and [en](https://rlinf.readthedocs.io/en/latest/rst_source/start/vla-eval.html#quick-start-libero)).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the latest RLinf code, training and rollout will not cause errors, but if users use intermediate models trained with early RLinf code (GRPO algorithm) and run it in the new version RLinf framework code, they may encounter an error where the loaded model contains extra keys (keys starting with ``value_head.`` ), for example:

```
RuntimeError: Error(s) in loading state_dict for OpenVLAOFTForRLActionPrediction:
	Unexpected key(s) in state_dict: "value_head.head_l1.weight", "value_head.head_l1.bias", "value_head.head_l2.weight", "value_head.head_l2.bias", "value_head.head_l3.weight".
```

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I followed the step of `docs\README.md` to build the doc and ran the pre-commit successfully.

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.