### PR TITLE
fix(ckpt_convertor): fix wrong attr setting in ckpt_convertor

### DIFF
--- a/toolkits/ckpt_convertor/config.py
+++ b/toolkits/ckpt_convertor/config.py
@@ -209,12 +209,13 @@ def load_convertor_config(hf_ckpt_path: str, ckpt_cfg: DictConfig) -> ConvertorC
         convertor_config.num_layers is not None and convertor_config.num_layers > 0
     ), "num_layers must be specified and greater than 0."
 
-    convertor_config.te_ln_linear_qkv = getattr(ckpt_cfg, "te_ln_linear_qkv", True)
-    convertor_config.te_ln_linear_mlp_fc1 = getattr(
-        ckpt_cfg, "te_ln_linear_mlp_fc1", True
-    )
-    convertor_config.te_ln_add_extra_state = getattr(
-        ckpt_cfg, "te_ln_add_extra_state", None
-    )
+    if hasattr(ckpt_cfg, "te_ln_linear_qkv"):
+        convertor_config.te_ln_linear_qkv = ckpt_cfg.te_ln_linear_qkv
+
+    if hasattr(ckpt_cfg, "te_ln_linear_mlp_fc1"):
+        convertor_config.te_ln_linear_mlp_fc1 = ckpt_cfg.te_ln_linear_mlp_fc1
+
+    if hasattr(ckpt_cfg, "te_ln_add_extra_state"):
+        convertor_config.te_ln_add_extra_state = ckpt_cfg.te_ln_add_extra_state
 
     return convertor_config

--- a/toolkits/ckpt_convertor/default_args.yaml
+++ b/toolkits/ckpt_convertor/default_args.yaml
@@ -20,9 +20,6 @@ explict_model:
     num_attention_heads: 12
     num_query_groups: 2
     head_dim: 128
-    te_ln_linear_qkv: True
-    te_ln_linear_mlp_fc1: True
-    te_ln_add_extra_state: True
   qwen_2.5_32b:
     model_type: qwen_2
     num_attention_heads: 40


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Former ckpt_convertor will use yaml's ckpt config in prior, and set a wrong default value when they are not in yaml's ckpt config. This PR use default ckpt_convertor config in prior and will be reset with ckpt config's value when the yaml's ckpt config has corresponding attr.

### How has this been tested?
Tested in single machine.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.