### PR TITLE
fix: fix sglang won't offload when using agent rl in collocated mode, it may cause oom

### DIFF
--- a/rlinf/runners/agent_runner.py
+++ b/rlinf/runners/agent_runner.py
@@ -176,6 +176,9 @@ class AgentRunner(ReasoningRunner):
                             input_channel=inference_channel,
                         )
 
+                        if not self.is_pipeline:
+                            rollout_handle.wait()
+                            self.rollout.offload_engine().wait()
                         metrics = actor_handle.wait()
                         actor_rollout_metrics = metrics[0][0]
                         actor_training_metrics = metrics[0][1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

In collocated mode, sglang should offload when rollout is done, to ensure actor has enough gpu memory.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.