### PR TITLE
feat(fsdp): add tensor parallel for FSDP trainer

### DIFF
--- a/rlinf/hybrid_engines/fsdp/strategy/parallel.py
+++ b/rlinf/hybrid_engines/fsdp/strategy/parallel.py
@@ -1,0 +1,116 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import TypeVar
+
+import torch.nn as nn
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import Replicate
+from torch.distributed.tensor.parallel import (
+    ColwiseParallel,
+    ParallelStyle,
+    RowwiseParallel,
+    parallelize_module,
+)
+
+T = TypeVar("T", bound="TensorParallelizerBase")
+
+
+class TensorParallelizerBase(ABC):
+    _registry: dict[str, type["TensorParallelizerBase"]] = {}
+    _by_model_type: dict[str, str] = {}
+
+    @abstractmethod
+    def _create_parallel_plan(
+        self,
+        hf_model: nn.Module,
+    ) -> dict[str, ParallelStyle]: ...
+
+    def parallelize(
+        self,
+        hf_model: nn.Module,
+        tp_mesh: DeviceMesh,
+    ) -> nn.Module:
+        parallel_plan = self._create_parallel_plan(hf_model)
+        return parallelize_module(hf_model, tp_mesh, parallel_plan)
+
+    @classmethod
+    def register(cls, key: str, *, model_type: str | None = None):
+        """
+        @TensorParallelizerBase.register("deepseek_qwen_1_5b", model_type="qwen2")
+        class DeepSeekQwenParallelizer(TensorParallelizerBase):
+            ...
+        """
+
+        def decorator(par_cls: type[T]) -> type[T]:
+            if key in cls._registry:
+                raise ValueError(f"Parallelizer key {key!r} already registered")
+            cls._registry[key] = par_cls
+            if model_type is not None:
+                cls._by_model_type[model_type] = key
+            return par_cls
+
+        return decorator
+
+    @classmethod
+    def create(cls, key: str, **kwargs) -> "TensorParallelizerBase":
+        try:
+            par_cls = cls._registry[key]
+        except KeyError:
+            raise KeyError(f"No parallelizer registered under key {key!r}")
+        return par_cls(**kwargs)
+
+    @classmethod
+    def create_for_model(
+        cls,
+        hf_model: nn.Module,
+        **kwargs,
+    ) -> "TensorParallelizerBase":
+        config = getattr(hf_model, "config", None)
+        model_type = getattr(config, "model_type", None)
+        if model_type is None:
+            raise ValueError("hf_model.config.model_type not found")
+
+        try:
+            key = cls._by_model_type[model_type]
+        except KeyError:
+            raise KeyError(f"No parallelizer registered for model_type {model_type!r}")
+        return cls.create(key, **kwargs)
+
+
+@TensorParallelizerBase.register("qwen2.5")
+class QwenTensorParallelizer(TensorParallelizerBase):
+    """
+    Tensor parallelizer for Qwen2 models.
+    """
+
+    @classmethod
+    def _create_parallel_plan(cls, hf_model: nn.Module) -> dict[str, ParallelStyle]:
+        parallel_plan = {}
+        parallel_plan["model.embed_tokens"] = RowwiseParallel(input_layouts=Replicate())
+        parallel_plan["lm_head"] = ColwiseParallel()
+
+        for layer_id, _layer in enumerate(hf_model.model.layers):
+            p = f"model.layers.{layer_id}"
+            parallel_plan[f"{p}.self_attn.q_proj"] = ColwiseParallel()
+            parallel_plan[f"{p}.self_attn.k_proj"] = ColwiseParallel()
+            parallel_plan[f"{p}.self_attn.v_proj"] = ColwiseParallel()
+            parallel_plan[f"{p}.self_attn.o_proj"] = RowwiseParallel()
+
+            parallel_plan[f"{p}.mlp.gate_proj"] = ColwiseParallel()
+            parallel_plan[f"{p}.mlp.up_proj"] = ColwiseParallel()
+            parallel_plan[f"{p}.mlp.down_proj"] = RowwiseParallel()
+
+        return parallel_plan

--- a/rlinf/hybrid_engines/fsdp/utils.py
+++ b/rlinf/hybrid_engines/fsdp/utils.py
@@ -56,15 +56,15 @@ class FSDPVersion(str, Enum):
 
 
 def create_device_mesh(world_size, fsdp_size):
-    if fsdp_size < 0 or fsdp_size >= world_size:
+    if fsdp_size < 0 or fsdp_size > world_size:
         device_mesh = init_device_mesh(
-            "cuda", mesh_shape=(world_size,), mesh_dim_names=["fsdp"]
+            "cuda", mesh_shape=(world_size,), mesh_dim_names=["dp"]
         )
     else:
         device_mesh = init_device_mesh(
             "cuda",
             mesh_shape=(world_size // fsdp_size, fsdp_size),
-            mesh_dim_names=["ddp", "fsdp"],
+            mesh_dim_names=["dp", "tp"],
         )
     return device_mesh
 

--- a/rlinf/workers/actor/fsdp_actor_worker.py
+++ b/rlinf/workers/actor/fsdp_actor_worker.py
@@ -686,10 +686,6 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
 
         return rollout_batch
 
-    def compute_logprobs(self):
-        self.model.eval()
-        self.rollout_batch["logprob"] = self.rollout_batch["prev_logprobs"]
-
     def compute_advantages_and_returns(self):
         stage_num = self.cfg.rollout.pipeline_stage_num
         env_world_size = self._component_placement.get_world_size("env")


### PR DESCRIPTION

### Description
Currently for math reasoning, FSDP can not train models with long text sequence(like 27k or longer) due to generated activations and logits. Use torch's original tensor parallel to lower down VRAM requirements.


### How has this been tested?
- [ ] corresponding documents
- [ ] ci test
- [ ] tested in single machine 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.