### PR TITLE
fix(libero): reset during evaluation now can update ids;

### DIFF
--- a/rlinf/envs/libero/libero_env.py
+++ b/rlinf/envs/libero/libero_env.py
@@ -450,6 +450,8 @@ class LiberoEnv(gym.Env):
         final_obs = copy.deepcopy(_final_obs)
         env_idx = np.arange(0, self.num_envs)[dones]
         final_info = copy.deepcopy(infos)
+        if self.cfg.only_eval:
+            self.update_reset_state_ids()
         obs, infos = self.reset(
             env_idx=env_idx,
             reset_state_ids=self.reset_state_ids[env_idx]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fix the bug from [issue](https://github.com/RLinf/RLinf/issues/290)
### Description
<!--- Describe your changes in detail -->
when enlarge the environments during evaluation, the update is function didn't work. So i add a update function calling in the function of the auto reset.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
to fix the bug

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
print the reset ids after init the env and print the reset ids after auto reset, i can make sure the id is updated correctly. More tests results will be added in the next commits.

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.