### PR TITLE
fix: wrong accelerator name when node_rank is not set

### DIFF
--- a/rlinf/scheduler/cluster/node.py
+++ b/rlinf/scheduler/cluster/node.py
@@ -428,7 +428,7 @@ class NodeProbe:
             # NODE_RANK not set, sort first by accelerator type, then by IP
             nodes_group_by_accel: dict[str, list[NodeInfo]] = {}
             for node in self._nodes:
-                accel_name = f"{node.accelerator_type.value}_{node.accelerator_model}"
+                accel_name = node.accelerator_type
                 nodes_group_by_accel.setdefault(accel_name, [])
                 nodes_group_by_accel[accel_name].append(node)
             for accel_name in nodes_group_by_accel.keys():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Accelerator name is wrongly accessed when node_rank is not set and nodes require sorting. CC @zanghz21

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.