### PR TITLE
chore: update hyperparams to align settings in \pi_{RL}

### DIFF
--- a/examples/embodiment/config/libero_goal_ppo_openpi_pi05.yaml
+++ b/examples/embodiment/config/libero_goal_ppo_openpi_pi05.yaml
@@ -137,7 +137,7 @@ actor:
     openpi:
       config_name: "pi05_libero"
       num_images_in_input: 2
-      noise_level: 0.5
+      noise_level: 0.3
       action_chunk: ${actor.model.num_action_chunks}
       num_steps: ${actor.model.num_steps}
       train_expert_only: True

--- a/examples/embodiment/config/libero_object_ppo_openpi_pi05.yaml
+++ b/examples/embodiment/config/libero_object_ppo_openpi_pi05.yaml
@@ -131,13 +131,13 @@ actor:
     gradient_checkpointing: False
     use_wrist_image: True
     use_proprio: True
-    num_steps: 3
+    num_steps: 5
     add_value_head: True
     # openpi specific parameters
     openpi:
       config_name: "pi05_libero"
       num_images_in_input: 2
-      noise_level: 0.5
+      noise_level: 0.3
       action_chunk: ${actor.model.num_action_chunks}
       num_steps: ${actor.model.num_steps}
       train_expert_only: True


### PR DESCRIPTION
chore: update hyperparams in libero_object_ppo_openpi_pi05.yaml to align settings in \pi_{RL}

### Description
This PR updates the hyperparameters in:

- libero_object_ppo_openpi_pi05.yaml
- libero_goal_ppo_openpi_pi05.yaml

to match the best-performing configuration reported in the paper.

<img width="1392" height="914" alt="best_hyperparams" src="https://github.com/user-attachments/assets/d6e9feff-5074-45ad-bee7-72ca2d7f79ca" />

where denoise steps is 5 and noise level is 0.3 in libero_object_ppo_openpi_pi05. However, in release/v0.1, the value is 3 and 0.5 respectively. Same problems in libero_object_ppo_openpi_pi05.yaml.

### Motivation and Context
The goal of this PR is to ensure reproducibility by aligning the released configuration files with the hyperparameters used in the paper.
This helps users faithfully reproduce the reported metrics and prevents training-performance discrepancies caused by outdated configuration defaults.

### How has this been tested?

- Verified that the updated hyperparameters load correctly during training.
- Ensured no breaking changes to the configuration structure.
- After updating, the performace is better.

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.