### PR TITLE
fix(dist): avoid redundant DDP initialization when WORLD_SIZE is present 

### DIFF
--- a/rlinf/workers/rollout/hf/huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/huggingface_worker.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import copy
 import gc
 from typing import Any
@@ -53,8 +54,14 @@ class MultiStepRolloutWorker(Worker):
         with open_dict(rollout_model_config):
             rollout_model_config.precision = self.cfg.rollout.model.precision
             rollout_model_config.path = self.cfg.rollout.model.model_path
-
-        self.hf_model = get_model(rollout_model_config)
+        
+        
+        old_world_size = os.environ.pop("WORLD_SIZE", None)
+        try:
+            self.hf_model = get_model(rollout_model_config)
+        finally:
+            if old_world_size is not None:
+                os.environ["WORLD_SIZE"] = old_world_size
 
         self.hf_model.eval()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Title: Prevent redundant DDP initialization in Prismatic by temporarily suppressing WORLD_SIZE**

### Description
This change wraps the `get_model` call from the Prismatic framework with a temporary environment variable modification. It pops the `WORLD_SIZE` environment variable before model initialization and restores it in a `finally` block. This prevents Prismatic's internal logic from detecting the variable and aggressively calling `torch.distributed.init_process_group`.

### Motivation and Context
The Prismatic framework automatically triggers Distributed Data Parallel (DDP) initialization if it detects `WORLD_SIZE` in the environment. This causes significant issues in managed distributed environments:
1. **Ray Integration Conflict**: When running within a Ray Cluster (e.g., for RLHF rollouts), Ray manages the process group. Prismatic’s attempt to re-initialize leads to a `RuntimeError` because the process group is already active.
2. **Port Contention**: Multiple attempts to bind to the same `MASTER_PORT` (default 29500) result in `Address already in use` errors.
3. **Redundant Logic**: In many deployment scenarios, we only need the model instance for inference or local processing, and Prismatic's "hardcoded" assumption that `WORLD_SIZE` equals "must start DDP" is too invasive.

This fix ensures that model loading remains decoupled from the distributed lifecycle management of the caller.

### How has this been tested?
- **Environment**: 8 * A800（80G）
- **Test Case**: gen-robot/openvla-7b-rlvla-warmup  from quick start https://rlinf.readthedocs.io/zh-cn/latest/rst_source/start/vla.html
- **Verification**: 
    - Verified that the `RuntimeError: [init_process_group] ... already in use` no longer occurs.
    - Verified that `WORLD_SIZE` is correctly restored after `get_model` completes, ensuring subsequent components that might rely on it are unaffected.
    - Confirmed the model loads successfully in singleton mode or within the pre-existing distributed context.

### Additional information (optional, e.g., figures and logs):
Typical error log before the fix:
```text
  File "/root/.local/share/uv/python/cpython-3.11.14-linux-x86_64-gnu/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.11.14-linux-x86_64-gnu/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/rlinf/scheduler/worker/worker.py", line 71, in sync_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/rlinf/workers/rollout/hf/huggingface_worker.py", line 57, in init_worker
    self.hf_model = get_model(rollout_model_config)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/rlinf/models/__init__.py", line 105, in get_model
    from prismatic.extern.hf.configuration_prismatic import OpenVLAConfig
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/prismatic/__init__.py", line 1, in <module>
    from .models import available_model_names, available_models, get_model_description, load
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/prismatic/models/__init__.py", line 1, in <module>
    from .load import available_model_names, available_models, get_model_description, load, load_vla
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/prismatic/models/load.py", line 16, in <module>
    from prismatic.models.materialize import get_llm_backbone_and_tokenizer, get_vision_backbone_and_transform
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/prismatic/models/materialize.py", line 12, in <module>
    from prismatic.models.backbones.llm import LLaMa2LLMBackbone, LLMBackbone, MistralLLMBackbone, PhiLLMBackbone
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/prismatic/models/backbones/llm/__init__.py", line 1, in <module>
    from .base_llm import LLMBackbone
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/prismatic/models/backbones/llm/base_llm.py", line 33, in <module>
    overwatch = initialize_overwatch(__name__)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/prismatic/overwatch/overwatch.py", line 147, in initialize_overwatch
    return DistributedOverwatch(name) if int(os.environ.get("WORLD_SIZE", -1)) != -1 else PureOverwatch(name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/prismatic/overwatch/overwatch.py", line 54, in __init__
    self.logger, self.distributed_state = ContextAdapter(logging.getLogger(name), extra={}), PartialState()
                                                                                             ^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/accelerate/state.py", line 236, in __init__
    torch.distributed.init_process_group(backend=self.backend, **kwargs)
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/torch/distributed/c10d_logger.py", line 95, in wrapper
    func_return = func(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py", line 1714, in init_process_group
    store, rank, world_size = next(rendezvous_iterator)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/torch/distributed/rendezvous.py", line 274, in _env_rendezvous_handler
    store = _create_c10d_store(
            ^^^^^^^^^^^^^^^^^^^
  File "/root/paddlejob/workspace/projs/RLinf/.venv/lib/python3.11/site-packages/torch/distributed/rendezvous.py", line 194, in _create_c10d_store
    return TCPStore(
           ^^^^^^^^^
RuntimeError: The server socket has failed to listen on any local network address. port: 18101, useIpv6: 0, code: -98, name: EADDRINUSE, message: address already in use
Exiting main process due to a failure upon worker execution.
```
<img width="931" height="499" alt="image" src="https://github.com/user-attachments/assets/7ebcff5c-289a-4a41-ab83-a5e966b86564" />


### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.