### PR TITLE
feat(embodied): Support full-shard and full-param finetune for openpi

### DIFF
--- a/rlinf/hybrid_engines/fsdp/strategy/fsdp.py
+++ b/rlinf/hybrid_engines/fsdp/strategy/fsdp.py
@@ -32,6 +32,7 @@ from rlinf.hybrid_engines.fsdp.utils import (
     FSDPVersion,
     get_backward_prefetch_strategy,
     get_fsdp_wrap_policy,
+    get_grad_norm_for_mixed_precision,
     get_sharding_strategy,
     init_fn,
 )
@@ -218,24 +219,113 @@ class FSDPStrategy(FSDPStrategyBase):
                         state[key] = value.to(device, non_blocking=True)
         clear_memory()
 
+    @torch.no_grad()
     def clip_grad_norm_(
         self,
         model: FSDP,
         norm_type: Union[float, int] = 2.0,
     ) -> float:
         """
-        Clip the gradients of the model parameters to a maximum norm specified in the configuration.
+        Clip the gradients of the model parameters by total norm.
 
         Args:
             - model (FSDP): The FSDP wrapped model.
-            - norm_type (Union[float,int]): The type of the used p-norm.
+            - norm_type (Union[float, int]): The type of the used p-norm.
 
         Returns:
             - float: The total norm of the gradients before clipping.
         """
-        return float(
-            model.clip_grad_norm_(self.cfg.optim.clip_grad, norm_type=norm_type).item()
+        device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+        max_norm = float(self.cfg.optim.clip_grad)
+        norm_type = float(norm_type)
+        all_handles = getattr(model, "_all_handles", None)
+        if all_handles is None:
+            raise RuntimeError("Expected FSDP root module with `_all_handles`.")
+
+        all_no_shard = all(not handle.uses_sharded_strategy for handle in all_handles)
+        if all_no_shard:
+            return (
+                torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm, norm_type)
+                .cpu()
+                .item()
+            )
+        sharded_params_set, nonsharded_params_set = set(), set()
+        sharded_params, nonsharded_params = [], []
+        grads = []
+
+        for handle in all_handles:
+            if handle.uses_sharded_strategy:
+                target_set, target_list = sharded_params_set, sharded_params
+            else:
+                target_set, target_list = nonsharded_params_set, nonsharded_params
+
+            if handle._use_orig_params:
+                for p in handle.flat_param._params:
+                    if p not in target_set:
+                        target_set.add(p)
+                        target_list.append(p)
+                        if p.grad is not None:
+                            grads.append(p.grad)
+            else:
+                fp = handle.flat_param
+                if fp not in target_set:
+                    target_set.add(fp)
+                    target_list.append(fp)
+                    if fp.grad is not None:
+                        grads.append(fp.grad)
+
+        # include non-FSDP-managed params (ignored modules etc.)
+        for p in model.parameters():
+            not_fsdp_managed = (
+                p not in sharded_params_set and p not in nonsharded_params_set
+            )
+            if not_fsdp_managed:
+                nonsharded_params_set.add(p)
+                nonsharded_params.append(p)
+                if p.grad is not None:
+                    grads.append(p.grad)
+        local_sharded_norm = get_grad_norm_for_mixed_precision(
+            sharded_params,
+            norm_type,
+            torch.tensor(0.0, device=device, dtype=torch.float32),
+            device,
         )
+        local_nonsharded_norm = (
+            get_grad_norm_for_mixed_precision(
+                nonsharded_params,
+                norm_type,
+                torch.tensor(0.0, device=device, dtype=torch.float32),
+                device,
+            )
+            if nonsharded_params
+            else None
+        )
+
+        if norm_type == torch.inf:
+            total_norm = (
+                torch.maximum(local_sharded_norm, local_nonsharded_norm)
+                if local_nonsharded_norm is not None
+                else local_sharded_norm
+            )
+            torch.distributed.all_reduce(
+                total_norm, op=torch.distributed.ReduceOp.MAX, group=self._dp_group
+            )
+        else:
+            total_norm = local_sharded_norm**norm_type
+            torch.distributed.all_reduce(
+                total_norm, op=torch.distributed.ReduceOp.SUM, group=self._dp_group
+            )
+            if local_nonsharded_norm is not None:
+                total_norm += local_nonsharded_norm**norm_type
+            total_norm = total_norm ** (1.0 / norm_type)
+
+        grad_norm = float(total_norm.item())
+        clip_coef = max_norm / (total_norm + 1e-6)
+        clip_coef = torch.clamp(clip_coef, max=1.0)
+        for g in grads:
+            g.mul_(clip_coef.to(device=g.device, dtype=g.dtype))
+
+        return grad_norm
 
     def before_micro_batch(
         self, model: FSDP, is_last_micro_batch: bool

--- a/rlinf/hybrid_engines/fsdp/utils.py
+++ b/rlinf/hybrid_engines/fsdp/utils.py
@@ -31,6 +31,7 @@ import functools
 import json
 import os
 import shutil
+from collections.abc import Iterable
 from enum import Enum
 from typing import Optional, Union
 
@@ -200,6 +201,19 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False, is_openvla_model=Fa
             transformer_layer_cls=transformer_cls_to_wrap,
         )
         policies.append(llm_wrap_policy)
+
+    if hasattr(module, "_no_split_names"):
+        no_split_names = getattr(module, "_no_split_names", None)
+        if no_split_names is not None:
+            from torch.distributed.fsdp.wrap import lambda_auto_wrap_policy
+
+            def lambda_policy_fn(module):
+                return hasattr(module, "name") and module.name in no_split_names
+
+            lambda_policy = functools.partial(
+                lambda_auto_wrap_policy, lambda_fn=lambda_policy_fn
+            )
+            policies.append(lambda_policy)
 
     # Add LoRA lambda policy if enabled
     if is_lora:
@@ -487,6 +501,38 @@ def get_grad_norm(
         total_norm = total_norm.item() ** (1.0 / norm_type)  # type: ignore
 
     return float(total_norm)
+
+
+def get_grad_norm_for_mixed_precision(
+    params: Iterable[torch.nn.Parameter],
+    norm_type: float,
+    zero: torch.Tensor,
+    device: torch.device,
+) -> torch.Tensor:
+    """
+    Return the gradient norm of parameters ``param`` s, where the gradients are viewed as a single vector.
+
+    The returned norm is in FP32 even if parameters/gradients are in a low precision. This is because the downstream
+    use of this return value is a reduction across ranks.
+    """
+    params_with_grad = [param for param in params if param.grad is not None]
+    if len(params_with_grad) == 0:
+        # Reuse a tensor for zero to avoid a GPU sync
+        return zero
+    grads = [param.grad.detach().to(torch.float32) for param in params_with_grad]
+    # Compute the gradient norm in FP32, where we treat the gradients as a
+    # single vector
+    grad_norm = torch.linalg.vector_norm(
+        torch.stack(
+            [
+                torch.linalg.vector_norm(grad.detach(), norm_type, dtype=torch.float32)
+                for grad in grads
+            ],
+        ),
+        norm_type,
+        dtype=torch.float32,
+    )
+    return grad_norm.to(device=device)
 
 
 def get_sharding_strategy(strategy_str: str) -> ShardingStrategy:

--- a/rlinf/models/__init__.py
+++ b/rlinf/models/__init__.py
@@ -378,7 +378,22 @@ def get_model(cfg: DictConfig, override_config_kwargs=None):
             for param in model.value_head.parameters():
                 param.requires_grad = True
 
+    # Set name attribute for all modules to enable FSDP wrap policy by name
+    _set_module_names(model)
+
     return model
+
+
+def _set_module_names(model):
+    """
+    Set the 'name' attribute for all modules in the model.
+    The name is set to the last part of the module's path (e.g., "action_in_proj").
+    This allows FSDP wrap policy to identify modules by name without using id() mapping.
+    """
+    for name, module in model.named_modules():
+        # Set name to the last part of the path (e.g., "model.action_in_proj" -> "action_in_proj")
+        path_parts = name.split(".")
+        module.name = path_parts[-1] if path_parts else name
 
 
 def tag_vlm_subtree(model, is_vlm: bool):

--- a/rlinf/models/embodiment/openpi_action_model.py
+++ b/rlinf/models/embodiment/openpi_action_model.py
@@ -75,13 +75,34 @@ class OpenPi0ForRLActionPrediction(BasePolicy, PI0Pytorch):
     @property
     def _no_split_modules(self) -> list[str]:
         # Currently, PaliGemmaForConditionalGeneration only support DDP, as many of it's modules are called without forward
+        if self.config.train_expert_only:
+            return [
+                "GemmaDecoderLayer",
+                "SiglipVisionEmbeddings",
+                "GemmaRMSNorm",
+                "GemmaRotaryEmbedding",
+            ]
+        else:
+            return [
+                "GemmaMLP",
+                "SiglipVisionEmbeddings",
+                "GemmaRMSNorm",
+                "GemmaRotaryEmbedding",
+            ]
+
+    @property
+    def _no_split_names(self) -> list[str]:
         return [
-            "PaliGemmaForConditionalGeneration",
-            "GemmaDecoderLayer",
-            "SiglipVisionEmbeddings",
-            "GemmaRMSNorm",
-            "GemmaForCausalLM",
-            "GemmaRotaryEmbedding",
+            "action_in_proj",
+            "action_out_proj",
+            "lm_head",
+            # --pi0 only--
+            "state_proj",
+            "action_time_mlp_in",
+            "action_time_mlp_out",
+            # --pi05 only--
+            "time_mlp_in",
+            "time_mlp_out",
         ]
 
     def __init__(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
(1) Adapt the OpenPI model to support full-parameter fine-tuning under the FSDP framework, with compatibility for full-shard mode. 
(2) Support gradient norm clipping with mixed-precision gradients. Mainly follows the official PyTorch FSDP implementation ([FullyShardedDataParallel source](https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/fully_sharded_data_parallel.py#L1070-L1218)).

Experimental evaluation on LIBERO-Goal using π₀ shows that both the training curves and training metrics are consistent with the original results.
<img width="1626" height="428" alt="截屏2026-01-05 14 45 58" src="https://github.com/user-attachments/assets/2699f530-3da3-466a-9731-9ee7ec2eb1f5" />

The original `no_shard` mode also runs correctly.

<img width="1626" height="447" alt="截屏2026-01-05 14 47 24" src="https://github.com/user-attachments/assets/18673daf-d8fc-4e7d-8070-4f155bb0f827" />

Full-parameter fine-tuning can improve the success rate.
<img width="1623" height="442" alt="截屏2026-01-05 14 49 29" src="https://github.com/user-attachments/assets/58768f4b-1235-4555-b9ab-ae903bfe902d" />


### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.