### PR TITLE
feat(mujoco): add support for MuJoCo benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ RLinf is a flexible and scalable open-source RL infrastructure designed for Embo
           <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/isaaclab.html">IsaacLab</a> ✅</li>
           <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/calvin.html">CALVIN</a> ✅</li>
           <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/robocasa.html">RoboCasa</a> ✅</li>
+          <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/mujoco.html">Mujoco</a> ✅</li>
           <li>More...</li>
         </ul>
       </td>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,6 +74,7 @@ RLinf 是一个灵活且可扩展的开源框架，专为具身智能和智能�
           <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/metaworld.html">MetaWorld</a> ✅</li>
           <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/isaaclab.html">IsaacLab</a> ✅</li>
           <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/robocasa.html">RoboCasa</a> ✅</li>
+          <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/mujoco.html">Mujoco</a> ✅</li>
           <li>More...</li>
         </ul>
       </td>

--- a/docs/source-en/rst_source/examples/index.rst
+++ b/docs/source-en/rst_source/examples/index.rst
@@ -278,6 +278,7 @@ Thanks to this decoupled design, workers can be flexibly and dynamically schedul
    isaaclab
    calvin
    robocasa
+   mujoco
    pi0
    gr00t
    reasoning

--- a/docs/source-en/rst_source/examples/mujoco.rst
+++ b/docs/source-en/rst_source/examples/mujoco.rst
@@ -1,0 +1,284 @@
+RL with MuJoCo Benchmark
+======================================================
+
+.. |huggingface| image:: /_static/svg/hf-logo.svg
+   :width: 16px
+   :height: 16px
+   :class: inline-icon
+
+This document provides a complete guide to launching and managing
+**Vision-Language-Action Models (VLAs)** training tasks in the **RLinf** framework.
+It also explains how to fine-tune a VLA model in the **MuJoCo** simulation environment
+to perform robotic manipulation tasks.
+
+The main goal is to enable the model to acquire the following capabilities:
+
+1. **Visual understanding**: process RGB images captured from robot cameras;
+2. **Language understanding**: interpret natural language task descriptions;
+3. **Action generation**: produce accurate robot actions (position, rotation, gripper control);
+4. **Reinforcement learning**: optimize policies with PPO using environment feedback.
+
+Environment
+-----------
+
+The MuJoCo environments are built on top of the
+`serl <https://rail-berkeley.github.io/serl/docs/sim_quick_start.html>`_ project.
+Two minimal MuJoCo simulation tasks are provided:
+
+- ``PandaPickCube-v0``
+- ``PandaPickCubeVision-v0``
+
+Task Definition
+~~~~~~~~~~~~~~~
+
+- **Task**: control a Franka Panda robot arm to pick up a cube and move it to a target position;
+- **Observation**:
+
+  - ``PandaPickCube-v0``: proprioceptive states + target position;
+  - ``PandaPickCubeVision-v0``: multi-view RGB images (third-person + wrist camera) + proprioceptive states;
+
+- **Action Space**: 4D continuous actions
+
+  - 3D end-effector position control (x, y, z)
+  - gripper control (open/close)
+
+Data Structure
+~~~~~~~~~~~~~~
+
+``PandaPickCube-v0``
+
+- **States**: proprioceptive states and target location
+
+  - end-effector 3D position
+  - end-effector 3D velocity
+  - gripper open/close state (1D)
+  - cube 3D position
+
+``PandaPickCubeVision-v0``
+
+- **Images**: RGB tensors from a third-person view and a wrist camera view
+- **States**: proprioceptive states
+
+  - end-effector 3D position
+  - end-effector 3D velocity
+  - gripper open/close state (1D)
+
+- **Task Descriptions**: natural language instructions
+- **Actions**: normalized continuous action values
+- **Rewards**: dense rewards based on task progress
+
+Algorithms
+----------
+
+The core algorithm components include:
+
+1. **PPO (Proximal Policy Optimization)**
+
+   - use GAE (Generalized Advantage Estimation) for advantage estimation;
+   - policy clipping with ratio constraints;
+   - value function clipping;
+   - entropy regularization.
+
+2. **GRPO (Group Relative Policy Optimization)**
+
+   - for each state/prompt, the policy samples *G* independent actions;
+   - compute advantages by subtracting the group mean reward.
+
+Dependencies
+------------
+
+1. Clone the RLinf repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # For faster downloads in mainland China (optional):
+   # git clone https://ghfast.top/github.com/RLinf/RLinf.git
+   git clone https://github.com/RLinf/RLinf.git
+   cd RLinf
+
+2. Install dependencies
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Option 1: Docker image
+^^^^^^^^^^^^^^^^^^^^^^
+
+Run experiments using the official Docker image:
+
+.. code-block:: bash
+
+   docker run -it --rm --gpus all \
+      --shm-size 20g \
+      --network host \
+      --name rlinf \
+      -v .:/workspace/RLinf \
+      rlinf/rlinf:agentic-rlinf0.1-torch2.6.0-openvla-openvlaoft-pi0
+
+   # For faster Docker pulls in mainland China (optional):
+   # docker.1ms.run/rlinf/rlinf:agentic-rlinf0.1-torch2.6.0-openvla-openvlaoft-pi0
+
+For experiments with different models, use the built-in ``switch_env`` tool
+inside the container to activate the corresponding virtual environment:
+
+.. code-block:: bash
+
+   # Switch to the OpenVLA environment
+   source switch_env openvla
+
+   # Switch to the OpenVLA-OFT environment
+   source switch_env openvla-oft
+
+Option 2: Custom environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   # To accelerate dependency downloads in China, append --use-mirror to install.sh
+   # Replace --model with openvla-oft to install the OpenVLA-OFT environment
+   bash requirements/install.sh embodied --model openvla --env maniskill_libero
+   source .venv/bin/activate
+
+Assets Download
+---------------
+
+Download MuJoCo resources and environment assets:
+
+.. code-block:: bash
+
+   cd rlinf/envs/mujoco
+   git clone https://github.com/RLinf/serl.git
+   cd serl/franka_sim
+   pip install -e .
+   pip install -r requirements.txt
+
+Run Training
+------------
+
+1. Key configuration parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Example 1: Pipeline overlap (recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+   cluster:
+     num_nodes: 2
+     component_placement:
+       env: 0-7
+       rollout: 8-15
+       actor: 0-15
+
+   rollout:
+     pipeline_stage_num: 2
+
+This configuration enables pipeline overlap between **rollout** and **env** to increase throughput.
+
+Example 2: Fully shared (env / rollout / actor share all GPUs)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+   cluster:
+     num_nodes: 1
+     component_placement:
+       env,rollout,actor: all
+
+Example 3: Fully separated (no interference, usually no offload needed)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+   cluster:
+     num_nodes: 2
+     component_placement:
+       env: 0-3
+       rollout: 4-7
+       actor: 8-15
+
+This configuration isolates env, rollout, and actor on different GPU groups, so offload is usually unnecessary.
+
+2. Launch command
+~~~~~~~~~~~~~~~~~
+
+After selecting a configuration, start training in root directory:
+
+.. code-block:: bash
+
+   bash examples/embodiment/run_embodiment.sh CHOSEN_CONFIG
+
+Currently, only PPO training with an MLP policy is supported in the MuJoCo environment:
+
+.. code-block:: bash
+
+   bash examples/embodiment/run_embodiment.sh mujoco_ppo_mlp
+
+Visualization and Results
+-------------------------
+
+1. TensorBoard logs
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   tensorboard --logdir ./logs --port 6006
+
+2. Key metrics to monitor
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Training metrics
+^^^^^^^^^^^^^^^^
+
+- ``train/actor/approx_kl``: approximate KL divergence, used to monitor policy update magnitude
+- ``train/actor/clip_fraction``: fraction of samples affected by PPO clipping
+- ``train/actor/clipped_ratio``: mean clipped probability ratio
+- ``train/actor/grad_norm``: gradient norm
+- ``train/actor/lr``: learning rate
+- ``train/actor/policy_loss``: policy loss
+- ``train/critic/value_loss``: value function loss
+- ``train/critic/value_clip_ratio``: fraction of samples affected by value clipping
+- ``train/critic/explained_variance``: value fit quality, closer to 1 is better
+- ``train/entropy_loss``: policy entropy
+- ``train/loss``: total loss (actor + critic + entropy regularization)
+
+Rollout metrics
+^^^^^^^^^^^^^^^
+
+- ``rollout/advantages_max``: maximum advantage
+- ``rollout/advantages_mean``: mean advantage
+- ``rollout/advantages_min``: minimum advantage
+- ``rollout/rewards``: reward statistics per chunk
+
+Environment metrics
+^^^^^^^^^^^^^^^^^^^
+
+- ``env/episode_len``: episode length (steps)
+- ``env/return``: total episode return (less informative for sparse rewards)
+- ``env/reward``: step-level reward
+- ``env/success_once``: recommended metric, reflects unnormalized success rate
+
+3. Video generation
+~~~~~~~~~~~~~~~~~~~
+
+Video generation is currently supported only in ``PandaPickCubeVision-v0``:
+
+.. code-block:: yaml
+
+   env:
+     eval:
+       video_cfg:
+         save_video: True
+         video_base_dir: ${runner.logger.log_path}/video/eval
+
+4. Logging backend integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   runner:
+     task_type: embodied
+     logger:
+       log_path: "../results"
+       project_name: rlinf
+       experiment_name: "maniskill_ppo_openvla"
+       logger_backends: ["tensorboard"]  # wandb, swanlab

--- a/docs/source-zh/rst_source/examples/index.rst
+++ b/docs/source-zh/rst_source/examples/index.rst
@@ -272,6 +272,7 @@ RLinf的整体设计简洁且模块化，以Worker为抽象封装强化学习训
    isaaclab
    calvin
    robocasa
+   mujoco
    pi0
    gr00t
    reasoning

--- a/docs/source-zh/rst_source/examples/mujoco.rst
+++ b/docs/source-zh/rst_source/examples/mujoco.rst
@@ -1,0 +1,281 @@
+基于 MuJoCo 评测平台的强化学习训练
+==================================
+
+.. |huggingface| image:: /_static/svg/hf-logo.svg
+   :width: 16px
+   :height: 16px
+   :class: inline-icon
+
+本文档给出在 **RLinf** 框架内启动与管理 **Vision-Language-Action Models (VLAs)** 训练任务的完整指南，
+并介绍如何在 **MuJoCo** 环境中微调 VLA 模型以完成机器人操作任务。
+
+主要目标是让模型具备以下能力：
+
+1. **视觉理解**：处理来自机器人相机的 RGB 图像；
+2. **语言理解**：理解自然语言的任务描述；
+3. **动作生成**：产生精确的机器人动作（位置、旋转、夹爪控制）；
+4. **强化学习**：结合环境反馈，使用 PPO 优化策略。
+
+环境
+----
+
+MuJoCo 环境基于项目 `serl <https://rail-berkeley.github.io/serl/docs/sim_quick_start.html>`_ 构建，
+包含两个最小化仿真环境：
+
+- ``PandaPickCube-v0``
+- ``PandaPickCubeVision-v0``
+
+任务定义
+~~~~~~~~
+
+- **Task**：控制 Franka Panda 机械臂抓取物块并移动至目标位置；
+- **Observation**：
+
+  - ``PandaPickCube-v0``：本体感知状态 + 目标位置；
+  - ``PandaPickCubeVision-v0``：多视角 RGB 图像（机器人视角 + 腕部相机）+ 本体感知状态；
+
+- **Action Space**：4 维连续动作
+
+  - 三维位置控制（x, y, z）
+  - 夹爪控制（开/合）
+
+数据结构
+~~~~~~~~
+
+``PandaPickCube-v0``
+
+- **States**：本体感知与目标位置
+
+  - 末端执行器三维位置
+  - 末端执行器三维速度
+  - 夹爪一维开合
+  - 物块三维位置
+
+``PandaPickCubeVision-v0``
+
+- **Images**：第三人称视角与腕部相机视角的 RGB 张量
+- **States**：本体感知
+
+  - 末端执行器三维位置
+  - 末端执行器三维速度
+  - 夹爪一维开合
+
+- **Task Descriptions**：自然语言指令
+- **Actions**：归一化连续动作值
+- **Rewards**：基于任务完成度的逐步奖励
+
+算法
+----
+
+核心算法组件包括：
+
+1. **PPO（近端策略优化）**
+
+   - 使用 GAE（广义优势估计）进行优势估计；
+   - 带比例限制（clipping）的策略裁剪；
+   - 价值函数裁剪；
+   - 熵正则化。
+
+2. **GRPO（组相对策略优化）**
+
+   - 对于每个状态/提示，策略生成 *G* 个独立动作；
+   - 通过减去组平均奖励来计算每个动作的优势。
+
+依赖安装
+--------
+
+1. 克隆 RLinf 仓库
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # 为提高国内下载速度，可以使用：
+   # git clone https://ghfast.top/github.com/RLinf/RLinf.git
+   git clone https://github.com/RLinf/RLinf.git
+   cd RLinf
+
+2. 安装依赖
+~~~~~~~~~~~
+
+**选项 1：Docker 镜像**
+
+
+使用 Docker 镜像运行实验：
+
+.. code-block:: bash
+
+   docker run -it --rm --gpus all \
+      --shm-size 20g \
+      --network host \
+      --name rlinf \
+      -v .:/workspace/RLinf \
+      rlinf/rlinf:agentic-rlinf0.1-torch2.6.0-openvla-openvlaoft-pi0
+
+   # 如果需要国内加速下载镜像，可以使用：
+   # docker.1ms.run/rlinf/rlinf:agentic-rlinf0.1-torch2.6.0-openvla-openvlaoft-pi0
+
+对于不同模型上的实验，请通过镜像内置的 ``switch_env`` 工具切换到对应虚拟环境：
+
+.. code-block:: bash
+
+   # 切换到 OpenVLA 环境
+   source switch_env openvla
+
+   # 切换到 OpenVLA-OFT 环境
+   source switch_env openvla-oft
+
+选项 2：自定义环境
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   # 为提高国内依赖安装速度，可以添加 --use-mirror 到下面的 install.sh 命令
+   # 将 --model 参数改为 openvla-oft 可安装 OpenVLA-OFT 环境
+   bash requirements/install.sh embodied --model openvla --env maniskill_libero
+   source .venv/bin/activate
+
+资源下载
+--------
+
+下载 MuJoCo 资源文件：
+
+.. code-block:: bash
+
+   cd rlinf/envs/mujoco
+   git clone https://github.com/RLinf/serl.git
+   cd serl/franka_sim
+   pip install -e .
+   pip install -r requirements.txt
+
+运行脚本
+--------
+
+1. 关键参数配置
+~~~~~~~~~~~~~~~~
+
+示例 1：流水线重叠（推荐）
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+   cluster:
+     num_nodes: 2
+     component_placement:
+       env: 0-7
+       rollout: 8-15
+       actor: 0-15
+
+   rollout:
+     pipeline_stage_num: 2
+
+该配置允许 **rollout 与 env** 之间流水线重叠，从而提升 rollout 吞吐。
+
+示例 2：完全共享（env / rollout / actor 共用 GPU）
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+   cluster:
+     num_nodes: 1
+     component_placement:
+       env,rollout,actor: all
+
+示例 3：完全分离（互不干扰，无需 offload）
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+   cluster:
+     num_nodes: 2
+     component_placement:
+       env: 0-3
+       rollout: 4-7
+       actor: 8-15
+
+该配置实现 env、rollout、actor 各自使用独立 GPU，互不干扰，因此通常不需要 offload 功能。
+
+2. 启动命令
+~~~~~~~~~~~
+
+选择配置后，在根目录下运行以下命令开始训练：
+
+.. code-block:: bash
+
+   bash examples/embodiment/run_embodiment.sh CHOSEN_CONFIG
+
+暂时只支持在 MuJoCo 环境中使用 PPO 训练 MLP Policy：
+
+.. code-block:: bash
+
+   bash examples/embodiment/run_embodiment.sh mujoco_ppo_mlp
+
+可视化与结果
+------------
+
+1. TensorBoard 日志
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # 启动 TensorBoard
+   tensorboard --logdir ./logs --port 6006
+
+2. 关键监控指标
+~~~~~~~~~~~~~~~
+
+训练指标
+^^^^^^^^
+
+- ``train/actor/approx_kl``：近似 KL，用于监控策略更新幅度
+- ``train/actor/clip_fraction``：触发 PPO clip 的样本比例
+- ``train/actor/clipped_ratio``：裁剪后的概率比均值，用来衡量 clip 的影响程度
+- ``train/actor/grad_norm``：梯度范数
+- ``train/actor/lr``：学习率
+- ``train/actor/policy_loss``：策略损失
+- ``train/critic/value_loss``：价值函数损失
+- ``train/critic/value_clip_ratio``：值函数裁剪触发比例
+- ``train/critic/explained_variance``：价值拟合程度，越接近 1 越好
+- ``train/entropy_loss``：策略熵
+- ``train/loss``：总损失（actor + critic + entropy regularization）
+
+Rollout 指标
+^^^^^^^^^^^^
+
+- ``rollout/advantages_max``：优势最大值
+- ``rollout/advantages_mean``：优势均值
+- ``rollout/advantages_min``：优势最小值
+- ``rollout/rewards``：一个 chunk 的奖励统计
+
+环境指标
+^^^^^^^^
+
+- ``env/episode_len``：回合步数（step）
+- ``env/return``：回合总回报（在稀疏奖励中参考意义有限）
+- ``env/reward``：step-level 奖励
+- ``env/success_once``：建议重点监控该指标，反映未归一化成功率，更能体现策略真实性能
+
+3. 视频生成
+~~~~~~~~~~~
+
+仅支持 ``PandaPickCubeVision-v0`` 环境下生成视频：
+
+.. code-block:: yaml
+
+   env:
+     eval:
+       video_cfg:
+         save_video: True
+         video_base_dir: ${runner.logger.log_path}/video/eval
+
+4. 训练日志工具集成
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml
+
+   runner:
+     task_type: embodied
+     logger:
+       log_path: "../results"
+       project_name: rlinf
+       experiment_name: "maniskill_ppo_openvla"
+       logger_backends: ["tensorboard"]  # wandb, swanlab

--- a/examples/embodiment/config/env/mujoco_pickcube_state.yaml
+++ b/examples/embodiment/config/env/mujoco_pickcube_state.yaml
@@ -1,0 +1,28 @@
+env_type: mujoco
+gym_id: PandaPickCube-v0
+
+
+obs_mode: state
+obs_format: tensor
+state_key: state
+
+mujoco_gl: egl
+render: false
+
+seed: 0
+total_num_envs: null
+group_size: 1
+
+auto_reset: True
+ignore_terminations: False
+max_steps_per_rollout_epoch: 200
+max_episode_steps: 200
+
+use_rel_reward: True
+reward_coef: 1.0
+is_eval: False
+
+video_cfg:
+  save_video: False
+  info_on_video: True
+  video_base_dir: ${runner.logger.log_path}/video/train

--- a/examples/embodiment/config/env/mujoco_pickcube_vision.yaml
+++ b/examples/embodiment/config/env/mujoco_pickcube_vision.yaml
@@ -1,0 +1,27 @@
+env_type: serl
+
+# SERL vision env id
+gym_id: PandaPickCubeVision-v0
+
+# observation mode
+obs_mode: image
+image_key: images
+camera: front     # front / wrist / both
+state_key: state
+
+mujoco_gl: egl
+render: false
+
+total_num_envs: null
+group_size: 1
+seed: 0
+
+auto_reset: True
+ignore_terminations: False
+max_steps_per_rollout_epoch: 256
+max_episode_steps: 200
+
+video_cfg:
+  save_video: True
+  info_on_video: True
+  video_base_dir: ${runner.logger.log_path}/video/train

--- a/examples/embodiment/config/mujoco_ppo_mlp.yaml
+++ b/examples/embodiment/config/mujoco_ppo_mlp.yaml
@@ -1,0 +1,219 @@
+defaults:
+  - env/mujoco_pickcube_state@env.train
+  - env/mujoco_pickcube_state@env.eval
+  - model/mlp_policy@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor: 0-0
+    env: 0-0
+    rollout: 0-0
+
+runner:
+  task_type: embodied
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "mujoco_ppo_mlp"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 200
+  max_steps: -1
+
+  only_eval: false
+  eval_policy_path: null
+  val_check_interval: 50
+  save_interval: -1
+
+  seq_length: 1
+  max_prompt_length: 1
+
+  resume_dir: null
+
+algorithm:
+  update_epoch: 8
+  normalize_advantages: true
+  kl_penalty: kl
+  group_size: 1
+
+  rollout_epoch: 1
+  eval_rollout_epoch: 1
+
+  reward_type: action_level
+  logprob_type: action_level
+  entropy_type: action_level
+
+  adv_type: gae
+  loss_type: actor_critic
+  loss_agg_func: token-mean
+  kl_beta: 0.0
+  entropy_bonus: 0
+
+  clip_ratio_high: 0.2
+  clip_ratio_low: 0.2
+  clip_ratio_c: 3.0
+  value_clip: 1.0
+  huber_delta: 10.0
+
+  gamma: 0.99
+  gae_lambda: 0.95
+
+  sampling_params:
+    do_sample: true
+    temperature_train: 1.0
+    temperature_eval: 0.6
+    top_k: 0
+    top_p: 1.0
+    repetition_penalty: 1.0
+
+  length_params:
+    max_new_token: 1
+    max_length: 1
+    min_length: 1
+
+env:
+  group_name: EnvGroup
+  enable_offload: false
+
+  device: cpu
+  mujoco_gl: disable
+
+  train:
+    env_type: mujoco
+    gym_id: PandaPickCube-v0
+
+    obs_mode: state
+    obs_format: tensor
+    state_key: state
+
+    mujoco_gl: egl
+    render: false
+
+    seed: 0
+    total_num_envs: 128
+    group_size: 1
+
+    auto_reset: true
+    ignore_terminations: false
+    max_steps_per_rollout_epoch: 200
+    max_episode_steps: 200
+
+    use_rel_reward: true
+    reward_coef: 1.0
+    is_eval: true
+    video_cfg:
+      save_video: true
+      info_on_video: true
+      video_base_dir: ${runner.logger.log_path}/video/train
+  eval:
+    env_type: mujoco
+    gym_id: PandaPickCube-v0
+
+    obs_mode: state
+    obs_format: tensor
+    state_key: state
+
+    mujoco_gl: egl
+    render: false
+
+    seed: 0
+    total_num_envs: 16
+    group_size: 1
+
+    auto_reset: true
+    ignore_terminations: true
+    max_steps_per_rollout_epoch: 200
+    max_episode_steps: 200
+
+    use_rel_reward: true
+    reward_coef: 1.0
+    is_eval: True
+    use_fixed_reset_state_ids: false
+    video_cfg:
+      save_video: True
+      video_base_dir: ${runner.logger.log_path}/video/eval
+
+rollout:
+  group_name: RolloutGroup
+  backend: huggingface
+  enable_offload: false
+  pipeline_stage_num: 1
+
+  device: cpu
+
+  model:
+    model_path: ""
+    precision: "32"
+
+actor:
+  group_name: ActorGroup
+  training_backend: fsdp
+  micro_batch_size: 256
+  global_batch_size: 256
+  seed: 1234
+  enable_offload: false
+
+  device: cuda
+
+  model:
+    model_type: mlp_policy
+    model_path: ""
+    policy_setup: panda-qpos
+    obs_dim: 10
+    action_dim: 8
+    num_action_chunks: 1
+    hidden_dim: 256
+    precision: "32"
+    add_value_head: true
+    is_lora: false
+    lora_rank: 32
+
+  optim:
+    lr: 3.0e-4
+    value_lr: 3.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_eps: 1.0e-05
+    weight_decay: 0.01
+    clip_grad: 0.5
+
+  fsdp_config:
+    strategy: fsdp
+    sharding_strategy: no_shard
+    gradient_checkpointing: false
+    cpu_offload: false
+    offload_pin_memory: false
+    reshard_after_forward: true
+    enable_gradient_accumulation: true
+    forward_prefetch: false
+    limit_all_gathers: false
+    backward_prefetch: null
+    use_orig_params: false
+    use_liger_kernel: false
+    fsdp_size: -1
+
+    mixed_precision:
+      param_dtype: "32"
+      reduce_dtype: "32"
+      buffer_dtype: "32"
+
+    amp:
+      enabled: false
+      precision: bf16
+      use_grad_scaler: false
+
+reward:
+  use_reward_model: false
+
+critic:
+  use_critic_model: false

--- a/rlinf/envs/__init__.py
+++ b/rlinf/envs/__init__.py
@@ -71,5 +71,9 @@ def get_env_cls(env_type, env_cfg=None):
         from rlinf.envs.realworld.realworld_env import RealWorldEnv
 
         return RealWorldEnv
+    elif env_type == "mujoco":
+        from rlinf.envs.mujoco.serl_franka_lift_cube import SERLFrankaEnv
+
+        return SERLFrankaEnv
     else:
         raise NotImplementedError(f"Environment type {env_type} not implemented")

--- a/rlinf/envs/action_utils.py
+++ b/rlinf/envs/action_utils.py
@@ -138,6 +138,18 @@ def prepare_actions_for_robocasa(
         return chunk_actions
 
 
+def prepare_actions_for_mujoco(raw_chunk_actions, model_type):
+    if raw_chunk_actions.shape[-1] >= 7:
+        chunk_actions = np.concatenate(
+            [raw_chunk_actions[..., :3], raw_chunk_actions[..., 6:7]], axis=-1
+        )
+    else:
+        chunk_actions = raw_chunk_actions[..., :4]
+    if SupportedModel(model_type) == SupportedModel.OPENPI:
+        chunk_actions[..., -1] = np.clip(chunk_actions[..., -1], -1.0, 1.0)
+    return chunk_actions
+
+
 def prepare_actions(
     raw_chunk_actions,
     env_type,
@@ -183,6 +195,11 @@ def prepare_actions(
         )
     elif env_type == "realworld":
         chunk_actions = raw_chunk_actions
+    elif env_type == "mujoco":
+        chunk_actions = prepare_actions_for_mujoco(
+            raw_chunk_actions=raw_chunk_actions,
+            model_type=model_type,
+        )
     else:
         raise NotImplementedError
 

--- a/rlinf/envs/mujoco/__init__.py
+++ b/rlinf/envs/mujoco/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from franka_sim.mujoco_gym_env import GymRenderingSpec, MujocoGymEnv
+from .serl_franka_lift_cube import SERLFrankaEnv
+
+__all__ = ["SERLFrankaEnv", "GymRenderingSpec", "MujocoGymEnv"]

--- a/rlinf/envs/mujoco/serl_franka_lift_cube.py
+++ b/rlinf/envs/mujoco/serl_franka_lift_cube.py
@@ -1,0 +1,757 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import copy
+import os
+from typing import Any, Optional, Union
+
+import gym
+import numpy as np
+import torch
+
+from rlinf.envs import utils as rlinf_utils
+
+__all__ = ["SERLFrankaEnv"]
+
+
+# ==========================================================
+# Obs utils: object scalar unwrap + robust flatten
+# ==========================================================
+def _unwrap_object_scalar(x: Any, max_unwrap: int = 10) -> Any:
+    """Unwrap numpy object scalar (shape=(), dtype=object) safely."""
+    cur = x
+    for _ in range(max_unwrap):
+        arr = np.asarray(cur)
+        if arr.dtype == object and arr.shape == ():
+            try:
+                cur = arr.item()
+            except Exception:
+                break
+        else:
+            break
+    return cur
+
+
+def _flatten_any_safe(
+    x: Any,
+    visited: Optional[set[int]] = None,
+    depth: int = 0,
+    max_depth: int = 20,
+) -> np.ndarray:
+    """Flatten nested dict/list/tuple/object-arr into 1D float32 array."""
+    if visited is None:
+        visited = set()
+    if depth > max_depth:
+        raise RuntimeError("Observation flatten exceeded max_depth; obs may be cyclic.")
+
+    obj_id = id(x)
+    if obj_id in visited:
+        return np.zeros((0,), dtype=np.float32)
+    visited.add(obj_id)
+
+    if isinstance(x, dict):
+        parts = [
+            _flatten_any_safe(x[k], visited, depth + 1, max_depth)
+            for k in sorted(x.keys())
+        ]
+        return np.concatenate(parts, axis=0) if parts else np.zeros((0,), np.float32)
+
+    if isinstance(x, (list, tuple)):
+        parts = [_flatten_any_safe(v, visited, depth + 1, max_depth) for v in x]
+        return np.concatenate(parts, axis=0) if parts else np.zeros((0,), np.float32)
+
+    arr = np.asarray(x)
+
+    if arr.dtype == object and arr.shape == ():
+        y = _unwrap_object_scalar(x)
+        if id(y) == id(x):
+            return np.zeros((0,), np.float32)
+        return _flatten_any_safe(y, visited, depth + 1, max_depth)
+
+    if arr.dtype == object:
+        parts = [
+            _flatten_any_safe(v, visited, depth + 1, max_depth)
+            for v in arr.ravel().tolist()
+        ]
+        return np.concatenate(parts, axis=0) if parts else np.zeros((0,), np.float32)
+
+    return arr.astype(np.float32, copy=False).reshape(-1)
+
+
+def extract_serl_state(raw_obs: Any, state_key: str = "states") -> np.ndarray:
+    """Extract and flatten SERL state."""
+    if isinstance(raw_obs, tuple) and len(raw_obs) == 2:
+        raw_obs = raw_obs[0]
+    if isinstance(raw_obs, dict):
+        raw_obs = raw_obs[state_key]
+    raw_obs = _unwrap_object_scalar(raw_obs)
+    return _flatten_any_safe(raw_obs)
+
+
+def extract_serl_images_dict(
+    raw_obs: Any,
+    image_key: str = "images",
+) -> dict[str, np.ndarray]:
+    """Extract SERL images dict from raw obs."""
+    if isinstance(raw_obs, tuple) and len(raw_obs) == 2:
+        raw_obs = raw_obs[0]
+    if not isinstance(raw_obs, dict):
+        raise TypeError(f"Expected dict obs, got {type(raw_obs)}.")
+
+    images_obj = raw_obs[image_key]
+    images_dict = _unwrap_object_scalar(images_obj)
+    if not isinstance(images_dict, dict):
+        raise TypeError(f"Expected images_dict to be dict, got {type(images_dict)}.")
+    return {k: np.asarray(v, dtype=np.uint8) for k, v in images_dict.items()}
+
+
+def _cfg_get(cfg: Any, key: str, default: Any = None) -> Any:
+    """Fetch cfg value for dict/attr config."""
+    if cfg is None:
+        return default
+    if isinstance(cfg, dict):
+        return cfg.get(key, default)
+    return getattr(cfg, key, default)
+
+
+def _torch_clone_dict(x: Any) -> Any:
+    """Clone nested tensor structures, deepcopy non-tensors."""
+    if isinstance(x, torch.Tensor):
+        return x.clone()
+    if isinstance(x, dict):
+        return {k: _torch_clone_dict(v) for k, v in x.items()}
+    if isinstance(x, (list, tuple)):
+        return [_torch_clone_dict(v) for v in x]
+    return copy.deepcopy(x)
+
+
+# ==========================================================
+# SERLFrankaEnv (Maniskill-style)
+# ==========================================================
+class SERLFrankaEnv(gym.Env):
+    """SERL Franka wrapper aligned with ManiSkill env wrapper style."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        cfg: Any,
+        num_envs: int,
+        seed_offset: int,
+        total_num_processes: int,
+        worker_info: Any,
+        record_metrics: bool = True,
+    ):
+        """Initialize SERL wrapper.
+
+        Args:
+          cfg: Config object/dict.
+          num_envs: Number of parallel envs (manual list of gym envs).
+          seed_offset: Seed offset added to cfg.seed.
+          total_num_processes: Total num processes for interface parity.
+          worker_info: Worker metadata.
+          record_metrics: Whether to record episode metrics.
+        """
+        super().__init__()
+        env_seed = int(_cfg_get(cfg, "seed", 0))
+        self.seed = env_seed + int(seed_offset)
+
+        self.total_num_processes = int(total_num_processes)
+        self.worker_info = worker_info
+        self.cfg = cfg
+
+        self.auto_reset = bool(_cfg_get(cfg, "auto_reset", True))
+        self.use_rel_reward = bool(_cfg_get(cfg, "use_rel_reward", False))
+        self.ignore_terminations = bool(_cfg_get(cfg, "ignore_terminations", False))
+
+        self.num_group = int(num_envs) // int(_cfg_get(cfg, "group_size", 1))
+        self.group_size = int(_cfg_get(cfg, "group_size", 1))
+        self.use_fixed_reset_state_ids = bool(
+            _cfg_get(cfg, "use_fixed_reset_state_ids", False)
+        )
+
+        self.video_cfg = _cfg_get(cfg, "video_cfg", None)
+        self.video_cnt = 0
+        self.render_images: list[np.ndarray] = []
+
+        self.wrap_obs_mode = str(
+            _cfg_get(cfg, "wrap_obs_mode", _cfg_get(cfg, "obs_format", "openvla"))
+        ).lower()
+        self.obs_mode = str(_cfg_get(cfg, "obs_mode", "state")).lower()
+        self.obs_mode = (
+            "rgb" if self.obs_mode in ("rgb", "image", "vision") else "state"
+        )
+
+        self.state_key = str(_cfg_get(cfg, "state_key", "states"))
+        self.image_key = str(_cfg_get(cfg, "image_key", "images"))
+
+        self.main_camera = str(
+            _cfg_get(cfg, "main_camera", _cfg_get(cfg, "camera", "front"))
+        )
+        self.extra_camera = str(_cfg_get(cfg, "extra_camera", "wrist"))
+        self.use_wrist_as_extra_view = bool(
+            _cfg_get(cfg, "use_wrist_as_extra_view", True)
+        )
+
+        self.task_prompt = str(_cfg_get(cfg, "task_prompt", "Pick up the cube."))
+
+        dev_str = str(_cfg_get(cfg, "device", "cpu"))
+        self._device = torch.device(dev_str)
+        if self._device.type == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError(f"cfg.device={dev_str} but CUDA is not available.")
+
+        self._configure_mujoco()
+
+        self.env_id = str(_cfg_get(cfg, "gym_id", "PandaPickCube-v0"))
+        self.envs = [self._make_env(i) for i in range(int(num_envs))]
+
+        self.single_action_space = self.envs[0].action_space
+        self.action_space = self.single_action_space
+
+        raw0, _ = self.envs[0].reset(seed=self.seed)
+        self._state_dim = int(extract_serl_state(raw0, self.state_key).shape[0])
+        self._init_observation_space(raw0)
+
+        # Maniskill-style metrics fields.
+        self.prev_step_reward = torch.zeros(self.num_envs, dtype=torch.float32).to(
+            self.device
+        )
+        self.record_metrics = bool(record_metrics)
+        self._is_start = True
+        self._elapsed_steps = torch.zeros(
+            self.num_envs, dtype=torch.int32, device=self.device
+        )
+        self._needs_reset = torch.zeros(
+            self.num_envs, dtype=torch.bool, device=self.device
+        )
+
+        self._init_reset_state_ids()
+        self.info_logging_keys = ["success", "fail"]
+        if self.record_metrics:
+            self._init_metrics()
+
+        self._last_obs: Optional[dict[str, Any]] = None
+        self._last_info: dict[str, Any] = {}
+
+    # -------------------- properties (match ManiSkill wrapper) --------------------
+    @property
+    def total_num_group_envs(self) -> int:
+        return np.iinfo(np.uint8).max // 2
+
+    @property
+    def num_envs(self) -> int:
+        return len(self.envs)
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    @property
+    def elapsed_steps(self) -> torch.Tensor:
+        return self._elapsed_steps
+
+    @property
+    def is_start(self) -> bool:
+        return self._is_start
+
+    @is_start.setter
+    def is_start(self, value: bool) -> None:
+        self._is_start = bool(value)
+
+    @property
+    def instruction(self) -> list[str]:
+        return [self.task_prompt] * self.num_envs
+
+    # -------------------- init helpers --------------------
+    def _configure_mujoco(self) -> None:
+        if self.obs_mode == "rgb":
+            os.environ.setdefault(
+                "MUJOCO_GL", str(_cfg_get(self.cfg, "mujoco_gl", "egl"))
+            )
+            os.environ.setdefault("PYOPENGL_PLATFORM", "egl")
+            os.environ.setdefault("NVIDIA_DRIVER_CAPABILITIES", "all")
+        else:
+            os.environ.setdefault(
+                "MUJOCO_GL", str(_cfg_get(self.cfg, "mujoco_gl", "disable"))
+            )
+            self.video_cfg = None
+
+    def _make_env(self, env_idx: int) -> gym.Env:
+        kwargs = {}
+        if self.obs_mode == "rgb":
+            kwargs["image_obs"] = True
+            kwargs["render_mode"] = "rgb_array"
+        env = gym.make(self.env_id, disable_env_checker=True, **kwargs)
+        try:
+            env.reset(seed=self.seed + env_idx)
+        except Exception:
+            pass
+        return env
+
+    def _init_observation_space(self, raw0: Any) -> None:
+        if self.obs_mode != "rgb":
+            self.observation_space = gym.spaces.Dict(
+                {
+                    "states": gym.spaces.Box(
+                        low=-np.inf,
+                        high=np.inf,
+                        shape=(self.num_envs, self._state_dim),
+                        dtype=np.float32,
+                    ),
+                }
+            )
+            return
+
+        imgs = extract_serl_images_dict(raw0, self.image_key)
+        main = imgs.get(self.main_camera, imgs[sorted(imgs.keys())[0]])
+        h, w, c = main.shape
+        spaces = {
+            "main_images": gym.spaces.Box(
+                0, 255, shape=(self.num_envs, h, w, c), dtype=np.uint8
+            ),
+            "states": gym.spaces.Box(
+                -np.inf,
+                np.inf,
+                shape=(self.num_envs, self._state_dim),
+                dtype=np.float32,
+            ),
+        }
+        if self.use_wrist_as_extra_view:
+            spaces["extra_view_images"] = gym.spaces.Box(
+                0, 255, shape=(self.num_envs, 1, h, w, c), dtype=np.uint8
+            )
+        self.observation_space = gym.spaces.Dict(spaces)
+
+    # -------------------- reset-state ids (compat only) --------------------
+    def _init_reset_state_ids(self) -> None:
+        self.reset_state_ids = None
+
+    def update_reset_state_ids(self) -> None:
+        return
+
+    # -------------------- obs wrap (match ManiSkill style) --------------------
+    def _wrap_obs(self, raw_obs: Any) -> dict[str, Any]:
+        if self.obs_mode == "state":
+            state_np = extract_serl_state(raw_obs, self.state_key)
+            state = torch.from_numpy(state_np).to(self.device)
+            if self.wrap_obs_mode == "simple":
+                return {"states": state}
+            return {"states": state, "task_descriptions": self.task_prompt}
+
+        state_np = extract_serl_state(raw_obs, self.state_key)
+        state = torch.from_numpy(state_np).to(self.device)
+
+        main_np, extra_np = self._pick_images(raw_obs)
+        main = torch.from_numpy(np.ascontiguousarray(main_np, np.uint8)).to(self.device)
+        extra = torch.from_numpy(np.ascontiguousarray(extra_np, np.uint8)).to(
+            self.device
+        )
+        extra_view = extra.unsqueeze(0) if self.use_wrist_as_extra_view else None
+
+        if self.wrap_obs_mode == "simple":
+            return {
+                "main_images": main,
+                "extra_view_images": extra_view,
+                "states": state,
+            }
+        if self.wrap_obs_mode == "openpi":
+            return {
+                "main_images": main,
+                "wrist_images": extra,
+                "extra_view_images": extra_view,
+                "states": state,
+                "task_descriptions": self.task_prompt,
+            }
+        # default openvla
+        return {
+            "main_images": main,
+            "extra_view_images": extra_view,
+            "states": state,
+            "task_descriptions": self.task_prompt,
+        }
+
+    def _pick_images(self, raw_obs: dict) -> tuple[np.ndarray, np.ndarray]:
+        images = extract_serl_images_dict(raw_obs, self.image_key)
+        keys = sorted(images.keys())
+        main = images.get(self.main_camera, images[keys[0]])
+        extra = images.get(self.extra_camera, main)
+        return main, extra
+
+    def _collate_obs(self, obs_list: list[dict[str, Any]]) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        keys = set().union(*[o.keys() for o in obs_list])
+
+        for k in sorted(keys):
+            vals = [o.get(k, None) for o in obs_list]
+            if all(v is None for v in vals):
+                out[k] = None
+            elif isinstance(vals[0], torch.Tensor):
+                out[k] = torch.stack(vals, dim=0)
+            else:
+                out[k] = vals
+
+        # pad states to max dim
+        states = [o["states"].view(-1) for o in obs_list]
+        max_d = max((s.numel() for s in states), default=0)
+        padded = torch.zeros(
+            (len(states), max_d), dtype=torch.float32, device=self.device
+        )
+        for i, s in enumerate(states):
+            padded[i, : s.numel()] = s
+        out["states"] = padded
+        return out
+
+    def _collate_infos(self, info_list: list[dict]) -> dict[str, Any]:
+        keys = set().union(*[inf.keys() for inf in info_list if isinstance(inf, dict)])
+        out: dict[str, Any] = {}
+        for k in sorted(keys):
+            vals = [inf.get(k, None) for inf in info_list]
+            is_bool = all(isinstance(v, (bool, np.bool_)) or v is None for v in vals)
+            is_num = all(
+                isinstance(v, (int, float, np.number)) or v is None for v in vals
+            )
+            if is_bool:
+                out[k] = torch.tensor(
+                    [bool(v) if v is not None else False for v in vals],
+                    device=self.device,
+                    dtype=torch.bool,
+                )
+            elif is_num:
+                out[k] = torch.tensor(
+                    [float(v) if v is not None else 0.0 for v in vals],
+                    device=self.device,
+                    dtype=torch.float32,
+                )
+            else:
+                out[k] = vals
+        return out
+
+    # -------------------- reward / metrics (match ManiSkill style) --------------------
+    def _calc_step_reward(self, reward: torch.Tensor) -> torch.Tensor:
+        reward_diff = reward - self.prev_step_reward
+        self.prev_step_reward = reward
+        return reward_diff if self.use_rel_reward else reward
+
+    def _init_metrics(self) -> None:
+        self.success_once = torch.zeros(
+            self.num_envs, device=self.device, dtype=torch.bool
+        )
+        self.fail_once = torch.zeros(
+            self.num_envs, device=self.device, dtype=torch.bool
+        )
+        self.returns = torch.zeros(
+            self.num_envs, device=self.device, dtype=torch.float32
+        )
+
+    def _reset_metrics(self, env_idx: Optional[torch.Tensor] = None) -> None:
+        if env_idx is not None:
+            mask = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
+            mask[env_idx] = True
+            self.prev_step_reward[mask] = 0.0
+            self._elapsed_steps[mask] = 0
+            if self.record_metrics:
+                self.success_once[mask] = False
+                self.fail_once[mask] = False
+                self.returns[mask] = 0.0
+        else:
+            self.prev_step_reward[:] = 0.0
+            self._elapsed_steps[:] = 0
+            if self.record_metrics:
+                self.success_once[:] = False
+                self.fail_once[:] = False
+                self.returns[:] = 0.0
+
+    def _record_metrics(
+        self, step_reward: torch.Tensor, infos: dict[str, Any]
+    ) -> dict[str, Any]:
+        if not self.record_metrics:
+            return infos
+        episode_info: dict[str, Any] = {}
+        self.returns += step_reward
+        if "success" in infos:
+            self.success_once = self.success_once | infos["success"].bool()
+            episode_info["success_once"] = self.success_once.clone()
+        if "fail" in infos:
+            self.fail_once = self.fail_once | infos["fail"].bool()
+            episode_info["fail_once"] = self.fail_once.clone()
+
+        episode_info["return"] = self.returns.clone()
+        episode_info["episode_len"] = self.elapsed_steps.clone()
+        denom = torch.clamp(episode_info["episode_len"].float(), min=1.0)
+        episode_info["reward"] = episode_info["return"] / denom
+        infos["episode"] = episode_info
+        return infos
+
+    # -------------------- RLinf API: reset/step (match ManiSkill style) --------------------
+    def reset(
+        self,
+        *,
+        seed: Optional[Union[int, list[int]]] = None,
+        options: Optional[dict] = None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if options is None:
+            seed = self.seed if seed is None else seed
+            options = {}
+
+        env_idx = options.get("env_idx", None) if isinstance(options, dict) else None
+        reset_options = dict(options)
+        reset_options.pop("env_idx", None)
+
+        if env_idx is None:
+            idxs = range(self.num_envs)
+            self._reset_metrics()
+            self._needs_reset[:] = False
+        else:
+            env_idx = torch.as_tensor(env_idx, dtype=torch.int64, device=self.device)
+            idxs = env_idx.detach().cpu().tolist()
+            self._reset_metrics(env_idx)
+            self._needs_reset[env_idx] = False
+
+        obs_list, info_list = [], []
+        for i in range(self.num_envs):
+            if i in idxs:
+                seed_i = None
+                if seed is not None:
+                    seed_i = (
+                        int(seed[i])
+                        if isinstance(seed, (list, tuple, np.ndarray))
+                        else int(seed) + i
+                    )
+                raw_obs, info = self.envs[i].reset(seed=seed_i, options=reset_options)
+                obs_list.append(self._wrap_obs(raw_obs))
+                info_list.append(info if isinstance(info, dict) else {})
+            else:
+                obs_list.append(self._index_cached_obs(i))
+                info_list.append({})
+
+        obs = self._collate_obs(obs_list)
+        infos = self._collate_infos(info_list)
+
+        self._is_start = True
+        self._last_obs, self._last_info = obs, infos
+        return obs, infos
+
+    def step(
+        self,
+        actions: Union[np.ndarray, torch.Tensor],
+        auto_reset: bool = True,
+    ) -> tuple[
+        dict[str, Any], torch.Tensor, torch.Tensor, torch.Tensor, dict[str, Any]
+    ]:
+        act_np = self._normalize_actions(actions)
+
+        obs_list, info_list = [], []
+        rew_list, term_list, trunc_list = [], [], []
+        stepped_mask = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
+
+        for i, env in enumerate(self.envs):
+            obs_i, info_i, rew_i, term_i, trunc_i, stepped = self._step_one_env(
+                env_idx=i,
+                env=env,
+                action=act_np[i],
+                auto_reset=auto_reset,
+            )
+            obs_list.append(obs_i)
+            info_list.append(info_i)
+            rew_list.append(rew_i)
+            term_list.append(term_i)
+            trunc_list.append(trunc_i)
+            stepped_mask[i] = stepped
+
+        self._elapsed_steps[stepped_mask] += 1
+
+        obs = self._collate_obs(obs_list)
+        infos = self._collate_infos(info_list)
+
+        raw_reward = torch.tensor(rew_list, device=self.device, dtype=torch.float32)
+        step_reward = self._calc_step_reward(raw_reward)
+
+        reward_scale = float(_cfg_get(self.cfg, "reward_scale", 1e5))
+        step_reward = step_reward * reward_scale
+
+        terminations = torch.tensor(term_list, device=self.device, dtype=torch.bool)
+        truncations = torch.tensor(trunc_list, device=self.device, dtype=torch.bool)
+
+        if self.video_cfg and getattr(self.video_cfg, "save_video", False):
+            self.add_new_frames_from_obs(obs)
+
+        infos = self._record_metrics(step_reward, infos)
+
+        if self.ignore_terminations:
+            terminations[:] = False
+            if self.record_metrics and "episode" in infos:
+                if "success" in infos:
+                    infos["episode"]["success_at_end"] = infos["success"].clone()
+                if "fail" in infos:
+                    infos["episode"]["fail_at_end"] = infos["fail"].clone()
+
+        dones = torch.logical_or(terminations, truncations)
+
+        _auto_reset = bool(auto_reset) and bool(self.auto_reset)
+        if dones.any() and _auto_reset:
+            if self.video_cfg and getattr(self.video_cfg, "save_video", False):
+                self.flush_video(video_sub_dir="eval")
+            obs, infos = self._handle_auto_reset(dones, obs, infos)
+
+        self._last_obs, self._last_info = obs, infos
+        return obs, step_reward, terminations, truncations, infos
+
+    def _normalize_actions(
+        self, actions: Union[np.ndarray, torch.Tensor]
+    ) -> np.ndarray:
+        act_np = (
+            actions.detach().cpu().numpy()
+            if isinstance(actions, torch.Tensor)
+            else np.asarray(actions)
+        )
+        if act_np.ndim == 1:
+            act_np = np.repeat(act_np[None, :], self.num_envs, axis=0)
+        if act_np.shape[0] != self.num_envs:
+            raise ValueError(
+                "Invalid action batch dimension. Expected shape [num_envs, act_dim] "
+                f"with num_envs={self.num_envs}, got {act_np.shape}."
+            )
+        return act_np.astype(np.float32, copy=False)
+
+    def _step_one_env(
+        self,
+        env_idx: int,
+        env: gym.Env,
+        action: np.ndarray,
+        auto_reset: bool,
+    ) -> tuple[dict[str, Any], dict, float, bool, bool, bool]:
+        if self._needs_reset[env_idx]:
+            if auto_reset and self.auto_reset:
+                env.reset()
+                self._needs_reset[env_idx] = False
+                self._reset_metrics(torch.tensor([env_idx], device=self.device))
+            else:
+                return self._index_cached_obs(env_idx), {}, 0.0, True, False, False
+
+        out = env.step(np.clip(action.reshape(-1), -1.0, 1.0))
+        if len(out) == 5:
+            raw_obs, rew, terminated, truncated, info = out
+        else:
+            raw_obs, rew, done, info = out
+            terminated, truncated = bool(done), False
+
+        obs = self._wrap_obs(raw_obs)
+        info = info if isinstance(info, dict) else {}
+        return obs, info, float(rew), bool(terminated), bool(truncated), True
+
+    def _index_cached_obs(self, env_idx: int) -> dict[str, Any]:
+        if self._last_obs is None:
+            raw_obs, _ = self.envs[env_idx].reset()
+            return self._wrap_obs(raw_obs)
+        out: dict[str, Any] = {}
+        for k, v in self._last_obs.items():
+            if isinstance(v, torch.Tensor) and v.shape[0] == self.num_envs:
+                out[k] = v[env_idx]
+            elif isinstance(v, list) and len(v) == self.num_envs:
+                out[k] = v[env_idx]
+            else:
+                out[k] = v
+        return out
+
+    def _handle_auto_reset(
+        self,
+        dones: torch.Tensor,
+        obs: dict[str, Any],
+        infos: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        final_obs = _torch_clone_dict(obs)
+        final_info = _torch_clone_dict(infos)
+
+        env_idx = torch.arange(0, self.num_envs, device=self.device)[dones]
+        obs, infos = self.reset(options={"env_idx": env_idx})
+
+        infos = dict(infos)
+        infos["final_observation"] = final_obs
+        infos["final_info"] = final_info
+        infos["_final_info"] = dones
+        infos["_final_observation"] = dones
+        infos["_elapsed_steps"] = dones
+        return obs, infos
+
+    # -------------------- chunk_step / sample_action_space (match ManiSkill style) --------------------
+    def chunk_step(self, chunk_actions: Union[np.ndarray, torch.Tensor]):
+        chunk_actions = (
+            chunk_actions
+            if isinstance(chunk_actions, torch.Tensor)
+            else torch.from_numpy(np.asarray(chunk_actions))
+        )
+        if chunk_actions.ndim != 3:
+            raise ValueError(
+                "chunk_actions must have shape [num_envs, chunk_steps, act_dim], "
+                f"got {tuple(chunk_actions.shape)}."
+            )
+
+        chunk_size = int(chunk_actions.shape[1])
+        chunk_rewards, raw_terms, raw_truncs = [], [], []
+        infos: dict[str, Any] = {}
+
+        for i in range(chunk_size):
+            actions = chunk_actions[:, i].to(self.device)
+            obs, rew, term, trunc, infos = self.step(actions, auto_reset=False)
+            chunk_rewards.append(rew)
+            raw_terms.append(term)
+            raw_truncs.append(trunc)
+
+        chunk_rewards = torch.stack(chunk_rewards, dim=1)
+        raw_terms = torch.stack(raw_terms, dim=1)
+        raw_truncs = torch.stack(raw_truncs, dim=1)
+
+        past_terminations = raw_terms.any(dim=1)
+        past_truncations = raw_truncs.any(dim=1)
+        past_dones = torch.logical_or(past_terminations, past_truncations)
+
+        if past_dones.any() and self.auto_reset:
+            obs, infos = self._handle_auto_reset(past_dones, obs, infos)
+
+        chunk_terminations = torch.zeros_like(raw_terms)
+        chunk_terminations[:, -1] = past_terminations
+
+        chunk_truncations = torch.zeros_like(raw_truncs)
+        chunk_truncations[:, -1] = past_truncations
+
+        return obs, chunk_rewards, chunk_terminations, chunk_truncations, infos
+
+    def sample_action_space(self) -> torch.Tensor:
+        a = self.action_space.sample()
+        return torch.from_numpy(np.asarray(a, dtype=np.float32)).to(self.device)
+
+    # -------------------- video helpers (match ManiSkill style) --------------------
+    def add_new_frames_from_obs(self, obs: dict[str, Any]) -> None:
+        if "main_images" not in obs:
+            return
+        raw_imgs = obs["main_images"].detach().cpu().numpy()
+        full_img = rlinf_utils.tile_images(
+            list(raw_imgs), nrows=int(np.sqrt(self.num_envs))
+        )
+        self.render_images.append(full_img)
+
+    def flush_video(self, video_sub_dir: Optional[str] = None) -> None:
+        if not (self.video_cfg and getattr(self.video_cfg, "save_video", False)):
+            return
+        output_dir = os.path.join(self.video_cfg.video_base_dir, f"seed_{self.seed}")
+        if video_sub_dir:
+            output_dir = os.path.join(output_dir, video_sub_dir)
+        rlinf_utils.save_rollout_video(
+            self.render_images,
+            output_dir=output_dir,
+            video_name=f"{self.video_cnt}",
+        )
+        self.video_cnt += 1
+        self.render_images = []


### PR DESCRIPTION
### Description
This PR adds support for MuJoCo benchmarks in RLinf, including environment integration, example configs, and user-facing documentation.

Key changes:
- Added MuJoCo benchmark environment implementation and registration.
- Added PPO-MLP configuration for MuJoCo benchmark runs.
- Added documentation pages for MuJoCo examples in both English and Chinese, and updated the examples index.

### Motivation and Context
RLinf currently lacks a built-in MuJoCo benchmark entrypoint and documented configuration examples. This PR enables users to run MuJoCo benchmark experiments out-of-the-box with a standard PPO-MLP setup, while providing clear documentation for reproducibility.

### How has this been tested?
Not included in this PR yet.

### Additional information (optional, e.g., figures and logs):
- Franka simulation assets are intentionally excluded from this PR and should be managed separately to avoid large binary files in the repository.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
