### PR TITLE
feat: enhance timing metrics collection in runners

### DIFF
--- a/rlinf/runners/agent_eval_runner.py
+++ b/rlinf/runners/agent_eval_runner.py
@@ -335,8 +335,12 @@ class AgentEvalRunner(ReasoningEvalRunner):
                     total_samples += batch_count
 
                 time_metrics = self.timer.consume_durations()
-                time_metrics["rollout"] = rollout_handle.consume_duration()
-                time_metrics["reward"] = reward_handle.consume_duration()
+                time_metrics["rollout"] = rollout_handle.consume_durations()[
+                    "run_agentloop_rollout"
+                ]
+                time_metrics["reward"] = reward_handle.consume_durations()[
+                    "compute_rewards"
+                ]
 
                 # Update progress bar with current metrics
                 current_accuracy = (

--- a/rlinf/runners/agent_runner.py
+++ b/rlinf/runners/agent_runner.py
@@ -266,17 +266,23 @@ class AgentRunner(ReasoningRunner):
                             return
 
                     time_metrics = self.timer.consume_durations()
-                    time_metrics["training"] = actor_handle.consume_duration()
-                    time_metrics["rollout"] = rollout_handle.consume_duration()
+                    time_metrics["training"] = actor_handle.consume_durations()[
+                        "run_training"
+                    ]
+                    time_metrics["rollout"] = rollout_handle.consume_durations()[
+                        "run_agentloop_rollout"
+                    ]
                     if self.reward is not None:
-                        time_metrics["reward"] = reward_handle.consume_duration()
+                        time_metrics["reward"] = reward_handle.consume_durations()[
+                            "compute_rewards"
+                        ]
                     if infer_handle is not None:
                         # Inference time should be the min time across ranks, because different DP receive the rollout results differently
                         # But at the begin of the pp schedule, there is a timer barrier
                         # This makes all DP end at the same time, while they start at differnt times, and thus only the min time is correct
-                        time_metrics["inference"] = infer_handle.consume_duration(
+                        time_metrics["inference"] = infer_handle.consume_durations(
                             reduction_type="min"
-                        )
+                        )["run_inference"]
 
                     logging_steps = (
                         self.global_steps - 1

--- a/rlinf/runners/coding_online_rl_runner.py
+++ b/rlinf/runners/coding_online_rl_runner.py
@@ -261,14 +261,14 @@ class CodingOnlineRLRunner:
                 rollout_handle.wait()
 
             time_metrics = self.timer.consume_durations()
-            time_metrics["training"] = actor_handle.consume_duration()
+            time_metrics["training"] = actor_handle.consume_durations()["run_training"]
             if infer_handle is not None:
                 # Inference time should be the min time across ranks, because different DP receive the rollout results differently
                 # But at the begin of the pp schedule, there is a timer barrier
                 # This makes all DP end at the same time, while they start at differnt times, and thus only the min time is correct
-                time_metrics["inference"] = infer_handle.consume_duration(
+                time_metrics["inference"] = infer_handle.consume_durations(
                     reduction_type="min"
-                )
+                )["run_inference"]
 
             logging_steps = (self.global_steps - 1) * self.cfg.algorithm.n_minibatches
             # add prefix to the metrics

--- a/rlinf/runners/reasoning_runner.py
+++ b/rlinf/runners/reasoning_runner.py
@@ -451,16 +451,20 @@ class ReasoningRunner:
                         return
 
                 time_metrics = self.timer.consume_durations()
-                time_metrics["training"] = actor_handle.consume_duration()
-                time_metrics["rollout"] = rollout_handle.consume_duration()
-                time_metrics["reward"] = reward_handle.consume_duration()
+                time_metrics["training"] = actor_handle.consume_durations()[
+                    "run_training"
+                ]
+                time_metrics["rollout"] = rollout_handle.consume_durations()["rollout"]
+                time_metrics["reward"] = reward_handle.consume_durations()[
+                    "compute_rewards"
+                ]
                 if infer_handle is not None:
                     # Inference time should be the min time across ranks, because different DP receive the rollout results differently
                     # But at the begin of the pp schedule, there is a timer barrier
                     # This makes all DP end at the same time, while they start at differnt times, and thus only the min time is correct
-                    time_metrics["inference"] = infer_handle.consume_duration(
+                    time_metrics["inference"] = infer_handle.consume_durations(
                         reduction_type="min"
-                    )
+                    )["run_inference"]
 
                 logging_steps = (
                     self.global_steps - 1

--- a/rlinf/runners/sft_runner.py
+++ b/rlinf/runners/sft_runner.py
@@ -117,7 +117,7 @@ class SFTRunner:
                     self._save_checkpoint()
 
             time_metrics = self.timer.consume_durations()
-            time_metrics["training"] = actor_handle.consume_duration()
+            time_metrics["training"] = actor_handle.consume_durations()["run_training"]
             time_metrics = {f"time/{k}": v for k, v in time_metrics.items()}
             training_metrics = {f"train/{k}": v for k, v in actor_metrics[0].items()}
             self.metric_logger.log(time_metrics, _step)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
The timer utility for Workers in RLinf currently does not support multiple tags or usage as a decorator on class methods, despite our documentation stating that both features are supported: https://rlinf.readthedocs.io/en/latest/rst_source/tutorials/user/worker.html

This PR:
- Update timing metrics in various runners to use the new `consume_durations` method for better granularity and accuracy.
- Add support for optional reduction types in the `consume_durations` method to allow for flexible execution time analysis.
- Introduce a decorator for timing methods in the Worker class to streamline performance tracking.

This improves the overall performance monitoring capabilities across the codebase.

By the way, this PR will change the default behavior of consume_durations, for it will return a dict[str, float | list[float]], rather than a float.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.