### PR TITLE
feat(dexbotic): support models from Dexbotic

### DIFF
--- a/examples/embodiment/config/libero_spatial_ppo_dexbotic_pi0.yaml
+++ b/examples/embodiment/config/libero_spatial_ppo_dexbotic_pi0.yaml
@@ -1,0 +1,168 @@
+defaults:
+  - env/libero_spatial@env.train
+  - env/libero_spatial@env.eval
+  - model/dexbotic@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: all
+
+runner:
+  task_type: embodied
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_spatial_ppo_dexbotic_pi0"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 1000
+  max_steps: 10
+
+  only_eval: False
+  eval_policy_path: null
+  val_check_interval: -1
+  save_interval: 50
+
+  resume_dir: null
+
+algorithm:
+  normalize_advantages: True
+  kl_penalty: kl
+  group_size: 1
+  reward_coef: 1.0
+
+  rollout_epoch: 1
+  eval_rollout_epoch: 1
+
+  reward_type: chunk_level
+  logprob_type: chunk_level
+  entropy_type: token_level
+
+  update_epoch: 4
+  adv_type: gae
+  loss_type: actor_critic
+  loss_agg_func: "token-mean"
+  kl_beta: 0.0
+  entropy_bonus: 0
+  clip_ratio_high: 0.2
+  clip_ratio_low: 0.2
+  clip_ratio_c: 3.0
+  value_clip: 0.2
+  huber_delta: 10.0
+
+  gamma: 0.99
+  gae_lambda: 0.95
+
+  filter_rewards: False
+  rewards_lower_bound: 0.1
+  rewards_upper_bound: 0.9
+
+  sampling_params:
+    do_sample: True
+    temperature_train: 1.0
+    temperature_eval: 0.6
+    top_k: 50
+    top_p: 1.0
+    repetition_penalty: 1.0
+    add_BOS: False
+
+  length_params:
+    max_new_token: null
+    max_length: 1024
+    min_length: 1
+
+env:
+  group_name: "EnvGroup"
+  enable_offload: False
+
+  train:
+    total_num_envs: 16
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 240
+    video_cfg:
+      save_video: True
+  eval:
+    total_num_envs: 1
+    auto_reset: True
+    ignore_terminations: True
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 240
+    group_size: 1
+    is_eval: True
+    video_cfg:
+      save_video: False
+      video_base_dir: ${runner.logger.log_path}/video/eval
+
+rollout:
+  group_name: "RolloutGroup"
+  generation_backend: "huggingface"
+  recompute_logprobs: False
+  unnorm_key: libero_spatial
+  enable_offload: True
+  pipeline_stage_num: 1
+
+  model:
+    model_path: "/path/to/model/Dexbotic-Pi05-SFT" # https://huggingface.co/Dexmal/libero-db-pi0
+    precision: ${actor.model.precision}
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 4
+  global_batch_size: 128
+  seed: 42
+  enable_offload: True
+
+  model:
+    model_path: "/path/to/model/Dexbotic-Pi05-SFT"
+    precision: "bf16"
+    num_action_chunks: 5
+    num_steps: 4
+    action_dim: 7
+    add_value_head: True
+    dexbotic:
+      num_images_in_input: 2
+      noise_level: 0.5
+      action_chunk: ${actor.model.num_action_chunks}
+      num_steps: ${actor.model.num_steps}
+      train_expert_only: True
+      action_env_dim: ${actor.model.action_dim}
+      noise_method: "flow_sde"
+      add_value_head: ${actor.model.add_value_head}
+      detach_critic_input: True
+
+  optim:
+    lr: 1.0e-6
+    value_lr: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-08
+    weight_decay: 0.01
+    clip_grad: 1.0
+    critic_warmup_steps: 0
+
+  fsdp_config:
+    strategy: "fsdp"
+    sharding_strategy: "full_shard"
+    gradient_checkpointing: False
+    use_orig_params: False
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+
+reward:
+  use_reward_model: False
+
+critic:
+  use_critic_model: False

--- a/examples/embodiment/config/model/dexbotic.yaml
+++ b/examples/embodiment/config/model/dexbotic.yaml
@@ -1,0 +1,38 @@
+model_type: "dexbotic"
+
+# Model path - should be set in specific config files
+model_path: "/path/to/model/dexbotic"
+
+precision: null
+
+# Action and chunk settings
+num_action_chunks: 50  # Dexbotic uses 50 (trajectory_length)
+action_dim: 7  # Environment action dimension (Libero uses 7)
+
+# LoRA settings
+is_lora: False
+lora_rank: 32
+
+# Training settings
+use_proprio: True
+num_steps: 10  # Number of diffusion/denoising steps
+add_value_head: True  # Add value head for PPO
+
+# RL training specific settings
+safe_get_logprob: False  # Use simplified logprob calculation (False = full Gaussian)
+chunk_critic_input: True  # Use only action chunk for critic (not full sequence)
+noise_anneal: False  # Whether to anneal noise during training
+joint_logprob: False  # Whether to include initial state in logprob (False = only transitions)
+value_after_vlm: False  # Whether value head comes after VLM (False = after action expert)
+
+# dexbotic specific parameters
+dexbotic:
+  num_images_in_input: 2  # Number of camera views
+  noise_level: 0.5  # Noise level for flow matching
+  action_chunk: ${actor.model.num_action_chunks}
+  num_steps: ${actor.model.num_steps}
+  train_expert_only: True  # Whether to only train action expert
+  action_env_dim: ${actor.model.action_dim}
+  noise_method: "flow_sde"  # Flow matching method
+  add_value_head: ${actor.model.add_value_head}
+  detach_critic_input: False

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -54,6 +54,7 @@ class SupportedModel(Enum):
     OPENPI = ("openpi", "embodied")
     MLP_POLICY = ("mlp_policy", "embodied")
     GR00T = ("gr00t", "embodied")
+    DEXBOTIC = ("dexbotic", "embodied")
     CNN_POLICY = ("cnn_policy", "embodied")
     FLOW_POLICY = ("flow_policy", "embodied")
     CMA_POLICY = ("cma", "embodied")

--- a/rlinf/models/__init__.py
+++ b/rlinf/models/__init__.py
@@ -26,6 +26,8 @@ def get_model(cfg: DictConfig):
         from rlinf.models.embodiment.openvla_oft import get_model
     elif model_type == SupportedModel.OPENPI:
         from rlinf.models.embodiment.openpi import get_model
+    elif model_type == SupportedModel.DEXBOTIC:
+        from rlinf.models.embodiment.dexbotic import get_model
     elif model_type == SupportedModel.MLP_POLICY:
         from rlinf.models.embodiment.mlp_policy import get_model
     elif model_type == SupportedModel.GR00T:

--- a/rlinf/models/embodiment/dexbotic/__init__.py
+++ b/rlinf/models/embodiment/dexbotic/__init__.py
@@ -1,0 +1,1085 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# dexbotic model configs
+
+import json
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+from dexbotic.data.dataset.transform.action import ActionNorm, PadState
+from dexbotic.data.dataset.transform.common import Pipeline, ToNumpy, ToTensor
+from dexbotic.data.dataset.transform.output import AbsoluteAction, ActionDenorm
+from dexbotic.model.pi0.pi0_arch import (
+    Pi0ForCausalLM,
+    make_attn_mask,
+    make_attn_mask_4d,
+)
+from dexbotic.tokenization.process import Pi0Tokenization
+from loguru import logger
+from omegaconf import DictConfig
+from PIL import Image
+from transformers import AutoTokenizer, DynamicCache
+
+from rlinf.models.embodiment.base_policy import BasePolicy
+
+
+def make_att_2d_masks(pad_masks, att_masks):
+    return make_attn_mask(pad_masks, att_masks)
+
+
+class DexboticPolicy:
+    def __init__(
+        self,
+        model_path: str,
+        action_dim: int = 7,
+        num_images: int = 3,
+        non_delta_mask: list = None,
+        device: str = "cuda",
+    ):
+        self.model_path = model_path
+        self.action_dim = action_dim
+        self.num_images = num_images
+        self.non_delta_mask = non_delta_mask or [6]
+        self.device = torch.device(device if torch.cuda.is_available() else "cpu")
+
+        norm_stats_file = os.path.join(model_path, "norm_stats.json")
+        self.norm_stats = self._read_normalization_stats(norm_stats_file)
+
+        self._load_model()
+
+        self.timestep = 0
+        self.episode = 0
+        self.prev_text = None
+
+    def _read_normalization_stats(self, norm_stats_file):
+        if not os.path.exists(norm_stats_file):
+            raise FileNotFoundError(
+                f"Normalization stats not found at {norm_stats_file}. "
+                "Make sure the checkpoint directory contains norm_stats.json"
+            )
+        with open(norm_stats_file, "r") as f:
+            norm_stats = json.load(f)
+            if "norm_stats" in norm_stats:
+                norm_stats = norm_stats["norm_stats"]
+        return ToNumpy()(norm_stats)
+
+    def _load_model(self):
+        # Set HF_HUB_OFFLINE to prevent any network access during model loading
+        import os
+
+        original_offline = os.environ.get("HF_HUB_OFFLINE", None)
+        os.environ["HF_HUB_OFFLINE"] = "1"
+
+        try:
+            self.model = Pi0ForCausalLM.from_pretrained(
+                self.model_path,
+                torch_dtype=None,
+                low_cpu_mem_usage=True,
+                trust_remote_code=True,
+                device_map="auto",
+                local_files_only=True,
+            ).to(self.device)
+        finally:
+            if original_offline is None:
+                os.environ.pop("HF_HUB_OFFLINE", None)
+            else:
+                os.environ["HF_HUB_OFFLINE"] = original_offline
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.model_path, use_fast=False, local_files_only=True
+        )
+
+        self.tokenization_func = Pi0Tokenization(self.tokenizer)
+        self.input_transform = Pipeline(
+            [
+                PadState(ndim=self.model.model.config.action_dim, axis=-1),
+                ActionNorm(statistic_mapping=self.norm_stats, strict=False),
+                ToTensor(),
+            ]
+        )
+        self.output_transform = Pipeline(
+            [
+                ToNumpy(),
+                ActionDenorm(statistic_mapping=self.norm_stats, strict=False),
+                AbsoluteAction(),
+            ]
+        )
+
+    def reset(self):
+        self.timestep = 0
+        self.episode += 1
+        self.prev_text = None
+
+    def infer(self, observation: dict) -> dict:
+        base_image = observation["observation/image"]
+        wrist_image = observation["observation/wrist_image"]
+        state = observation["observation/state"]
+        text = observation["prompt"]
+
+        images = [
+            Image.fromarray(base_image.astype(np.uint8)),
+            Image.fromarray(wrist_image.astype(np.uint8)),
+        ]
+
+        batch_images_tensor = [
+            self.model.process_images(images).to(dtype=self.model.dtype)
+        ]
+
+        num_input_images = len(images)
+        if num_input_images < self.num_images:
+            batch_images_tensor = [
+                torch.cat(
+                    [
+                        image_tensor,
+                        torch.zeros_like(image_tensor[0:1]).repeat(
+                            self.num_images - num_input_images, 1, 1, 1
+                        ),
+                    ],
+                    dim=0,
+                )
+                for image_tensor in batch_images_tensor
+            ]
+        batch_image_masks = [
+            torch.tensor(
+                [True for _ in range(num_input_images)]
+                + [False for _ in range(self.num_images - num_input_images)],
+                device=self.device,
+            )
+        ]
+        batch_images_tensor = torch.stack(batch_images_tensor, dim=0)
+        batch_image_masks = torch.stack(batch_image_masks, dim=0)
+        batch_input_ids = np.array(
+            [self.tokenization_func([{"value": text}])["input_ids"]]
+        )
+        batch_attention_mask = np.array(
+            [np.array(ids != self.tokenizer.pad_token_id) for ids in batch_input_ids]
+        )
+        batch_states = np.array([state], dtype=np.float32)
+        inference_args = {
+            "input_ids": batch_input_ids,
+            "attention_mask": batch_attention_mask,
+            "images": batch_images_tensor,
+            "image_masks": batch_image_masks,
+            "state": batch_states,
+            "meta_data": {
+                "non_delta_mask": np.array(self.non_delta_mask),
+            },
+        }
+        inputs = self.input_transform(inference_args)
+        inputs["states"] = inputs["state"]
+        inputs = {
+            k: v.to(self.device) if isinstance(v, torch.Tensor) else v
+            for k, v in inputs.items()
+        }
+        with torch.no_grad():
+            actions = self.model.inference_action(**inputs)
+        outputs = {
+            k: v.detach().cpu().numpy() if isinstance(v, torch.Tensor) else v
+            for k, v in inputs.items()
+        }
+        outputs["action"] = actions.detach().cpu().numpy()
+        outputs = self.output_transform(outputs)
+        action_sequence = outputs["action"][0, :, : self.action_dim]
+        self.timestep += 1
+
+        return {"actions": action_sequence}
+
+
+def setup_policy(args):
+    policy = DexboticPolicy(
+        model_path=args.pretrained_path,
+        action_dim=getattr(args, "action_dim", 7),
+        num_images=getattr(args, "num_images", 3),
+        non_delta_mask=getattr(args, "non_delta_mask", [6]),
+        device=getattr(args, "device", "cuda"),
+    )
+    return policy
+
+
+class DexboticPi0ForRLActionPrediction(BasePolicy, Pi0ForCausalLM):
+    def __init__(self, config):
+        Pi0ForCausalLM.__init__(self, config)
+        model_dtype = None
+        if (
+            hasattr(self.model, "llm")
+            and hasattr(self.model.llm, "layers")
+            and len(self.model.llm.layers) > 0
+        ):
+            first_layer = self.model.llm.layers[0]
+            for param in first_layer.parameters():
+                model_dtype = param.dtype
+                break
+        elif (
+            hasattr(self.model, "action_expert")
+            and hasattr(self.model.action_expert, "layers")
+            and len(self.model.action_expert.layers) > 0
+        ):
+            first_layer = self.model.action_expert.layers[0]
+            for param in first_layer.parameters():
+                model_dtype = param.dtype
+                break
+        if model_dtype is None:
+            all_params = list(self.model.parameters())
+            if all_params:
+                model_dtype = all_params[0].dtype
+            else:
+                model_dtype = torch.float32
+        self.model = self.model.to(dtype=model_dtype)
+
+        if hasattr(self.model, "action_expert") and hasattr(
+            self.model.action_expert, "embed_tokens"
+        ):
+            self.model.action_expert.embed_tokens = None
+        for name, module in self.named_modules():
+            path_parts = name.split(".")
+            setattr(module, "_fsdp_wrap_name", path_parts[-1] if path_parts else name)
+
+        self.config = config
+        self.num_steps = config.num_steps
+        self.action_horizon = config.chunk_size
+        self.num_action_chunks = getattr(
+            config, "output_action_chunks", config.chunk_size
+        )
+        self.action_dim = config.action_dim
+        self.non_delta_mask = getattr(
+            config, "non_delta_mask", [6]
+        )  # Indices of absolute actions (default: [6] for gripper)
+        self.global_step = 0
+        self.use_vlm_value = False
+        self.value_head = nn.Linear(config.action_config.hidden_size, 1)
+        self.value_head = self.value_head.to(
+            dtype=self.model.action_out_proj.weight.dtype
+        )
+        self._input_transform = None
+        self._output_transform = None
+        self.norm_stats = None
+        self.pi0_tokenization = None
+
+    def freeze_vlm(self):
+        if not getattr(self.config, "train_expert_only", False):
+            logger.warning("freeze_vlm() called but train_expert_only is False")
+            return
+        # Freeze vision tower
+        if (
+            hasattr(self.model, "mm_vision_tower")
+            and self.model.mm_vision_tower is not None
+        ):
+            self.model.mm_vision_tower.eval()
+            for param in self.model.mm_vision_tower.parameters():
+                param.requires_grad = False
+        # Freeze LLM
+        if hasattr(self.model, "llm") and self.model.llm is not None:
+            self.model.llm.eval()
+            for param in self.model.llm.parameters():
+                param.requires_grad = False
+        # Freeze mm_projector
+        if hasattr(self.model, "mm_projector") and self.model.mm_projector is not None:
+            self.model.mm_projector.eval()
+            for param in self.model.mm_projector.parameters():
+                param.requires_grad = False
+
+    def _read_normalization_stats(self, norm_stats_file):
+        if not os.path.exists(norm_stats_file):
+            raise FileNotFoundError(
+                f"Normalization stats not found at {norm_stats_file}. "
+                "Make sure the checkpoint directory contains norm_stats.json"
+            )
+        with open(norm_stats_file, "r") as f:
+            norm_stats = json.load(f)
+            if "norm_stats" in norm_stats:
+                norm_stats = norm_stats["norm_stats"]
+        from dexbotic.data.dataset.transform.common import ToNumpy
+
+        return ToNumpy()(norm_stats)
+
+    def setup_wrappers(self, transforms=(), output_transforms=()):
+        if transforms:
+            self._input_transform = Pipeline(transforms)
+        else:
+            self._input_transform = None
+
+        if output_transforms:
+            self._output_transform = Pipeline(output_transforms)
+        else:
+            self._output_transform = None
+
+    def output_transform(self, outputs):
+        if self._output_transform is None:
+            return outputs
+
+        batch_size = outputs["actions"].shape[0]
+        transformed_actions = []
+        state_batch = outputs.get("state", None)
+        meta_data = outputs.get("meta_data", {})
+
+        for i in range(batch_size):
+            sample = {"action": outputs["actions"][i].cpu().numpy()}
+            if state_batch is not None:
+                if isinstance(state_batch, torch.Tensor):
+                    sample["state"] = state_batch[i].cpu().numpy()
+                else:
+                    sample["state"] = state_batch[i]
+            if meta_data:
+                sample["meta_data"] = meta_data
+            sample = self._output_transform(sample)
+            transformed_actions.append(torch.from_numpy(sample["action"]))
+
+        outputs["actions"] = torch.stack(transformed_actions, dim=0).to(
+            outputs["actions"].device
+        )
+        return outputs
+
+    def input_transform(self, obs: dict, transpose=True):
+        if "prompt" in obs:
+            prompts = obs["prompt"]
+            if isinstance(prompts, str):
+                prompts = [prompts]
+            elif isinstance(prompts, torch.Tensor):
+                prompts = [str(p) for p in prompts]
+            batch_input_ids = []
+            for prompt in prompts:
+                tokenized = self.pi0_tokenization([{"value": prompt}])
+                batch_input_ids.append(tokenized["input_ids"])
+
+            batch_input_ids = torch.from_numpy(np.array(batch_input_ids))
+            batch_attention_mask = batch_input_ids != self.tokenizer.pad_token_id
+
+            obs["tokenized_prompt"] = batch_input_ids
+            obs["tokenized_prompt_mask"] = batch_attention_mask
+
+        if self._input_transform is not None:
+            if "observation/state" in obs:
+                state_tensor = obs["observation/state"]
+                if isinstance(state_tensor, torch.Tensor):
+                    state_value = state_tensor.cpu().float().numpy()
+                else:
+                    state_value = state_tensor
+
+                state_dict = {"state": state_value}
+                state_dict = self._input_transform(state_dict)
+
+                obs["observation/state"] = state_dict["state"]
+                obs["states"] = state_dict["state"]
+        return obs
+
+    def output_transform(self, outputs):
+        if self._output_transform is None:
+            logger.warning(
+                "[output_transform] WARNING: _output_transform is None! Actions will NOT be denormalized!"
+            )
+            return outputs
+
+        state_batch = outputs.get("state", None)
+        meta_data = outputs.get("meta_data", {})
+
+        batch_size = outputs["actions"].shape[0]
+        transformed_actions = []
+
+        for i in range(batch_size):
+            sample = {"action": outputs["actions"][i].cpu().numpy()}
+            if state_batch is not None:
+                if isinstance(state_batch, torch.Tensor):
+                    sample["state"] = state_batch[i].cpu().numpy()
+                else:
+                    sample["state"] = state_batch[i]
+            if meta_data:
+                sample["meta_data"] = meta_data
+            sample = self._output_transform(sample)
+
+            transformed_actions.append(torch.from_numpy(sample["action"]))
+
+        outputs["actions"] = torch.stack(transformed_actions, dim=0).to(
+            outputs["actions"].device
+        )
+        outputs["actions"] = outputs["actions"][:, : self.num_action_chunks]
+
+        return outputs
+
+    def precision_processor(self, processed_obs):
+        device = next(self.parameters()).device
+        for key, value in processed_obs.items():
+            if isinstance(value, list):
+                processed_obs[key] = [
+                    item.to(device=device).contiguous()
+                    if torch.is_tensor(item)
+                    else item
+                    for item in value
+                ]
+            elif torch.is_tensor(value):
+                processed_obs[key] = value.to(device=device).contiguous()
+            elif isinstance(value, dict):
+                for sub_key, sub_value in value.items():
+                    if torch.is_tensor(sub_value):
+                        processed_obs[key][sub_key] = sub_value.to(
+                            device=device
+                        ).contiguous()
+        return processed_obs
+
+    def forward(self, forward_type="default_forward", **kwargs):
+        if "forward_inputs" in kwargs and "data" not in kwargs:
+            kwargs["data"] = kwargs.pop("forward_inputs")
+
+        if forward_type == "default_forward":
+            return self.default_forward(**kwargs)
+        else:
+            raise NotImplementedError(f"Forward type {forward_type} not implemented")
+
+    def default_forward(self, data, **kwargs):
+        compute_values = kwargs.get("compute_values", False)
+        chains = data["chains"]
+        denoise_inds = data["denoise_inds"]
+        if "tokenized_prompt" in data:
+            observation = data
+        else:
+            observation = self.input_transform(data, transpose=False)
+
+        device = chains.device
+
+        raw_main_images = observation["observation/image"]
+        raw_wrist_images = observation.get("observation/wrist_image", None)
+        images, img_masks = self._process_images_for_training(
+            raw_main_images, raw_wrist_images, device
+        )
+
+        batch_size = images.shape[0]
+
+        target_dtype = next(self.parameters()).dtype
+        lang_tokens = observation["tokenized_prompt"].to(device)
+        lang_masks = observation["tokenized_prompt_mask"].to(device)
+
+        state = observation["observation/state"].to(device=device)
+        chains = data["chains"].to(device=device, dtype=target_dtype)
+
+        log_probs, value_t, entropy = self.get_log_prob_value(
+            images,
+            img_masks,
+            lang_tokens,
+            lang_masks,
+            state,
+            chains,
+            denoise_inds,
+            compute_values,
+        )
+        log_probs = log_probs[
+            :, :, : self.num_action_chunks, : self.config.action_env_dim
+        ]
+        entropy = entropy[:, :, : self.num_action_chunks, : self.config.action_env_dim]
+        log_probs = log_probs.mean(dim=1)
+        entropy = entropy.mean(dim=[1, 2, 3], keepdim=False)[:, None]
+        value_t = value_t.mean(dim=-1, keepdim=False)
+
+        return {
+            "logprobs": log_probs,
+            "values": value_t,
+            "entropy": entropy,
+        }
+
+    def _process_images_for_training(self, raw_main_images, raw_wrist_images, device):
+        from PIL import Image
+
+        if torch.is_tensor(raw_main_images):
+            raw_main_images = raw_main_images.cpu().numpy()
+        if raw_wrist_images is not None and torch.is_tensor(raw_wrist_images):
+            raw_wrist_images = raw_wrist_images.cpu().numpy()
+
+        batch_size = raw_main_images.shape[0]
+        base_pil_images = []
+        for batch_idx in range(batch_size):
+            img_np = raw_main_images[batch_idx]
+            if img_np.dtype != np.uint8:
+                if img_np.max() <= 1.0:
+                    img_np = (img_np * 255).astype(np.uint8)
+                else:
+                    img_np = img_np.astype(np.uint8)
+            base_pil_images.append(Image.fromarray(img_np))
+        wrist_pil_images = []
+        if raw_wrist_images is not None:
+            for batch_idx in range(batch_size):
+                wrist_np = raw_wrist_images[batch_idx].astype(np.uint8)
+                wrist_pil_images.append(Image.fromarray(wrist_np))
+        images_list = []
+        for batch_idx in range(batch_size):
+            if wrist_pil_images:
+                pil_pair = [base_pil_images[batch_idx], wrist_pil_images[batch_idx]]
+                processed = self.process_images(pil_pair)  # [2, C, H, W]
+            else:
+                processed = self.process_images(
+                    [base_pil_images[batch_idx]]
+                )  # [1, C, H, W]
+            images_list.append(processed)
+        images = torch.stack(images_list, dim=0).to(
+            device=device, dtype=next(self.parameters()).dtype
+        )
+
+        num_views = images.shape[1]
+        required_num_images = 3
+        if num_views < required_num_images:
+            pad_size = required_num_images - num_views
+            padding = torch.zeros(
+                batch_size,
+                pad_size,
+                images.shape[2],
+                images.shape[3],
+                images.shape[4],
+                dtype=images.dtype,
+                device=device,
+            )
+            images = torch.cat([images, padding], dim=1)
+        image_masks = torch.zeros(
+            batch_size, required_num_images, dtype=torch.bool, device=device
+        )
+        image_masks[:, :num_views] = True
+
+        return images, image_masks
+
+    def _normalize_state(self, state):
+        if not hasattr(self, "norm_stats") or self.norm_stats is None:
+            return state
+        if "state" not in self.norm_stats:
+            return state
+        stats = self.norm_stats["state"]
+        mean = torch.tensor(stats["mean"], device=state.device, dtype=state.dtype)
+        std = torch.tensor(stats["std"], device=state.device, dtype=state.dtype)
+        normalized = (state - mean) / (std + 1e-6)
+        return normalized
+
+    def obs_processor(self, env_obs):
+        processed_obs = {
+            "observation/image": env_obs["main_images"],
+            "prompt": env_obs["task_descriptions"],
+        }
+        state = env_obs["states"]
+        if torch.is_tensor(state):
+            state = state.to(dtype=torch.float32)
+        processed_obs["observation/state"] = state
+        if "wrist_images" in env_obs:
+            processed_obs["observation/wrist_image"] = env_obs["wrist_images"]
+        return processed_obs
+
+    @torch.no_grad()
+    def sample_actions(
+        self, processed_obs, noise=None, mode="train", compute_values=True
+    ):
+        original_training_mode = self.training
+        self.eval()
+        try:
+            input_ids = processed_obs.get("tokenized_prompt")
+            attention_mask = processed_obs.get("tokenized_prompt_mask")
+            states = processed_obs["observation/state"].to(
+                device=next(self.parameters()).device
+            )
+
+            raw_images = processed_obs["observation/image"]
+            batch_size = raw_images.shape[0]
+            device = states.device
+
+            from PIL import Image
+
+            base_pil_images = []
+            for batch_idx in range(batch_size):
+                img_np = raw_images[batch_idx].cpu().numpy()
+                if img_np.dtype != np.uint8:
+                    if img_np.max() <= 1.0:
+                        img_np = (img_np * 255).astype(np.uint8)
+                    else:
+                        img_np = img_np.astype(np.uint8)
+
+                pil_img = Image.fromarray(img_np)
+                base_pil_images.append(pil_img)
+
+            wrist_pil_images = []
+            if "observation/wrist_image" in processed_obs:
+                wrist_raw = processed_obs["observation/wrist_image"]
+                for batch_idx in range(batch_size):
+                    wrist_np = wrist_raw[batch_idx].cpu().numpy().astype(np.uint8)
+                    pil_img = Image.fromarray(wrist_np)
+                    wrist_pil_images.append(pil_img)
+            images_list = []
+            for batch_idx in range(batch_size):
+                if wrist_pil_images:
+                    pil_pair = [base_pil_images[batch_idx], wrist_pil_images[batch_idx]]
+                    processed = self.process_images(pil_pair)
+                else:
+                    processed = self.process_images([base_pil_images[batch_idx]])
+                images_list.append(processed)
+            images = torch.stack(images_list, dim=0).to(
+                device=device, dtype=next(self.parameters()).dtype
+            )
+            num_views = images.shape[1]
+            required_num_images = 3
+
+            if num_views < required_num_images:
+                pad_size = required_num_images - num_views
+                padding = torch.zeros(
+                    batch_size,
+                    pad_size,
+                    images.shape[2],
+                    images.shape[3],
+                    images.shape[4],
+                    dtype=images.dtype,
+                    device=device,
+                )
+                images = torch.cat([images, padding], dim=1)
+            image_masks = torch.zeros(
+                batch_size, required_num_images, dtype=torch.bool, device=device
+            )
+            image_masks[:, :num_views] = True
+            model_dtype = next(self.parameters()).dtype
+            device_type = next(self.parameters()).device.type
+
+            if model_dtype == torch.bfloat16:
+                with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
+                    actions = self.inference_action(
+                        input_ids=input_ids,
+                        attention_mask=attention_mask,
+                        states=states,
+                        images=images,
+                        image_masks=image_masks,
+                        diffusion_steps=self.num_steps,
+                    )
+            else:
+                actions = self.inference_action(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    states=states,
+                    images=images,
+                    image_masks=image_masks,
+                    diffusion_steps=self.num_steps,
+                )
+            dummy_chains = (
+                actions.unsqueeze(1)
+                .expand(batch_size, self.num_steps + 1, -1, -1)
+                .contiguous()
+            )
+            return {
+                "actions": actions,
+                "chains": dummy_chains,
+                "prev_logprobs": torch.zeros(
+                    batch_size, 10, self.config.action_env_dim, device=device
+                ),
+                "prev_values": torch.zeros(batch_size, 1, device=device),
+                "denoise_inds": torch.zeros(
+                    batch_size, self.num_steps, dtype=torch.long, device=device
+                ),
+            }
+        finally:
+            if original_training_mode:
+                self.train()
+
+    def get_logprob_norm(self, sample, mu, sigma):
+        if self.config.safe_get_logprob:
+            log_prob = -torch.pow((sample - mu), 2)
+        else:
+            mask = sigma == 0
+            sigma_safe = torch.where(mask, torch.ones_like(sigma), sigma)
+            constant_term = -torch.log(sigma_safe) - 0.5 * torch.log(
+                2 * torch.pi * torch.ones_like(sample)
+            )
+            exponent_term = -0.5 * torch.pow((sample - mu) / sigma_safe, 2)
+            log_prob = constant_term + exponent_term
+            log_prob = torch.where(mask, torch.zeros_like(log_prob), log_prob)
+        return log_prob
+
+    def gaussian_entropy(self, sigma):
+        import math
+
+        mask = sigma == 0
+        sigma_safe = torch.where(mask, torch.ones_like(sigma), sigma)
+        entropy = 0.5 * torch.log(2 * math.pi * math.e * (sigma_safe**2))
+        return entropy
+
+    def get_suffix_out(
+        self,
+        state,
+        prefix_pad_masks,
+        past_key_values,
+        x_t,
+        timestep,
+    ):
+        batch_size = state.shape[0]
+        device = state.device
+
+        if not torch.is_tensor(timestep):
+            timestep = torch.tensor(timestep, device=device)
+        if timestep.dim() == 0:
+            timestep = timestep.unsqueeze(0).expand(batch_size)
+        suffix_tokens, suffix_mask, suffix_ar_mask = self.embed_suffix(
+            states=state,
+            noisy_actions=x_t,
+            time=timestep,
+        )
+        suffix_attn_mask = make_attn_mask(suffix_mask, suffix_ar_mask)
+        prefix_attn_mask = prefix_pad_masks.unsqueeze(1).repeat(
+            1, suffix_tokens.shape[1], 1
+        )
+        full_attn_mask = torch.cat([prefix_attn_mask, suffix_attn_mask], dim=-1)
+        full_attn_mask = make_attn_mask_4d(full_attn_mask)
+        full_positions = (
+            prefix_pad_masks.sum(axis=-1).unsqueeze(-1)
+            + torch.cumsum(suffix_mask, dim=-1)
+            - 1
+        )
+        full_position_embeddings = self.model.llm.rotary_emb(
+            suffix_tokens, full_positions
+        )
+        decoder_embeds_list, _, _, _ = self._inner_forward_mot(
+            [self.model.llm, self.model.action_expert],
+            [None, suffix_tokens],
+            mask=full_attn_mask,
+            position_embeddings=full_position_embeddings,
+            past_key_values=past_key_values,
+            cache_position=None,
+            output_hidden_states=False,
+            output_attentions=False,
+            update_cache=False,
+        )
+        prefix_out = decoder_embeds_list[0]
+        suffix_out = decoder_embeds_list[1]
+        assert prefix_out is None
+        suffix_out = suffix_out.clone()[:, -self.config.chunk_size :]
+        suffix_out = suffix_out.to(dtype=next(self.parameters()).dtype)
+        return suffix_out
+
+    def sample_mean_var_val(
+        self,
+        x_t,
+        idx,
+        state,
+        prefix_pad_masks,
+        past_key_values,
+        mode,
+        denoise_steps,
+        compute_values=True,
+    ):
+        bsize = state.shape[0]
+        device = state.device
+        if isinstance(idx, int):
+            idx = torch.tensor(idx, device=device).expand(bsize)
+        if self.config.noise_anneal:
+            noise_start, noise_end, anneal_steps = self.config.noise_params
+            noise_level = (
+                noise_start
+                + (noise_end - noise_start)
+                * min(self.global_step, anneal_steps)
+                / anneal_steps
+            )
+            noise_level = torch.tensor(noise_level).to(device)
+        else:
+            noise_level = torch.tensor(self.config.noise_level).to(device)
+        # Timesteps: [1, 9/10, 8/10, ..., 1/10, 0] for 10 steps
+        timesteps = torch.linspace(1, 1 / denoise_steps, denoise_steps, device=device)
+        timesteps = torch.cat([timesteps, torch.tensor([0.0], device=device)])
+        t_input = timesteps[idx]
+        delta = timesteps[idx] - timesteps[idx + 1]
+
+        suffix_out = self.get_suffix_out(
+            state,
+            prefix_pad_masks,
+            past_key_values,
+            x_t,
+            t_input,
+        )
+        v_t = self.model.action_out_proj(
+            suffix_out.to(dtype=self.model.action_out_proj.weight.dtype)
+        )
+        if (
+            self.config.add_value_head
+            and compute_values
+            and not self.config.value_after_vlm
+        ):
+            if self.config.chunk_critic_input:
+                suffix_out_value = torch.mean(
+                    suffix_out[:, : self.config.chunk_size], dim=1, keepdim=False
+                )
+            else:
+                suffix_out_value = torch.mean(suffix_out, dim=1, keepdim=False)
+            if self.config.detach_critic_input:
+                suffix_out_value = suffix_out_value.detach()
+            value_t = self.value_head(
+                suffix_out_value.to(self.value_head.weight.dtype)
+            )[:, 0]
+        else:
+            value_t = torch.zeros((bsize), device=device)
+        delta = delta[:, None, None].expand_as(x_t)
+        t_input = t_input[:, None, None].expand_as(x_t)
+        x0_pred = x_t - v_t * t_input
+        x1_pred = x_t + v_t * (1 - t_input)
+
+        if mode == "eval":
+            x0_weight = 1 - (t_input - delta)
+            x1_weight = t_input - delta
+            x_t_std = torch.zeros_like(t_input)
+        elif mode == "train":
+            if self.config.noise_method == "flow_sde":
+                sigmas = (
+                    noise_level
+                    * torch.sqrt(
+                        timesteps
+                        / (1 - torch.where(timesteps == 1, timesteps[1], timesteps))
+                    )[:-1]
+                )
+                sigma_i = sigmas[idx][:, None, None].expand_as(x_t)
+                x0_weight = torch.ones_like(t_input) - (t_input - delta)
+                x1_weight = t_input - delta - sigma_i**2 * delta / (2 * t_input)
+                x_t_std = torch.sqrt(delta) * sigma_i
+            elif self.config.noise_method == "flow_cps":
+                pi = torch.pi
+                cos_term = torch.cos(pi * noise_level / 2).to(device)
+                sin_term = torch.sin(pi * noise_level / 2).to(device)
+                x0_weight = torch.ones_like(t_input) - (t_input - delta)
+                x1_weight = (t_input - delta) * cos_term
+                x_t_std = (t_input - delta) * sin_term
+            elif self.config.noise_method == "flow_noise":
+                x0_weight = 1 - (t_input - delta)
+                x1_weight = t_input - delta
+                x_t_std = self.noise_head(
+                    suffix_out.to(dtype=self.model.action_out_proj.weight.dtype)
+                )
+            else:
+                raise ValueError(f"Invalid noise method: {self.config.noise_method}")
+        x_t_mean = x0_pred * x0_weight + x1_pred * x1_weight
+        return x_t_mean, x_t_std, value_t
+
+    def get_log_prob_value(
+        self,
+        images,
+        img_masks,
+        lang_tokens,
+        lang_masks,
+        state,
+        chains,
+        denoise_inds,
+        compute_values=False,
+    ):
+        bsize = state.shape[0]
+        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+            input_ids=lang_tokens,
+            attention_mask=lang_masks,
+            images=images,
+            image_masks=img_masks,
+        )
+        prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+        prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
+        prefix_att_2d_masks_4d = make_attn_mask_4d(prefix_att_2d_masks)
+
+        [prefix_output, _], past_key_values, _, _ = self._inner_forward_mot(
+            [self.model.llm, self.model.action_expert],
+            [prefix_embs, None],
+            mask=prefix_att_2d_masks_4d,
+            position_embeddings=self.model.llm.rotary_emb(
+                prefix_embs, prefix_position_ids
+            ),
+            past_key_values=DynamicCache(),
+            cache_position=prefix_position_ids,
+            output_hidden_states=False,
+            output_attentions=False,
+            update_cache=True,
+        )
+
+        chains_log_probs = []
+        chains_values = []
+        chains_entropy = []
+
+        if self.config.joint_logprob:
+            num_steps = self.config.num_steps
+            initial_log_prob = self.get_logprob_norm(
+                chains[:, 0],
+                torch.zeros_like(chains[:, 0]),
+                torch.ones_like(chains[:, 0]),
+            )
+            initial_entropy = self.gaussian_entropy(torch.ones_like(chains[:, 0]))
+            chains_log_probs.append(initial_log_prob)
+            chains_entropy.append(initial_entropy)
+        else:
+            num_steps = 1
+
+        for idx in range(num_steps):
+            denoise_ind = denoise_inds[:, idx]
+            chains_pre = chains[torch.arange(bsize), denoise_ind].clone()
+            chains_next = chains[torch.arange(bsize), denoise_ind + 1].clone()
+            x_t_mean, x_t_std, value_t = self.sample_mean_var_val(
+                chains_pre,
+                denoise_ind,
+                state,
+                prefix_pad_masks,
+                past_key_values,
+                "train",
+                self.config.num_steps,
+                compute_values,
+            )
+            log_probs = self.get_logprob_norm(chains_next, x_t_mean, x_t_std)
+            entropy = self.gaussian_entropy(x_t_std)
+
+            chains_log_probs.append(log_probs)
+            chains_entropy.append(entropy)
+
+            if self.use_vlm_value:
+                chains_values.append(self.get_value_from_vlm(prefix_output))
+            else:
+                chains_values.append(value_t)
+        chains_log_probs = torch.stack(chains_log_probs, dim=1)
+        chains_values = torch.stack(chains_values, dim=1)
+        if self.config.noise_method == "flow_noise":
+            chains_entropy = torch.stack(chains_entropy, dim=1)
+        else:
+            chains_entropy = torch.zeros_like(chains_log_probs)
+
+        return chains_log_probs, chains_values, chains_entropy
+
+    def predict_action_batch(self, env_obs, **kwargs):
+        mode = kwargs.get("mode", "train")
+        compute_values = kwargs.get("compute_values", True)
+        to_process_obs = self.obs_processor(env_obs)
+        processed_obs = self.input_transform(to_process_obs, transpose=False)
+        processed_obs = self.precision_processor(processed_obs)
+
+        outputs = self.sample_actions(
+            processed_obs=processed_obs, mode=mode, compute_values=compute_values
+        )
+        if hasattr(self, "_output_transform") and self._output_transform is not None:
+            state_for_transform = processed_obs.get("observation/state")
+            if state_for_transform is not None:
+                if isinstance(state_for_transform, torch.Tensor):
+                    state_numpy = state_for_transform.cpu().numpy()
+                else:
+                    state_numpy = state_for_transform
+                meta_data = {"non_delta_mask": np.array(self.non_delta_mask)}
+                outputs["state"] = state_numpy
+                outputs["meta_data"] = meta_data
+                outputs = self.output_transform(outputs)
+            else:
+                outputs = self.output_transform(outputs)
+        else:
+            pass
+
+        actions = outputs["actions"][:, :, : self.config.action_env_dim].cpu().numpy()
+        forward_inputs = {
+            "chains": outputs["chains"],
+            "denoise_inds": outputs["denoise_inds"],
+        }
+        if "tokenized_prompt" in processed_obs:
+            forward_inputs["tokenized_prompt"] = processed_obs["tokenized_prompt"]
+        if "tokenized_prompt_mask" in processed_obs:
+            forward_inputs["tokenized_prompt_mask"] = processed_obs[
+                "tokenized_prompt_mask"
+            ]
+        forward_inputs.update(to_process_obs)
+        forward_inputs.pop("prompt", None)
+        result = {
+            "prev_logprobs": outputs["prev_logprobs"],
+            "prev_values": outputs["prev_values"],
+            "forward_inputs": forward_inputs,
+        }
+
+        return actions, result
+
+
+def get_model(cfg: DictConfig, torch_dtype=None):
+    import glob
+    import os
+
+    import safetensors.torch
+    from dexbotic.model.pi0.pi0_arch import Pi0Config
+
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.empty_cache()
+
+    if not cfg.model_path or not os.path.exists(cfg.model_path):
+        raise ValueError(f"Model path does not exist: {cfg.model_path}")
+
+    try:
+        config = Pi0Config.from_pretrained(cfg.model_path, local_files_only=True)
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            cfg.model_path, use_fast=False, local_files_only=True
+        )
+        config.num_steps = cfg.get("num_steps", 10)
+        config.action_env_dim = cfg.action_dim
+        config.add_value_head = cfg.get("add_value_head", True)
+        config.noise_level = cfg.get("dexbotic", {}).get("noise_level", 0.5)
+        config.noise_method = cfg.get("dexbotic", {}).get("noise_method", "flow_sde")
+        config.detach_critic_input = cfg.get("dexbotic", {}).get(
+            "detach_critic_input", True
+        )
+        config.train_expert_only = cfg.get("dexbotic", {}).get(
+            "train_expert_only", False
+        )
+        config.action_horizon = config.chunk_size
+        config.output_action_chunks = cfg.num_action_chunks
+        config.safe_get_logprob = cfg.get("safe_get_logprob", False)
+        config.chunk_critic_input = cfg.get("chunk_critic_input", True)
+        config.noise_anneal = cfg.get("noise_anneal", False)
+        config.joint_logprob = cfg.get("joint_logprob", False)
+        config.value_after_vlm = cfg.get("value_after_vlm", False)
+        config.processor_config = cfg.model_path
+        original_offline = os.environ.get("HF_HUB_OFFLINE", None)
+        os.environ["HF_HUB_OFFLINE"] = "1"
+
+        try:
+            model = DexboticPi0ForRLActionPrediction(config)
+        finally:
+            if original_offline is None:
+                os.environ.pop("HF_HUB_OFFLINE", None)
+            else:
+                os.environ["HF_HUB_OFFLINE"] = original_offline
+        model.tokenizer = tokenizer
+
+        from dexbotic.tokenization.process import Pi0Tokenization
+
+        model.pi0_tokenization = Pi0Tokenization(tokenizer)
+        weight_paths = sorted(glob.glob(os.path.join(cfg.model_path, "*.safetensors")))
+        weight_paths = [p for p in weight_paths if not p.endswith(".index.json")]
+        if not weight_paths:
+            weight_path = os.path.join(cfg.model_path, "model.safetensors")
+            if not os.path.exists(weight_path):
+                raise FileNotFoundError(f"No weights found in {cfg.model_path}")
+            weight_paths = [weight_path]
+        for i, weight_path in enumerate(weight_paths):
+            safetensors.torch.load_model(model, weight_path, strict=False)
+        norm_stats_file = os.path.join(cfg.model_path, "norm_stats.json")
+        if os.path.exists(norm_stats_file):
+            model.norm_stats = model._read_normalization_stats(norm_stats_file)
+        else:
+            model.norm_stats = None
+
+        if getattr(config, "train_expert_only", False):
+            model._train_expert_only = True
+        else:
+            model._train_expert_only = False
+
+    except Exception as e:
+        logger.error(f"Failed to load pretrained model: {e}")
+        raise
+    input_transforms_list = []
+    if model.norm_stats is not None:
+        input_transforms_list = [
+            PadState(ndim=config.action_dim, axis=-1),
+            ActionNorm(statistic_mapping=model.norm_stats, strict=False),
+            ToTensor(),
+        ]
+    output_transforms_list = []
+    if model.norm_stats is not None:
+        output_transforms_list = [
+            ToNumpy(),
+            ActionDenorm(statistic_mapping=model.norm_stats, strict=False),
+            AbsoluteAction(),
+        ]
+    model.setup_wrappers(
+        transforms=input_transforms_list, output_transforms=output_transforms_list
+    )
+    return model

--- a/toolkits/eval_scripts_dexbotic/__init__.py
+++ b/toolkits/eval_scripts_dexbotic/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dexbotic evaluation utilities for RLinf."""
+
+import logging
+import os
+
+
+def setup_logger(exp_name, log_dir):
+    os.makedirs(log_dir, exist_ok=True)
+    log_file = os.path.join(log_dir, f"{exp_name}.log")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s: %(message)s",
+        handlers=[logging.FileHandler(log_file, mode="w"), logging.StreamHandler()],
+        force=True,
+    )
+    logger = logging.getLogger(__name__)
+    return logger
+
+
+def setup_policy(args):
+    from rlinf.models.embodiment.dexbotic import setup_policy as _setup_policy
+
+    return _setup_policy(args)

--- a/toolkits/eval_scripts_dexbotic/dexbotic_policy.py
+++ b/toolkits/eval_scripts_dexbotic/dexbotic_policy.py
@@ -1,0 +1,152 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import numpy as np
+import torch
+from dexbotic.data.dataset.transform.action import ActionNorm, PadState
+from dexbotic.data.dataset.transform.common import Pipeline, ToNumpy, ToTensor
+from dexbotic.data.dataset.transform.output import AbsoluteAction, ActionDenorm
+from dexbotic.model.pi0.pi0_arch import Pi0ForCausalLM
+from dexbotic.tokenization.process import Pi0Tokenization
+from PIL import Image
+from transformers import AutoTokenizer
+
+
+class DexboticPolicy:
+    def __init__(
+        self,
+        model_path: str,
+        norm_stats: dict[str, Any],
+        action_dim: int = 7,
+        num_images: int = 3,
+        non_delta_mask: list = None,
+        device: str = "cuda",
+    ):
+        self.model_path = model_path
+        self.norm_stats = norm_stats
+        self.action_dim = action_dim
+        self.num_images = num_images
+        self.non_delta_mask = non_delta_mask or [6]
+        self.device = torch.device(device if torch.cuda.is_available() else "cpu")
+
+        self._load_model()
+
+        self.timestep = 0
+        self.episode = 0
+        self.prev_text = None
+
+    def _load_model(self):
+        self.model = Pi0ForCausalLM.from_pretrained(
+            self.model_path,
+            torch_dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+            trust_remote_code=True,
+        ).to(self.device)
+
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_path, use_fast=False)
+        self.tokenization_func = Pi0Tokenization(self.tokenizer)
+        self.input_transform = Pipeline(
+            [
+                PadState(ndim=self.model.model.config.action_dim, axis=-1),
+                ActionNorm(statistic_mapping=self.norm_stats, strict=False),
+                ToTensor(),
+            ]
+        )
+        self.output_transform = Pipeline(
+            [
+                ToNumpy(),
+                ActionDenorm(statistic_mapping=self.norm_stats, strict=False),
+                AbsoluteAction(),
+            ]
+        )
+
+    def reset(self):
+        self.timestep = 0
+        self.episode += 1
+        self.prev_text = None
+
+    def infer(self, observation: dict[str, Any]) -> dict[str, np.ndarray]:
+        base_image = observation["observation/image"]
+        wrist_image = observation["observation/wrist_image"]
+        state = observation["observation/state"]
+        text = observation["prompt"]
+
+        images = [
+            Image.fromarray(base_image.astype(np.uint8)),
+            Image.fromarray(wrist_image.astype(np.uint8)),
+        ]
+        batch_images_tensor = [
+            self.model.process_images(images).to(dtype=torch.bfloat16)
+        ]
+        num_input_images = len(images)
+        if num_input_images < self.num_images:
+            batch_images_tensor = [
+                torch.cat(
+                    [
+                        image_tensor,
+                        torch.zeros_like(image_tensor[0:1]).repeat(
+                            self.num_images - num_input_images, 1, 1, 1
+                        ),
+                    ],
+                    dim=0,
+                )
+                for image_tensor in batch_images_tensor
+            ]
+        batch_image_masks = [
+            torch.tensor(
+                [True for _ in range(num_input_images)]
+                + [False for _ in range(self.num_images - num_input_images)],
+                device=self.device,
+            )
+        ]
+        batch_images_tensor = torch.stack(batch_images_tensor, dim=0)
+        batch_image_masks = torch.stack(batch_image_masks, dim=0)
+        batch_input_ids = np.array(
+            [self.tokenization_func([{"value": text}])["input_ids"]]
+        )
+        batch_attention_mask = np.array(
+            [np.array(ids != self.tokenizer.pad_token_id) for ids in batch_input_ids]
+        )
+        batch_states = np.array([state], dtype=np.float32)
+        inference_args = {
+            "input_ids": batch_input_ids,
+            "attention_mask": batch_attention_mask,
+            "images": batch_images_tensor,
+            "image_masks": batch_image_masks,
+            "state": batch_states,
+            "meta_data": {
+                "non_delta_mask": np.array(self.non_delta_mask),
+            },
+        }
+        inputs = self.input_transform(inference_args)
+        inputs["states"] = inputs["state"]
+        inputs = {
+            k: v.to(self.device) if isinstance(v, torch.Tensor) else v
+            for k, v in inputs.items()
+        }
+        with torch.no_grad():
+            actions = self.model.inference_action(**inputs)
+        outputs = {
+            k: v.detach().cpu().numpy() if isinstance(v, torch.Tensor) else v
+            for k, v in inputs.items()
+        }
+        outputs["action"] = actions.detach().cpu().numpy()
+        outputs = self.output_transform(outputs)
+        action_sequence = outputs["action"][0, :, : self.action_dim]
+
+        self.timestep += 1
+
+        return {"actions": action_sequence}

--- a/toolkits/eval_scripts_dexbotic/libero_eval.py
+++ b/toolkits/eval_scripts_dexbotic/libero_eval.py
@@ -1,0 +1,314 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import math
+import os
+import pathlib
+
+import imageio
+import numpy as np
+import tqdm
+from libero.libero import benchmark, get_libero_path
+from libero.libero.envs import OffScreenRenderEnv
+
+from toolkits.eval_scripts_dexbotic import setup_logger, setup_policy
+
+os.environ["MUJOCO_GL"] = "egl"
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+LIBERO_DUMMY_ACTION = [0.0] * 6 + [-1.0]
+LIBERO_ENV_RESOLUTION = 256  # resolution used to render training data
+
+
+def _quat2axisangle(quat):
+    """
+    Copied from robosuite: https://github.com/ARISE-Initiative/robosuite/blob/eafb81f54ffc104f905ee48a16bb15f059176ad3/robosuite/utils/transform_utils.py#L490C1-L512C55
+    """
+    # clip quaternion
+    if quat[3] > 1.0:
+        quat[3] = 1.0
+    elif quat[3] < -1.0:
+        quat[3] = -1.0
+
+    den = np.sqrt(1.0 - quat[3] * quat[3])
+    if math.isclose(den, 0.0):
+        # This is (close to) a zero degree rotation, immediately return
+        return np.zeros(3)
+
+    return (quat[:3] * 2.0 * math.acos(quat[3])) / den
+
+
+def _get_libero_env(task, resolution, seed):
+    """Initializes and returns the LIBERO environment, along with the task description."""
+    task_description = task.language
+    task_bddl_file = (
+        pathlib.Path(get_libero_path("bddl_files"))
+        / task.problem_folder
+        / task.bddl_file
+    )
+    env_args = {
+        "bddl_file_name": task_bddl_file,
+        "camera_heights": resolution,
+        "camera_widths": resolution,
+    }
+    env = OffScreenRenderEnv(**env_args)
+    env.seed(
+        seed
+    )  # IMPORTANT: seed seems to affect object positions even when using fixed initial state
+    return env, task_description
+
+
+# main function
+def main(args):
+    # Setup logging
+    logger = setup_logger(args.exp_name, args.log_dir)
+
+    # Set random seed
+    np.random.seed(args.seed)
+
+    # Initialize LIBERO task suite
+    benchmark_dict = benchmark.get_benchmark_dict()
+    task_suite = benchmark_dict[args.task_suite_name]()
+    num_tasks_in_suite = task_suite.n_tasks
+    logger.info(f"Task suite: {args.task_suite_name}")
+
+    # Determine max steps based on task suite
+    if args.task_suite_name == "libero_spatial":
+        max_steps = 220  # longest training demo has 193 steps
+    elif args.task_suite_name == "libero_object":
+        max_steps = 280  # longest training demo has 254 steps
+    elif args.task_suite_name == "libero_goal":
+        max_steps = 300  # longest training demo has 270 steps
+    elif args.task_suite_name == "libero_10":
+        max_steps = 520  # longest training demo has 505 steps
+    elif args.task_suite_name == "libero_90":
+        max_steps = 400  # longest training demo has 373 steps
+    else:
+        raise ValueError(f"Unknown task suite: {args.task_suite_name}")
+
+    # policy setup
+    logger.info("policy setup start")
+    policy = setup_policy(args)
+    logger.info("policy setup done")
+
+    # Start evaluation
+    total_episodes, total_successes = 0, 0
+    results_per_task = {}
+
+    for task_id in tqdm.tqdm(range(num_tasks_in_suite)):
+        # Get task
+        task = task_suite.get_task(task_id)
+
+        # Get default LIBERO initial states
+        initial_states = task_suite.get_task_init_states(task_id)
+
+        # Initialize LIBERO environment and task description
+        env, task_description = _get_libero_env(task, LIBERO_ENV_RESOLUTION, args.seed)
+
+        # Start episodes
+        task_episodes, task_successes = 0, 0
+        for episode_idx in range(args.num_trials_per_task):
+            logger.info(f"\nTask: {task_description}")
+            logger.info(f"Starting episode {task_episodes + 1}...")
+
+            # Reset environment
+            policy.reset()
+            env.reset()
+            action_plan = collections.deque()
+
+            # Set initial states
+            obs = env.set_init_state(initial_states[episode_idx])
+
+            # Setup
+            replay_images = []
+
+            for t in range(max_steps + args.num_steps_wait):
+                # IMPORTANT: Do nothing for the first few timesteps because the simulator drops objects
+                # and we need to wait for them to fall
+                if t < args.num_steps_wait:
+                    obs, reward, done, info = env.step(LIBERO_DUMMY_ACTION)
+                    continue
+
+                # Get preprocessed image
+                # IMPORTANT: rotate 180 degrees to match train preprocessing
+                img = np.ascontiguousarray(obs["agentview_image"][::-1, ::-1])
+                wrist_img = np.ascontiguousarray(
+                    obs["robot0_eye_in_hand_image"][::-1, ::-1]
+                )
+
+                # Save preprocessed image for replay video
+                replay_images.append(img)
+
+                state = np.concatenate(
+                    (
+                        obs["robot0_eef_pos"],
+                        _quat2axisangle(obs["robot0_eef_quat"]),
+                        obs["robot0_gripper_qpos"],
+                    )
+                )
+
+                if not action_plan:
+                    observation = {
+                        "observation/image": img,
+                        "observation/wrist_image": wrist_img,
+                        "observation/state": state,
+                        "prompt": str(task_description),
+                    }
+                    # infer the action
+                    action_chunk = policy.infer(observation)["actions"]
+
+                    assert len(action_chunk) >= args.action_chunk, (
+                        f"We want to replan every {args.action_chunk} steps, but policy only predicts {len(action_chunk)} steps."
+                    )
+                    action_plan.extend(action_chunk[: args.action_chunk])
+
+                action = action_plan.popleft()
+                # Execute action in environment
+                obs, reward, done, info = env.step(action.tolist())
+                if done:
+                    task_successes += 1
+                    total_successes += 1
+                    break
+
+            task_episodes += 1
+            total_episodes += 1
+
+            # Save a replay video of the episode (only for first N episodes across all tasks)
+            if total_episodes <= args.num_save_videos:
+                suffix = "success" if done else "failure"
+                task_segment = task_description.replace(" ", "_")
+                out_path = (
+                    pathlib.Path(f"{args.log_dir}/{args.exp_name}/")
+                    / f"rollout_{task_segment}_{episode_idx}_{suffix}.mp4"
+                )
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                imageio.mimwrite(
+                    out_path,
+                    [
+                        np.asarray(x)
+                        for x in replay_images[:: args.video_temp_subsample]
+                    ],
+                    fps=30 // args.video_temp_subsample,
+                )
+
+            # Log current results
+            logger.info(f"Success: {done}")
+            logger.info(f"# episodes completed so far: {total_episodes}")
+            logger.info(
+                f"# successes: {total_successes} ({total_successes / total_episodes * 100:.1f}%)"
+            )
+
+        env.close()
+
+        # Log final results for this task
+        task_success_rate = task_successes / task_episodes if task_episodes > 0 else 0.0
+        results_per_task[task_description] = task_success_rate
+        logger.info(
+            f"Task: {task_description}, Successes: {task_successes}/{task_episodes}, Success Rate: {task_success_rate:.2%}"
+        )
+
+    # Log final performance
+    total_success_rate = total_successes / total_episodes if total_episodes > 0 else 0.0
+    logger.info("\n===============")
+    logger.info("Per-Task Success Rate:")
+    for task_description, sr in results_per_task.items():
+        logger.info(f"{task_description}: {sr:.2%}")
+
+    logger.info(
+        f"\nTotal Success Rate: {total_successes}/{total_episodes} = {total_success_rate:.2%}"
+    )
+    logger.info(f"results/total_success_rate: {total_success_rate}")
+    logger.info(f"results/total_episodes: {total_episodes}")
+    logger.info(f"results/total_successes: {total_successes}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--log_dir",
+        type=str,
+        default="logs",
+        help="Directory to save log files",
+    )
+    parser.add_argument(
+        "--exp_name",
+        type=str,
+        default="libero_spatial_dexbotic",
+        help="Experiment name used for naming log files and video save directories",
+    )
+    parser.add_argument(
+        "--pretrained_path",
+        type=str,
+        required=True,
+        help="Path to the trained Dexbotic checkpoint directory",
+    )
+    parser.add_argument(
+        "--task_suite_name",
+        type=str,
+        default="libero_spatial",
+        help="Task suite. Options: libero_spatial, libero_object, libero_goal, libero_10, libero_90",
+    )
+    parser.add_argument(
+        "--num_trials_per_task",
+        type=int,
+        default=50,
+        help="Number of rollouts per task",
+    )
+    parser.add_argument(
+        "--action_chunk",
+        type=int,
+        default=50,
+        help="Action chunk size: the length of action sequence predicted by the policy each time. Actions are replanned every N steps. Dexbotic uses 50 by default.",
+    )
+    parser.add_argument(
+        "--num_steps",
+        type=int,
+        default=10,
+        help="Number of diffusion denoising steps for Dexbotic action generation (default: 10).",
+    )
+    parser.add_argument(
+        "--num_steps_wait",
+        type=int,
+        default=10,
+        help="Number of steps to wait for objects to stabilize in sim",
+    )
+    parser.add_argument(
+        "--num_save_videos",
+        type=int,
+        default=10,
+        help="Number of videos to save. Only saves rollout videos for the first N episodes to disk",
+    )
+    parser.add_argument(
+        "--video_temp_subsample",
+        type=int,
+        default=10,
+        help="Video temporal subsampling rate. Saves every Nth frame to the video to reduce file size",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=7,
+        help="Random seed (for reproducibility)",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda",
+        help="Device to run the model on (cuda or cpu)",
+    )
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
### Description
This PR introduces native support in the RLinf repository for policies trained with Dexbotic.
With this change, RLinf can directly load and use Dexbotic-trained policies without requiring any additional model conversion steps.

### Motivation and Context
By integrating native support for Dexbotic-trained policies, this PR simplifies post-training usage and enables a smoother, more efficient integration between Dexbotic and RLinf.

### How has this been tested?
N/A

### Additional information (optional, e.g., figures and logs):
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.