### PR TITLE
fix: replace bare except with except BaseException in channel_worker

### DIFF
--- a/rlinf/scheduler/channel/channel_worker.py
+++ b/rlinf/scheduler/channel/channel_worker.py
@@ -48,7 +48,7 @@ class PeekQueue(asyncio.Queue):
             self._getters.append(getter)
             try:
                 await getter
-            except:
+            except BaseException:
                 getter.cancel()  # Just in case getter is not done yet.
                 try:
                     # Clean self._getters from canceled getters.


### PR DESCRIPTION
Replace bare `except:` with `except BaseException:` in `channel_worker.py`'s async queue getter. `BaseException` is correct here because `asyncio.CancelledError` (a `BaseException` subclass) needs to trigger the future cleanup, while making the catch explicit.