### PR TITLE
fix: sft ckpt loader

### DIFF
--- a/rlinf/models/embodiment/openpi/__init__.py
+++ b/rlinf/models/embodiment/openpi/__init__.py
@@ -47,8 +47,12 @@ def get_model(cfg: DictConfig, torch_dtype=None):
 
     # Check if this is a checkpoint directory (saved by FSDP)
     # Check for model_state_dict/full_weights.pt (direct checkpoint) or actor/model_state_dict/full_weights.pt (from runner)
-    full_weights_path = os.path.join(checkpoint_dir, "model_state_dict", "full_weights.pt")
-    actor_full_weights_path = os.path.join(checkpoint_dir, "actor", "model_state_dict", "full_weights.pt")
+    full_weights_path = os.path.join(
+        checkpoint_dir, "model_state_dict", "full_weights.pt"
+    )
+    actor_full_weights_path = os.path.join(
+        checkpoint_dir, "actor", "model_state_dict", "full_weights.pt"
+    )
 
     model: OpenPi0ForRLActionPrediction = OpenPi0ForRLActionPrediction(
         actor_model_config
@@ -59,11 +63,11 @@ def get_model(cfg: DictConfig, torch_dtype=None):
 
     # Load weights from checkpoint if it's a checkpoint directory, otherwise load from safetensors
     if os.path.exists(full_weights_path):
-        # Direct checkpoint directory (e.g., checkpoints/global_step_900/model_state_dict/full_weights.pt)
+        # Direct checkpoint directory
         model_state_dict = torch.load(full_weights_path, map_location="cpu")
         model.load_state_dict(model_state_dict, strict=False)
     elif os.path.exists(actor_full_weights_path):
-        # Checkpoint directory from runner (e.g., checkpoints/global_step_900/actor/model_state_dict/full_weights.pt)
+        # Checkpoint directory from runner
         model_state_dict = torch.load(actor_full_weights_path, map_location="cpu")
         model.load_state_dict(model_state_dict, strict=False)
     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
If we use RLinf to fine-tune OpenPi models, the checkpoints will be saved under `*.pt` mode and thus cannot be loaded into RLinf for RL training. Therefore, we have to modify the loader to support sft models. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This script can successfully load RLinf sft ckpts. 

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.