### PR TITLE
fix actor load bug

### DIFF
--- a/rlinf/scheduler/collective/collective_group.py
+++ b/rlinf/scheduler/collective/collective_group.py
@@ -1036,22 +1036,8 @@ class CollectiveGroup:
             int: -1 means no common device; 0 means have common devices, but not sure if the tensor will be on the same device (the worker has multiple devices); 1 means the two workers are on the same device.
 
         """
-        peer_devices = self._group_info.workers[self._peer_rank].available_accelerators
-        my_devices = self._group_info.workers[self._rank].available_accelerators
-
-        # Check if the peer is on the same node
-        if (
-            self._group_info.workers[self._peer_rank].cluster_node_rank
-            != self._group_info.workers[self._rank].cluster_node_rank
-        ):
-            return -1
-
-        # Check if the two device list has intersection
-        if not set(peer_devices).intersection(set(my_devices)):
-            return -1
-        if len(peer_devices) == 1 and len(my_devices) == 1:
-            return 1
-        return 0
+        # Always use NCCL instead of CUDA IPC, even for colocated workers
+        return -1
 
     def _object_to_tensor(self, obj: Any, device: str):
         """Convert an object to tensor.

--- a/rlinf/scheduler/collective/multi_channel_pg.py
+++ b/rlinf/scheduler/collective/multi_channel_pg.py
@@ -68,6 +68,13 @@ class MultiChannelProcessGroup:
         # Check if all workers have the same accelerator type
         accel_type = group_info.workers[0].accelerator_type
         accel_model = group_info.workers[0].accelerator_model
+        # Check if workers are colocated (same node, shared accelerators)
+        same_node = len(set(w.cluster_node_rank for w in group_info.workers)) == 1
+        shared_accel = same_node and len(group_info.workers) >= 2 and bool(
+            set(group_info.workers[0].available_accelerators).intersection(
+                set(group_info.workers[1].available_accelerators)
+            )
+        )
         self._no_accel_ccl = (
             # Hetero accelerator models in the same group, disable CCL
             # NCCL for example does not support mixed GPU models
@@ -78,6 +85,8 @@ class MultiChannelProcessGroup:
             or accel_type == AcceleratorType.NO_ACCEL
             # Unsupported accelerator CCL type, disable CCL
             or accel_type not in AcceleratorUtil.CCL_SUPPORT_LIST
+            # Colocated workers on same GPU, NCCL may deadlock
+            or shared_accel
         )
         self._accel_ccl_backend = (
             AcceleratorUtil.get_ccl_backend(accel_type)


### PR DESCRIPTION
  
   **Description**
  Skip CUDA IPC and force GLOO CPU relay (GPU→CPU→GLOO→CPU→GPU) for colocated workers (same node, shared  GPU).

  - collective_group.py: _check_same_device_with_peer() always returns -1 to skip CUDA IPC
  - multi_channel_pg.py: detect colocated worker pairs and set _no_accel_ccl = True to force GLOO

  **Motivation and Context**

  In colocated placement (actor and rollout on the same GPU), CUDA IPC keeps GPU memory occupied even after
  offload. Switching to NCCL causes deadlock since CUDA kernels from two processes on the same GPU are serialized.
  GLOO CPU relay avoids both issues.

  **How has this been tested?**

  Tested on 8-GPU colocated config (actor/env/rollout all on GPU 0-7) with WAN world model + OpenVLA-OFT + GRPO.
  Model sync completes without hanging and training runs normally.

  **Types of changes**

  - Bug fix (non-breaking change which fixes an issue)

  **Checklist:**

  - My code follows the code style of this project.
  - My change requires a change to the documentation.
  - I have updated the documentation accordingly.
  - I have added tests to cover my changes.
  - All new and existing tests passed.
