### PR TITLE
perf: overlap bootstrap with training (cpu rendering)

### DIFF
--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -875,6 +875,10 @@ def validate_embodied_cfg(cfg):
         weight_sync_interval = cfg.runner.get("weight_sync_interval", 1)
         assert weight_sync_interval > 0, "weight_sync_interval must be greater than 0"
         cfg.runner.weight_sync_interval = weight_sync_interval
+        cfg.runner.overlap_env_bootstrap = (
+            bool(cfg.runner.get("overlap_env_bootstrap", True))
+            and not cfg.env.train.get("enable_offload", False)
+        )
         if (
             SupportedEnvType(cfg.env.train.env_type) == SupportedEnvType.MANISKILL
             or SupportedEnvType(cfg.env.eval.env_type) == SupportedEnvType.MANISKILL

--- a/rlinf/runners/embodied_runner.py
+++ b/rlinf/runners/embodied_runner.py
@@ -71,6 +71,9 @@ class EmbodiedRunner:
         self.critic = critic
         self.reward = reward
         self.weight_sync_interval = self.cfg.runner.weight_sync_interval
+        self.overlap_env_bootstrap = bool(
+            self.cfg.runner.get("overlap_env_bootstrap", False)
+        )
         # Data channels
         self.env_channel = Channel.create("Env")
         self.rollout_channel = Channel.create("Rollout")
@@ -308,8 +311,15 @@ class EmbodiedRunner:
 
                 # actor training.
                 actor_training_handle: Handle = self.actor.run_training()
+                env_bootstrap_handle: Handle | None = None
+                if self.overlap_env_bootstrap and _step + 1 < self.max_steps:
+                    env_bootstrap_handle = self.env.prefetch_train_bootstrap(
+                        rollout_channel=self.rollout_channel
+                    )
 
                 actor_training_metrics = actor_training_handle.wait()
+                if env_bootstrap_handle is not None:
+                    env_bootstrap_handle.wait()
 
                 self.global_step += 1
 

--- a/rlinf/workers/env/env_worker.py
+++ b/rlinf/workers/env/env_worker.py
@@ -55,6 +55,7 @@ class EnvWorker(Worker):
 
         self.last_obs_list = []
         self.last_intervened_info_list = []
+        self._prefetched_train_bootstrap: list[EnvOutput] | None = None
         self.rollout_epoch = self.cfg.algorithm.get("rollout_epoch", 1)
         self._component_placement = HybridComponentPlacement(cfg, Cluster())
 
@@ -876,6 +877,38 @@ class EnvWorker(Worker):
 
         return env_outputs
 
+    def _send_train_bootstrap(
+        self, rollout_channel: Channel, env_outputs: list[EnvOutput]
+    ) -> None:
+        for stage_id in range(self.stage_num):
+            env_output: EnvOutput = env_outputs[stage_id]
+            env_batch = env_output.to_dict()
+            self.send_env_batch(
+                rollout_channel,
+                {
+                    "obs": env_batch["obs"],
+                    "final_obs": env_batch["final_obs"],
+                },
+            )
+
+    def _bootstrap_and_send_train(
+        self, rollout_channel: Channel
+    ) -> list[EnvOutput]:
+        env_outputs = self.bootstrap_step()
+        self._send_train_bootstrap(rollout_channel, env_outputs)
+        return env_outputs
+
+    def prefetch_train_bootstrap(self, rollout_channel: Channel) -> None:
+        """Prepare and send the first env batch for the next training rollout."""
+        if self._prefetched_train_bootstrap is not None:
+            raise RuntimeError(
+                "A prefetched train bootstrap already exists. "
+                "Call interact() to consume it before prefetching again."
+            )
+        self._prefetched_train_bootstrap = self._bootstrap_and_send_train(
+            rollout_channel
+        )
+
     def record_env_metrics(
         self, env_metrics: dict[str, list], env_info: dict[str, Any], epoch: int
     ):
@@ -926,17 +959,11 @@ class EnvWorker(Worker):
         env_metrics = defaultdict(list)
 
         for epoch in range(self.rollout_epoch):
-            env_outputs = self.bootstrap_step()
-            for stage_id in range(self.stage_num):
-                env_output: EnvOutput = env_outputs[stage_id]
-                env_batch = env_output.to_dict()
-                self.send_env_batch(
-                    rollout_channel,
-                    {
-                        "obs": env_batch["obs"],
-                        "final_obs": env_batch["final_obs"],
-                    },
-                )
+            if epoch == 0 and self._prefetched_train_bootstrap is not None:
+                env_outputs = self._prefetched_train_bootstrap
+                self._prefetched_train_bootstrap = None
+            else:
+                env_outputs = self._bootstrap_and_send_train(rollout_channel)
 
             for chunk_step_idx in range(self.n_train_chunk_steps):
                 for stage_id in range(self.stage_num):


### PR DESCRIPTION
Performance Improvement: Asynchronous Environment Bootstrapping and Training Overlap

### Description
~~This PR introduces a new `warmup` method to the `EnvWorker` class to enable asynchronous environment preparation. The `warmup` function is designed to be called prior to `interact`, allowing environment bootstrapping to occur in parallel with `run_training`.
We also add a new `-1` configuration option for environment settings to explicitly denote CPU-only physics and rendering, and the function `get_group_accelerators` in `embodied_runner.py` to check if there is resource overlap.~~
Updated the PR based on feedback and copied suggested changes. Main difference is that warmup is not a function but an async handle (it is not called warmup anymore) and class member holding the bootstrap data is freed after consumption (e.g. set to `None`). 
There is also a new configuration for `runner`, `overlap_env_bootstrap`. This parameter needs to be set to True in the yaml file:
```
runner:
     overlap_env_bootstrap: True
``` 

### Motivation and Context
Currently, environment bootstrap time accounts for a significant portion (5%–20%) of each global step. In hardware configurations where `EnvWorker` processes do not compete for resources with the training actor (e.g., CPU-based rendering vs. NPU/GPU-based training), this bootstrap latency can be masked by overlapping it with the training phase.

While the initial global step time remains unchanged, subsequent steps see significant improvement in throughput.
*Preliminary Results:*
In a CPU + NPU environment (benchmarked on `libero_10` with Pi0.5 and PPO, with changes for minimal configuration), we observed a reduction in per-global-step time from 720s to approximately 620–640s.

### How has this been tested?
Validation is ongoing on our internal clusters using standard RLinf examples. Specifically:
Execution Script: `run_embodiment.sh`
Configuration: `libero_10_ppo_openpi_pi05.yaml` (with some selected minor adjustments from [Section 2.4 Minimum Test Case](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/pi0.html)).

### Additional information (optional, e.g., figures and logs):
Initial performance figures are posted in [comment](https://github.com/RLinf/RLinf/pull/942#issuecomment-4145842761).
_Further logs and performance figures will be attached upon completion of the test run._

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
(We are doing our due diligence to ensure that our changes do not break existing functionality. However, we are marking this box in case we miss something. If we are confident that our changes are non-breaking, we will remove the tick.)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.