### PR TITLE
feat(embodied): add LingBot-VA RoboTwin evaluation support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -476,6 +476,65 @@ jobs:
           outputs: type=cacheonly
           tags: rlinf:embodied-isaaclab
 
+  build-embodied-robotwin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Maximize storage space
+        run: |
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+  
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+  
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+  
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+  
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+  
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+  
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+  
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+  
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+  
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+  
+          # Remove CodeQL and other toolcaches
+          sudo rm -rf /opt/hostedtoolcache
+  
+          docker system prune -af || true
+          docker builder prune -af || true
+          df -h
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build embodied-robotwin
+        uses: docker/build-push-action@v6
+        with:
+          file: ./docker/Dockerfile
+          push: false
+          build-args: |
+            BUILD_TARGET=embodied-robotwin
+            NO_MIRROR=true
+          outputs: type=cacheonly
+          tags: rlinf:embodied-robotwin
+
   build-embodied-franka:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/embodied-e2e-tests.yml
+++ b/.github/workflows/embodied-e2e-tests.yml
@@ -806,6 +806,52 @@ jobs:
           rm -rf .venv
           uv cache prune
 
+  embodied-lingbotva-robotwin-test:
+    runs-on: embodied
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Create embodied environment
+        run: |
+          unset UV_DEFAULT_INDEX
+          export UV_PATH=/workspace/dataset/.uv
+          export UV_LINK_MODE=symlink
+          export UV_CACHE_DIR=/workspace/dataset/.uv_cache
+          export UV_PYTHON_INSTALL_DIR=/workspace/dataset/.uv_python
+          export ROBOTWIN_PATH=/workspace/dataset/RoboTwin
+          bash requirements/install.sh embodied --model lingbotva --env robotwin
+          source .venv/bin/activate
+          bash requirements/embodied/download_assets.sh --dir /workspace/dataset --assets lingbotva
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          config_path = Path("/workspace/dataset/.cache/lingbotva/lingbot-va-posttrain-robotwin/transformer/config.json")
+          config = json.loads(config_path.read_text())
+          if config.get("attn_mode") not in {"torch", "flashattn"}:
+              config["attn_mode"] = "torch"
+              config_path.write_text(json.dumps(config, indent=2) + "\n")
+          PY
+
+      - name: RoboTwin-LingBotVA eval test
+        timeout-minutes: 30
+        run: |
+          unset PYTHONPATH
+          export REPO_PATH=$(pwd)
+          source .venv/bin/activate
+          export ROBOT_PLATFORM=ALOHA
+          export ROBOTWIN_PATH="/workspace/dataset/RoboTwin"
+          export PYTHONPATH=${ROBOTWIN_PATH}:$PYTHONPATH
+          export LINGBOT_VA_REPO_PATH="$(pwd)/.venv/lingbot-va"
+          export LINGBOT_VA_MODEL_PATH="/workspace/dataset/.cache/lingbotva/lingbot-va-posttrain-robotwin"
+          bash tests/e2e_tests/embodied/run_eval.sh robotwin_eval_lingbotva
+
+      - name: Clean up
+        run: |
+          rm -rf .venv
+          uv cache prune
+
   embodied-openvlaoft-liberopro-test:
     runs-on: embodied
     steps:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -96,6 +96,16 @@ jobs:
           pip install uv
           bash requirements/install.sh embodied --model dexbotic --env maniskill_libero
           rm -rf .venv
+
+      - name: Install lingbotva
+        run: |
+          pip install uv
+          if ! command -v nvcc >/dev/null 2>&1 && [ ! -x /usr/local/cuda/bin/nvcc ]; then
+            echo "nvcc not found on runner; skipping LingBot-VA RoboTwin install check."
+            exit 0
+          fi
+          bash requirements/install.sh embodied --model lingbotva --env robotwin
+          rm -rf .venv
       
       - name: Install xsquare_turtle2
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,6 +132,12 @@ if [ -d /opt/assets/.cache/openpi ]; then
     fi
     ln -s /opt/assets/.cache/openpi ~/.cache/openpi
 fi
+if [ -d /opt/assets/.cache/lingbotva ]; then
+    if [ -d ~/.cache/lingbotva ]; then
+        rm -rf ~/.cache/lingbotva
+    fi
+    ln -s /opt/assets/.cache/lingbotva ~/.cache/lingbotva
+fi
 EOF
 RUN chmod +x /usr/local/bin/link_assets
 
@@ -261,12 +267,27 @@ RUN echo "source ${UV_PATH}/franka-0.15.0/bin/activate" >> ~/.bashrc
 ##################################################################################################
 FROM embodied-common-image AS embodied-robotwin-image
 
-# Install openvla-oft, openpi, and lingbotvla envs
+# Install openvla-oft, openpi, lingbotvla, and lingbotva envs
 RUN bash requirements/install.sh embodied --venv openvla-oft --model openvla-oft --env robotwin && \
     bash requirements/install.sh embodied --venv openpi --model openpi --env robotwin && \
-    bash requirements/install.sh embodied --venv lingbotvla --model lingbotvla --env robotwin
+    bash requirements/install.sh embodied --venv lingbotvla --model lingbotvla --env robotwin && \
+    bash requirements/install.sh embodied --venv lingbotva --model lingbotva --env robotwin
 
+# openvla-oft stays the default shell env. LingBot-VA can be enabled explicitly
+# at runtime with `source /opt/venv/lingbotva/bin/activate`.
 RUN source switch_env openpi && download_assets --dir /opt/assets --assets openpi
+RUN source ${UV_PATH}/lingbotva/bin/activate && download_assets --dir /opt/assets --assets lingbotva
+RUN python3 - <<'PY'
+import json
+from pathlib import Path
+
+config_path = Path("/opt/assets/.cache/lingbotva/lingbot-va-posttrain-robotwin/transformer/config.json")
+if config_path.exists():
+    config = json.loads(config_path.read_text())
+    if config.get("attn_mode") not in {"torch", "flashattn"}:
+        config["attn_mode"] = "torch"
+        config_path.write_text(json.dumps(config, indent=2) + "\n")
+PY
 RUN link_assets
 
 # Set default env

--- a/docs/source-en/rst_source/examples/embodied/lingbotva.rst
+++ b/docs/source-en/rst_source/examples/embodied/lingbotva.rst
@@ -1,0 +1,158 @@
+:orphan:
+
+LingBot-VA on RoboTwin
+======================
+
+This document describes how to evaluate the official LingBot-VA RoboTwin checkpoint in RLinf.
+
+The current integration focuses on RoboTwin evaluation and keeps the official LingBot-VA inference workflow, including 16D end-effector actions, ``add_init_pose``, key-frame updates, and ``compute_kv_cache`` between chunks.
+
+Overview
+--------
+
+LingBot-VA is currently supported in RLinf for **RoboTwin evaluation only**.
+
+The current integration has the following characteristics:
+
+* **Environment**: RoboTwin 2.0 tasks executed through RLinf ``RoboTwinEnv``.
+* **Observation**: head RGB image, left/right wrist RGB images, and 14D proprioception.
+* **Action Space**: 16D end-effector actions.
+* **Planner backend**: ``curobo``.
+* **Execution type**: ``action_type: ee``.
+* **Current support**: evaluation only, one LingBot-VA websocket session per rollout worker.
+
+The validated configs keep:
+
+* ``runner.only_eval=True``
+* ``total_num_envs: 1``
+* ``enable_offload: false``
+
+Dependency Installation
+-----------------------
+
+1. Clone the RLinf repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   git clone https://github.com/RLinf/RLinf.git
+   cd RLinf
+
+2. Install LingBot-VA and RoboTwin support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   bash requirements/install.sh embodied --model lingbotva --env robotwin
+   source .venv/bin/activate
+
+The install script clones the official LingBot-VA repository into ``.venv/lingbot-va`` and writes ``LINGBOT_VA_REPO_PATH`` into ``.venv/bin/activate`` automatically.
+
+3. Prepare RoboTwin assets
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the RoboTwin ``RLinf_support`` branch and download its assets:
+
+.. code-block:: bash
+
+   git clone https://github.com/RoboTwin-Platform/RoboTwin.git -b RLinf_support
+   cd RoboTwin
+   bash script/_download_assets.sh
+
+4. Download the LingBot-VA checkpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   bash requirements/embodied/download_assets.sh --dir /path/to/assets --assets lingbotva
+
+Set ``LINGBOT_VA_MODEL_PATH`` to:
+
+.. code-block:: bash
+
+   /path/to/assets/.cache/lingbotva/lingbot-va-posttrain-robotwin
+
+5. Check ``attn_mode`` before evaluation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before evaluation, open ``<model>/transformer/config.json`` and make sure ``attn_mode`` is set to ``"torch"`` or ``"flashattn"``.
+
+Configuration Files
+-------------------
+
+The current RoboTwin evaluation configs are:
+
+* ``examples/embodiment/config/robotwin_click_bell_eval_lingbotva.yaml``
+* ``examples/embodiment/config/robotwin_place_empty_cup_eval_lingbotva.yaml``
+
+These configs keep the validated setup:
+
+* ``planner_backend: curobo``
+* ``action_type: ee``
+* ``action_dim: 16``
+* ``num_action_chunks: 32``
+* ``ignore_terminations: false``
+* ``enable_offload: false``
+
+Environment Variables
+---------------------
+
+.. code-block:: bash
+
+   export ROBOTWIN_PATH=/path/to/RoboTwin
+   export LINGBOT_VA_MODEL_PATH=/path/to/assets/.cache/lingbotva/lingbot-va-posttrain-robotwin
+   export ROBOT_PLATFORM=ALOHA
+
+Optional overrides:
+
+.. code-block:: bash
+
+   # Only needed when calling eval_embodied_agent.py directly.
+   export REPO_PATH=/path/to/RLinf
+
+   # Only needed when overriding the LingBot-VA repo cloned by install.sh.
+   export LINGBOT_VA_REPO_PATH=/path/to/lingbot-va
+
+Launch Command
+--------------
+
+Recommended command:
+
+.. code-block:: bash
+
+   bash examples/embodiment/eval_embodiment.sh robotwin_click_bell_eval_lingbotva
+
+If you call ``eval_embodied_agent.py`` directly, set ``REPO_PATH`` first and then run:
+
+.. code-block:: bash
+
+   python examples/embodiment/eval_embodied_agent.py \
+     --config-path examples/embodiment/config \
+     --config-name robotwin_click_bell_eval_lingbotva
+
+Evaluation Results and Visualization
+------------------------------------
+
+The current validated tasks are:
+
+* ``click_bell``
+* ``place_empty_cup``
+
+If TensorBoard logging is enabled, you can inspect results with:
+
+.. code-block:: bash
+
+   tensorboard --logdir ../results --port 6006
+
+If evaluation video logging is enabled, videos are saved under:
+
+.. code-block:: bash
+
+   <runner.logger.log_path>/video/eval
+
+Notes
+-----
+
+* ``center_crop`` should be set explicitly per task.
+* ``max_episode_steps`` and ``max_steps_per_rollout_epoch`` should stay aligned with RLinf chunk rollout scheduling.
+* The current integration keeps the official LingBot-VA chunk/key-frame/KV-cache evaluation rhythm.

--- a/docs/source-zh/rst_source/examples/embodied/lingbotva.rst
+++ b/docs/source-zh/rst_source/examples/embodied/lingbotva.rst
@@ -1,0 +1,158 @@
+:orphan:
+
+LingBot-VA 在 RoboTwin 上的评测
+==============================
+
+本文档介绍如何在 RLinf 中对官方 LingBot-VA 的 RoboTwin checkpoint 执行评测。
+
+当前接入面向 RoboTwin evaluation，并保留了官方 LingBot-VA 的推理流程，包括 16D end-effector action、``add_init_pose``、key-frame 更新，以及 chunk 之间的 ``compute_kv_cache``。
+
+概览
+----
+
+LingBot-VA 当前在 RLinf 中仅支持 **RoboTwin 评测**。
+
+当前接入具有以下特征：
+
+* **环境**：通过 RLinf ``RoboTwinEnv`` 执行 RoboTwin 2.0 任务。
+* **观测**：头部 RGB 图像、左右腕部 RGB 图像，以及 14 维 proprioception。
+* **动作空间**：16 维 end-effector 动作。
+* **规划后端**：``curobo``。
+* **执行类型**：``action_type: ee``。
+* **当前支持**：仅支持 evaluation，每个 rollout worker 维护一个 LingBot-VA websocket 会话。
+
+已验证配置固定为：
+
+* ``runner.only_eval=True``
+* ``total_num_envs: 1``
+* ``enable_offload: false``
+
+依赖安装
+--------
+
+1. 克隆 RLinf 仓库
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   git clone https://github.com/RLinf/RLinf.git
+   cd RLinf
+
+2. 安装 LingBot-VA 与 RoboTwin 支持
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   bash requirements/install.sh embodied --model lingbotva --env robotwin
+   source .venv/bin/activate
+
+安装脚本会把官方 LingBot-VA 仓库克隆到 ``.venv/lingbot-va``，并自动把 ``LINGBOT_VA_REPO_PATH`` 写入 ``.venv/bin/activate``。
+
+3. 准备 RoboTwin 资产
+~~~~~~~~~~~~~~~~~~~~~
+
+请使用 RoboTwin 的 ``RLinf_support`` 分支，并下载对应资产：
+
+.. code-block:: bash
+
+   git clone https://github.com/RoboTwin-Platform/RoboTwin.git -b RLinf_support
+   cd RoboTwin
+   bash script/_download_assets.sh
+
+4. 下载 LingBot-VA checkpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   bash requirements/embodied/download_assets.sh --dir /path/to/assets --assets lingbotva
+
+随后将 ``LINGBOT_VA_MODEL_PATH`` 指向：
+
+.. code-block:: bash
+
+   /path/to/assets/.cache/lingbotva/lingbot-va-posttrain-robotwin
+
+5. 评测前检查 ``attn_mode``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+评测前请打开 ``<model>/transformer/config.json``，确认 ``attn_mode`` 为 ``"torch"`` 或 ``"flashattn"``。
+
+配置文件
+--------
+
+当前 RoboTwin 评测配置包括：
+
+* ``examples/embodiment/config/robotwin_click_bell_eval_lingbotva.yaml``
+* ``examples/embodiment/config/robotwin_place_empty_cup_eval_lingbotva.yaml``
+
+这些配置保持了已验证的设置：
+
+* ``planner_backend: curobo``
+* ``action_type: ee``
+* ``action_dim: 16``
+* ``num_action_chunks: 32``
+* ``ignore_terminations: false``
+* ``enable_offload: false``
+
+环境变量
+--------
+
+.. code-block:: bash
+
+   export ROBOTWIN_PATH=/path/to/RoboTwin
+   export LINGBOT_VA_MODEL_PATH=/path/to/assets/.cache/lingbotva/lingbot-va-posttrain-robotwin
+   export ROBOT_PLATFORM=ALOHA
+
+可选覆盖项：
+
+.. code-block:: bash
+
+   # 仅在直接调用 eval_embodied_agent.py 时需要手动设置。
+   export REPO_PATH=/path/to/RLinf
+
+   # 仅在需要覆盖 install.sh 自动克隆的 LingBot-VA 仓库路径时使用。
+   export LINGBOT_VA_REPO_PATH=/path/to/lingbot-va
+
+启动命令
+--------
+
+推荐命令：
+
+.. code-block:: bash
+
+   bash examples/embodiment/eval_embodiment.sh robotwin_click_bell_eval_lingbotva
+
+如果你直接调用 ``eval_embodied_agent.py``，请先设置 ``REPO_PATH``，然后运行：
+
+.. code-block:: bash
+
+   python examples/embodiment/eval_embodied_agent.py \
+     --config-path examples/embodiment/config \
+     --config-name robotwin_click_bell_eval_lingbotva
+
+评测结果与可视化
+----------------
+
+当前已验证的任务包括：
+
+* ``click_bell``
+* ``place_empty_cup``
+
+如果启用了 TensorBoard，可以使用：
+
+.. code-block:: bash
+
+   tensorboard --logdir ../results --port 6006
+
+如果启用了评测视频记录，视频会保存在：
+
+.. code-block:: bash
+
+   <runner.logger.log_path>/video/eval
+
+说明
+----
+
+* ``center_crop`` 需要按任务显式配置。
+* ``max_episode_steps`` 与 ``max_steps_per_rollout_epoch`` 需要和 RLinf 的 chunk rollout 调度保持一致。
+* 当前接入保留了官方 LingBot-VA 的 chunk/key-frame/KV-cache 评测节奏。

--- a/examples/embodiment/config/model/lingbotva.yaml
+++ b/examples/embodiment/config/model/lingbotva.yaml
@@ -1,0 +1,17 @@
+model_type: lingbotva
+model_path: ${oc.env:LINGBOT_VA_MODEL_PATH}
+precision: bf16
+num_action_chunks: 32
+action_dim: 16
+is_lora: false
+lora_rank: 4
+lora_path: null
+lingbotva:
+  repo_path: ${oc.env:LINGBOT_VA_REPO_PATH}
+  enable_offload: false
+  save_root: /tmp/rlinf_lingbotva
+  reuse_server: false
+  fixed_server_port: null
+  server_cuda_visible_devices: null
+  server_torch_num_threads: 32
+  action_per_frame: 16

--- a/examples/embodiment/config/robotwin_click_bell_eval_lingbotva.yaml
+++ b/examples/embodiment/config/robotwin_click_bell_eval_lingbotva.yaml
@@ -1,0 +1,169 @@
+defaults:
+- env/robotwin_click_bell@env.train
+- env/robotwin_click_bell@env.eval
+- model/lingbotva@actor.model
+- training_backend/fsdp@actor.fsdp_config
+- override hydra/job_logging: stdout
+- _self_
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+  - file://${oc.env:REPO_PATH}/examples/embodiment/config
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,rollout: 0
+    env: 0
+runner:
+  task_type: embodied
+  logger:
+    log_path: ../results
+    project_name: rlinf
+    experiment_name: robotwin_click_bell_eval_lingbotva
+    logger_backends:
+    - tensorboard
+  max_epochs: 1
+  max_steps: -1
+  only_eval: true
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+algorithm:
+  normalize_advantages: true
+  kl_penalty: kl
+  group_size: 2
+  rollout_epoch: 1
+  eval_rollout_epoch: 1
+  reward_type: action_level
+  logprob_type: token_level
+  entropy_type: token_level
+  adv_type: grpo
+  loss_type: actor
+  loss_agg_func: token-mean
+  kl_beta: 0.0
+  entropy_bonus: 0
+  clip_ratio_high: 0.28
+  clip_ratio_low: 0.2
+  clip_ratio_c: 3.0
+  value_clip: 0.2
+  huber_delta: 10.0
+  gamma: 1.0
+  gae_lambda: 0.95
+  reward_coef: 1.0
+  filter_rewards: false
+  rewards_lower_bound: 0.5
+  rewards_upper_bound: 4.5
+  sampling_params:
+    do_sample: false
+    temperature_train: 1.0
+    temperature_eval: -1
+    top_k: -1
+    top_p: 1.0
+    repetition_penalty: 1.0
+  length_params:
+    max_new_token: null
+    max_length: 512
+    min_length: 1
+env:
+  group_name: EnvGroup
+  train:
+    total_num_envs: 1
+    use_custom_reward: false
+    max_steps_per_rollout_epoch: 416
+    group_size: 2
+    assets_path: ${oc.env:ROBOTWIN_PATH}
+    seeds_path: ${oc.env:REPO_PATH}/rlinf/envs/robotwin/seeds/train_seeds.json
+    task_config:
+      step_lim: 400
+      planner_backend: curobo
+      action_type: ee
+      embodiment:
+        - aloha-agilex
+      domain_randomization:
+        random_background: false
+        cluttered_table: false
+        clean_background_rate: 1
+        random_table_height: 0
+        random_light: false
+        crazy_random_light_rate: 0
+      data_type:
+        endpose: true
+      clear_cache_freq: 5
+  eval:
+    total_num_envs: 1
+    auto_reset: true
+    ignore_terminations: false
+    use_custom_reward: false
+    max_steps_per_rollout_epoch: 416
+    use_fixed_reset_state_ids: true
+    is_eval: true
+    assets_path: ${oc.env:ROBOTWIN_PATH}
+    seeds_path: ${oc.env:REPO_PATH}/rlinf/envs/robotwin/seeds/eval_seeds.json
+    task_config:
+      step_lim: 400
+      planner_backend: curobo
+      action_type: ee
+      embodiment:
+        - aloha-agilex
+      domain_randomization:
+        random_background: false
+        cluttered_table: false
+        clean_background_rate: 1
+        random_table_height: 0
+        random_light: false
+        crazy_random_light_rate: 0
+      data_type:
+        endpose: true
+      clear_cache_freq: 5
+    video_cfg:
+      save_video: true
+      video_base_dir: ${runner.logger.log_path}/video/eval
+rollout:
+  group_name: RolloutGroup
+  backend: huggingface
+  enable_offload: false
+  pipeline_stage_num: 1
+  model:
+    model_type: lingbotva
+    model_path: ${actor.model.model_path}
+    precision: ${actor.model.precision}
+actor:
+  group_name: ActorGroup
+  training_backend: fsdp
+  micro_batch_size: 1
+  global_batch_size: 1
+  seed: 1234
+  enable_offload: false
+  model:
+    model_type: lingbotva
+    model_path: ${oc.env:LINGBOT_VA_MODEL_PATH}
+    precision: bf16
+    num_action_chunks: 32
+    action_dim: 16
+    lingbotva:
+      repo_path: ${oc.env:LINGBOT_VA_REPO_PATH}
+      enable_offload: false
+      save_root: /tmp/rlinf_lingbotva
+      action_per_frame: 16
+  optim:
+    lr: 5.0e-05
+    value_lr: 1.0e-05
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_eps: 1.0e-05
+    weight_decay: 0.01
+    clip_grad: 1.0
+  fsdp_config:
+    strategy: fsdp
+    gradient_checkpointing: false
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+reward:
+  use_reward_model: false
+critic:
+  use_critic_model: false

--- a/examples/embodiment/config/robotwin_place_empty_cup_eval_lingbotva.yaml
+++ b/examples/embodiment/config/robotwin_place_empty_cup_eval_lingbotva.yaml
@@ -1,0 +1,187 @@
+defaults:
+  - env/robotwin_place_empty_cup@env.train
+  - env/robotwin_place_empty_cup@env.eval
+  - model/lingbotva@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+  - _self_
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/embodiment/config
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,rollout: 0
+    env: 0
+
+runner:
+  task_type: embodied
+  logger:
+    log_path: ../results
+    project_name: rlinf
+    experiment_name: robotwin_place_empty_cup_eval_lingbotva
+    logger_backends:
+      - tensorboard
+  max_epochs: 1
+  max_steps: -1
+  only_eval: true
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+
+algorithm:
+  normalize_advantages: true
+  kl_penalty: kl
+  group_size: 2
+  rollout_epoch: 1
+  eval_rollout_epoch: 1
+  reward_type: action_level
+  logprob_type: token_level
+  entropy_type: token_level
+  adv_type: grpo
+  loss_type: actor
+  loss_agg_func: token-mean
+  kl_beta: 0.0
+  entropy_bonus: 0
+  clip_ratio_high: 0.28
+  clip_ratio_low: 0.2
+  clip_ratio_c: 3.0
+  value_clip: 0.2
+  huber_delta: 10.0
+  gamma: 1.0
+  gae_lambda: 0.95
+  reward_coef: 1.0
+  filter_rewards: false
+  rewards_lower_bound: 0.5
+  rewards_upper_bound: 4.5
+  sampling_params:
+    do_sample: false
+    temperature_train: 1.0
+    temperature_eval: -1
+    top_k: -1
+    top_p: 1.0
+    repetition_penalty: 1.0
+  length_params:
+    max_new_token: null
+    max_length: 512
+    min_length: 1
+
+env:
+  group_name: EnvGroup
+  train:
+    total_num_envs: 1
+    use_custom_reward: false
+    max_episode_steps: 400
+    reward_coef: ${algorithm.reward_coef}
+    max_steps_per_rollout_epoch: 416
+    group_size: 2
+    assets_path: ${oc.env:ROBOTWIN_PATH}
+    seeds_path: ${oc.env:REPO_PATH}/rlinf/envs/robotwin/seeds/train_seeds.json
+    center_crop: false
+    task_config:
+      step_lim: 400
+      planner_backend: curobo
+      action_type: ee
+      embodiment:
+        - aloha-agilex
+      domain_randomization:
+        random_background: false
+        cluttered_table: false
+        clean_background_rate: 1
+        random_table_height: 0
+        random_light: false
+        crazy_random_light_rate: 0
+      camera:
+        collect_wrist_camera: true
+      data_type:
+        endpose: true
+      clear_cache_freq: 5
+  eval:
+    total_num_envs: 1
+    auto_reset: true
+    ignore_terminations: false
+    use_custom_reward: false
+    max_episode_steps: 400
+    reward_coef: ${algorithm.reward_coef}
+    max_steps_per_rollout_epoch: 416
+    use_fixed_reset_state_ids: true
+    is_eval: true
+    assets_path: ${oc.env:ROBOTWIN_PATH}
+    seeds_path: ${oc.env:REPO_PATH}/rlinf/envs/robotwin/seeds/eval_seeds.json
+    center_crop: false
+    task_config:
+      step_lim: 400
+      planner_backend: curobo
+      action_type: ee
+      embodiment:
+        - aloha-agilex
+      domain_randomization:
+        random_background: false
+        cluttered_table: false
+        clean_background_rate: 1
+        random_table_height: 0
+        random_light: false
+        crazy_random_light_rate: 0
+      camera:
+        collect_wrist_camera: true
+      data_type:
+        endpose: true
+      clear_cache_freq: 5
+    video_cfg:
+      video_base_dir: ${runner.logger.log_path}/video/eval
+
+rollout:
+  group_name: RolloutGroup
+  backend: huggingface
+  enable_offload: false
+  pipeline_stage_num: 1
+  model:
+    model_type: lingbotva
+    model_path: ${actor.model.model_path}
+    precision: ${actor.model.precision}
+
+actor:
+  group_name: ActorGroup
+  training_backend: fsdp
+  micro_batch_size: 1
+  global_batch_size: 1
+  seed: 1234
+  enable_offload: false
+  model:
+    model_type: lingbotva
+    model_path: ${oc.env:LINGBOT_VA_MODEL_PATH}
+    precision: bf16
+    num_action_chunks: 32
+    action_dim: 16
+    lingbotva:
+      repo_path: ${oc.env:LINGBOT_VA_REPO_PATH}
+      enable_offload: false
+      save_root: /tmp/rlinf_lingbotva
+      action_per_frame: 16
+  optim:
+    lr: 5.0e-05
+    value_lr: 1.0e-05
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_eps: 1.0e-05
+    weight_decay: 0.01
+    clip_grad: 1.0
+  fsdp_config:
+    strategy: fsdp
+    gradient_checkpointing: false
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+
+reward:
+  use_reward_model: false
+
+critic:
+  use_critic_model: false

--- a/requirements/embodied/download_assets.sh
+++ b/requirements/embodied/download_assets.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 DOWNLOAD_DIR=${DOWNLOAD_DIR:-$HOME}
-SUPPORT_LIST=("maniskill" "openpi")
+SUPPORT_LIST=("maniskill" "openpi" "lingbotva")
 GITHUB_PREFIX=${GITHUB_PREFIX:-""}
 ASSETS=()
 
@@ -66,6 +66,19 @@ download_openpi_assets() {
 	fi
 }
 
+download_lingbotva_assets() {
+	local root_dir=$1
+
+	export LINGBOTVA_MODEL_DIR="${root_dir}/.cache/lingbotva/lingbot-va-posttrain-robotwin"
+
+	if [ -f "$LINGBOTVA_MODEL_DIR/model_index.json" ] || [ -f "$LINGBOTVA_MODEL_DIR/config.json" ]; then
+		echo "[download_assets] LingBot-VA model already exists at $LINGBOTVA_MODEL_DIR, skipping download."
+	else
+		mkdir -p "$LINGBOTVA_MODEL_DIR"
+		hf download robbyant/lingbot-va-posttrain-robotwin --local-dir "$LINGBOTVA_MODEL_DIR"
+	fi
+}
+
 parse_args() {
 	while [ "$#" -gt 0 ]; do
 		case "$1" in
@@ -120,6 +133,9 @@ main() {
 				;;
 			openpi)
 				download_openpi_assets "$DOWNLOAD_DIR"
+				;;
+			lingbotva)
+				download_lingbotva_assets "$DOWNLOAD_DIR"
 				;;
 			*)
 				echo "Unknown asset group: $asset. Supported: ${SUPPORT_LIST[*]}" >&2

--- a/requirements/install.sh
+++ b/requirements/install.sh
@@ -17,7 +17,7 @@ GITHUB_PREFIX=""
 NO_ROOT=0
 NO_INSTALL_RLINF_CMD="--no-install-project"
 SUPPORTED_TARGETS=("embodied" "agentic" "docs")
-SUPPORTED_MODELS=("openvla" "openvla-oft" "openpi" "gr00t" "dexbotic" "lingbotvla")
+SUPPORTED_MODELS=("openvla" "openvla-oft" "openpi" "gr00t" "dexbotic" "lingbotvla" "lingbotva")
 SUPPORTED_ENVS=("behavior" "maniskill_libero" "metaworld" "calvin" "isaaclab" "robocasa" "franka" "frankasim" "robotwin" "habitat" "opensora" "wan" "xsquare_turtle2" "liberopro" "liberoplus")
 
 #=======================Utility Functions=======================
@@ -595,6 +595,35 @@ install_lingbot_vla_model() {
     uv pip uninstall pynvml || true
 }
 
+install_lingbot_va_model() {
+    if ! command -v uv &> /dev/null && [ -x "$HOME/.local/bin/uv" ]; then
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+    create_and_sync_venv
+    install_common_embodied_deps
+
+    local lingbotva_dir
+    lingbotva_dir=$(clone_or_reuse_repo LINGBOT_VA_REPO_PATH "$VENV_DIR/lingbot-va" ${GITHUB_PREFIX}https://github.com/robbyant/lingbot-va.git --recurse-submodules)
+    local filtered_requirements
+    filtered_requirements=$(mktemp)
+    grep -vE '^[[:space:]]*flash_attn([[:space:]]|=|>|<|!|$)' "$lingbotva_dir/requirements.txt" > "$filtered_requirements"
+    uv pip install -r "$filtered_requirements"
+    rm -f "$filtered_requirements"
+    echo "export LINGBOT_VA_REPO_PATH=$(realpath "$lingbotva_dir")" >> "$VENV_DIR/bin/activate"
+
+    case "$ENV_NAME" in
+        robotwin)
+            install_robotwin_env
+            install_flash_attn
+            ;;
+        *)
+            echo "Environment '$ENV_NAME' is not supported for LingBot-VA model." >&2
+            exit 1
+            ;;
+    esac
+    uv pip uninstall pynvml || true
+}
+
 install_env_only() {
     create_and_sync_venv
     SKIP_ROS=${SKIP_ROS:-0}
@@ -960,6 +989,9 @@ main() {
                     ;;
                 lingbotvla)                  
                     install_lingbot_vla_model 
+                    ;;
+                lingbotva)
+                    install_lingbot_va_model
                     ;;
                 "")
                     install_env_only

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -59,6 +59,7 @@ class SupportedModel(Enum):
     FLOW_POLICY = ("flow_policy", "embodied")
     CMA_POLICY = ("cma", "embodied")
     LINGBOTVLA = ("lingbotvla", "embodied")
+    LINGBOTVA = ("lingbotva", "embodied")
     RESNET_REWARD = ("resnet", "embodied")
 
     # Sft models

--- a/rlinf/data/embodied_io_struct.py
+++ b/rlinf/data/embodied_io_struct.py
@@ -103,13 +103,22 @@ class EnvOutput:
             else None
         )
 
-        return {
+        prepared = {
             "main_images": image_tensor,  # [N_ENV, H, W, C]
             "wrist_images": wrist_image_tensor,  # [N_ENV, H, W, C] or [N_ENV, N_IMG, H, W, C]
             "extra_view_images": extra_view_image_tensor,  # [N_ENV, N_IMG, H, W, C]
             "states": states,
             "task_descriptions": task_descriptions,
         }
+
+        extra_obs = obs.get("extra_obs")
+        if isinstance(extra_obs, dict) and extra_obs:
+            prepared["extra_obs"] = {
+                key: list(value) if isinstance(value, tuple) else value
+                for key, value in extra_obs.items()
+            }
+
+        return prepared
 
     @staticmethod
     def merge_env_outputs(env_outputs: list[dict]) -> dict[str, Any]:

--- a/rlinf/envs/robotwin/robotwin_env.py
+++ b/rlinf/envs/robotwin/robotwin_env.py
@@ -60,6 +60,7 @@ class RoboTwinEnv(gym.Env):
         self._is_start = True
 
         self.task_name = cfg.task_config.task_name
+        self.action_type = cfg.task_config.get("action_type", "qpos")
 
         self.center_crop = cfg.get("center_crop", False)
         self._init_reset_state_ids()
@@ -82,9 +83,13 @@ class RoboTwinEnv(gym.Env):
         from robotwin.envs.vector_env import VectorEnv
 
         env_seeds = self.reset_state_ids.tolist()
+        task_config = OmegaConf.to_container(self.cfg.task_config, resolve=True)
+        if self.action_type == "ee":
+            data_type = task_config.setdefault("data_type", {})
+            data_type["endpose"] = True
 
         self.venv = VectorEnv(
-            task_config=OmegaConf.to_container(self.cfg.task_config, resolve=True),
+            task_config=task_config,
             n_envs=self.num_envs,
             env_seeds=env_seeds,
         )
@@ -236,6 +241,51 @@ class RoboTwinEnv(gym.Env):
 
         return chunk_rewards
 
+    def _get_raw_task_obs(self) -> list[dict]:
+        return [sub_env.task.get_obs() for sub_env in self.venv.envs]
+
+    def _extract_eef_poses_from_raw_obs(
+        self, raw_obs: list[dict[str, dict[str, np.ndarray | float]]]
+    ) -> torch.Tensor:
+        eef_poses = []
+        for obs in raw_obs:
+            endpose = obs["endpose"]
+            pose = np.concatenate(
+                [
+                    np.asarray(endpose["left_endpose"], dtype=np.float32),
+                    np.asarray([endpose["left_gripper"]], dtype=np.float32),
+                    np.asarray(endpose["right_endpose"], dtype=np.float32),
+                    np.asarray([endpose["right_gripper"]], dtype=np.float32),
+                ]
+            )
+            eef_poses.append(torch.from_numpy(pose))
+        return torch.stack(eef_poses)
+
+    def _attach_extra_obs(
+        self,
+        extracted_obs: dict[str, torch.Tensor | list[str] | None],
+        *,
+        raw_task_obs: list[dict],
+        chunk_observations: list[list[dict]] | None = None,
+        episode_dones: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor | list[str] | dict[str, object] | None]:
+        obs = dict(extracted_obs)
+        extra_obs = dict(obs.get("extra_obs") or {})
+        extra_obs["eef_poses"] = self._extract_eef_poses_from_raw_obs(raw_task_obs)
+        if chunk_observations is not None:
+            extra_obs["chunk_observations"] = chunk_observations
+        if episode_dones is not None:
+            extra_obs["episode_dones"] = episode_dones
+        obs["extra_obs"] = extra_obs
+        return obs
+
+    def _collect_current_obs(self) -> tuple[dict, list[dict]]:
+        raw_obs = [sub_env.get_obs() for sub_env in self.venv.envs]
+        extracted_obs = self._extract_obs_image(raw_obs)
+        raw_task_obs = self._get_raw_task_obs()
+        extracted_obs = self._attach_extra_obs(extracted_obs, raw_task_obs=raw_task_obs)
+        return extracted_obs, raw_obs
+
     def reset(
         self,
         env_idx: Optional[Union[int, list[int]]] = None,
@@ -253,6 +303,10 @@ class RoboTwinEnv(gym.Env):
         self._reset_metrics(env_idx)
 
         extracted_obs = self._extract_obs_image(raw_obs)
+        if self.action_type == "ee":
+            extracted_obs = self._attach_extra_obs(
+                extracted_obs, raw_task_obs=self._get_raw_task_obs()
+            )
 
         return extracted_obs, infos
 
@@ -271,6 +325,22 @@ class RoboTwinEnv(gym.Env):
         if len(actions.shape) == 2:
             # [n_envs, action_dim] -> [n_envs, 1, action_dim]
             actions = actions[:, None, :]
+
+        if self.action_type == "ee":
+            (
+                obs_list,
+                chunk_rewards,
+                chunk_terminations,
+                chunk_truncations,
+                infos_list,
+            ) = self.chunk_step(actions)
+            return (
+                obs_list[-1],
+                chunk_rewards[:, -1],
+                chunk_terminations[:, -1],
+                chunk_truncations[:, -1],
+                infos_list[-1],
+            )
 
         raw_obs, step_reward, terminations, truncations, info_list = self.venv.step(
             actions
@@ -320,6 +390,9 @@ class RoboTwinEnv(gym.Env):
     def chunk_step(self, chunk_actions):
         if isinstance(chunk_actions, torch.Tensor):
             chunk_actions = chunk_actions.cpu().numpy()
+
+        if self.action_type == "ee":
+            return self._ee_chunk_step(chunk_actions)
 
         # chunk_actions: [num_envs, chunk_step, action_dim]
         num_envs = chunk_actions.shape[0]
@@ -380,6 +453,99 @@ class RoboTwinEnv(gym.Env):
 
         chunk_truncations = torch.zeros((num_envs, chunk_step))
         chunk_truncations[:, -1] = truncations
+
+        return (
+            obs_list,
+            chunk_rewards,
+            chunk_terminations,
+            chunk_truncations,
+            infos_list,
+        )
+
+    def _ee_chunk_step(self, chunk_actions):
+        num_envs, chunk_step, _ = chunk_actions.shape
+        obs_list = []
+        infos_list = []
+        chunk_rewards = torch.zeros(
+            (num_envs, chunk_step), dtype=torch.float32, device=self.device
+        )
+        chunk_terminations = torch.zeros(
+            (num_envs, chunk_step), dtype=torch.bool, device=self.device
+        )
+        chunk_truncations = torch.zeros(
+            (num_envs, chunk_step), dtype=torch.bool, device=self.device
+        )
+        chunk_observations = [[] for _ in range(num_envs)]
+
+        for step_idx in range(chunk_step):
+            step_success = torch.zeros(num_envs, dtype=torch.bool, device=self.device)
+            step_truncated = torch.zeros(num_envs, dtype=torch.bool, device=self.device)
+
+            for env_id, sub_env in enumerate(self.venv.envs):
+                sub_env.task.take_action(
+                    chunk_actions[env_id, step_idx], action_type="ee"
+                )
+                success = bool(getattr(sub_env.task, "eval_success", False))
+                step_limit = getattr(sub_env.task, "step_lim", None)
+                take_action_cnt = getattr(sub_env.task, "take_action_cnt", 0)
+                truncated = bool(
+                    step_limit is not None
+                    and take_action_cnt >= step_limit
+                    and not success
+                )
+                step_success[env_id] = success
+                step_truncated[env_id] = truncated
+
+            extracted_obs, raw_obs = self._collect_current_obs()
+            for env_id, raw_step_obs in enumerate(raw_obs):
+                chunk_observations[env_id].append(raw_step_obs)
+
+            infos = {"success": step_success.clone()}
+            if self.record_metrics:
+                infos = self._record_metrics(
+                    step_success.to(dtype=torch.float32), infos
+                )
+
+            obs_list.append(extracted_obs)
+            infos_list.append(infos)
+            chunk_rewards[:, step_idx] = step_success.to(dtype=torch.float32)
+            chunk_terminations[:, step_idx] = step_success
+            chunk_truncations[:, step_idx] = step_truncated
+
+        self._elapsed_steps += chunk_step
+        truncated = self._elapsed_steps >= self.cfg.max_episode_steps
+        if truncated.any():
+            chunk_truncations[:, -1] = torch.logical_or(
+                truncated, chunk_truncations[:, -1]
+            )
+
+        if self.ignore_terminations:
+            chunk_terminations[:] = False
+            if self.record_metrics and infos_list:
+                infos_list[-1]["episode"]["success_at_end"] = infos_list[-1][
+                    "success"
+                ].clone()
+
+        episode_dones = torch.logical_or(
+            chunk_terminations[:, -1], chunk_truncations[:, -1]
+        )
+        obs_list[-1] = self._attach_extra_obs(
+            obs_list[-1],
+            raw_task_obs=self._get_raw_task_obs(),
+            chunk_observations=chunk_observations,
+            episode_dones=episode_dones,
+        )
+
+        if episode_dones.any() and self.auto_reset:
+            obs_list[-1], infos_list[-1] = self._handle_auto_reset(
+                episode_dones, obs_list[-1], infos_list[-1]
+            )
+            obs_list[-1] = self._attach_extra_obs(
+                obs_list[-1],
+                raw_task_obs=self._get_raw_task_obs(),
+                chunk_observations=chunk_observations,
+                episode_dones=episode_dones,
+            )
 
         return (
             obs_list,

--- a/rlinf/models/__init__.py
+++ b/rlinf/models/__init__.py
@@ -38,6 +38,8 @@ def get_model(cfg: DictConfig):
         from rlinf.models.embodiment.flow_policy import get_model
     elif model_type == SupportedModel.LINGBOTVLA:
         from rlinf.models.embodiment.lingbotvla import get_model
+    elif model_type == SupportedModel.LINGBOTVA:
+        from rlinf.models.embodiment.lingbotva import get_model
     else:
         return None
 

--- a/rlinf/models/embodiment/lingbotva/__init__.py
+++ b/rlinf/models/embodiment/lingbotva/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LingBot-VA embodied model integration for RLinf."""
+
+from __future__ import annotations
+
+import torch
+from omegaconf import DictConfig
+
+from rlinf.utils.logging import get_logger
+
+
+def get_model(cfg: DictConfig, torch_dtype: torch.dtype | None = None):
+    """Build the LingBot-VA model adapter.
+
+    Args:
+        cfg: Model configuration.
+        torch_dtype: Optional target dtype for the adapter.
+
+    Returns:
+        The LingBot-VA action model.
+    """
+    from rlinf.models.embodiment.lingbotva.lingbotva_action_model import (
+        LingbotVAActionModel,
+    )
+
+    model = LingbotVAActionModel(cfg=cfg, torch_dtype=torch_dtype or torch.bfloat16)
+    get_logger().info("Initialized LingBot-VA adapter.")
+    return model

--- a/rlinf/models/embodiment/lingbotva/history_buffer.py
+++ b/rlinf/models/embodiment/lingbotva/history_buffer.py
@@ -1,0 +1,76 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""State helpers for LingBot-VA chunked rollout."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class LingbotVAEpisodeState:
+    """Episode-local LingBot-VA rollout state."""
+
+    prompt: str | None = None
+    first_obs: dict[str, Any] | None = None
+    first_chunk: bool = True
+    chunk_id: int = 0
+    action_queue: deque[np.ndarray] = field(default_factory=deque)
+    prev_model_action: np.ndarray | None = None
+    initial_eef_pose: np.ndarray | None = None
+    last_action_per_frame: int | None = None
+
+    def reset(self, prompt: str, initial_eef_pose: np.ndarray | None = None) -> None:
+        self.prompt = prompt
+        self.first_obs = None
+        self.first_chunk = True
+        self.chunk_id = 0
+        self.action_queue.clear()
+        self.prev_model_action = None
+        self.initial_eef_pose = initial_eef_pose
+        self.last_action_per_frame = None
+
+
+def select_key_frames(
+    chunk_observations: list[list[dict[str, Any]]] | None,
+    env_idx: int,
+    prompt: str,
+    action_per_frame: int,
+) -> list[dict[str, Any]]:
+    """Select official key frames from per-step chunk observations."""
+    if not chunk_observations:
+        return []
+    if env_idx >= len(chunk_observations):
+        return []
+
+    from rlinf.models.embodiment.lingbotva.observation_adapter import (
+        LingbotVAObservationAdapter,
+    )
+
+    frames: list[dict[str, Any]] = []
+    for step_idx, obs in enumerate(chunk_observations[env_idx]):
+        if (step_idx + 1) % action_per_frame != 0:
+            continue
+        frames.append(
+            LingbotVAObservationAdapter.format_raw_step_observation(
+                raw_obs=obs,
+                prompt=prompt,
+            )
+        )
+    return frames

--- a/rlinf/models/embodiment/lingbotva/lingbotva_action_model.py
+++ b/rlinf/models/embodiment/lingbotva/lingbotva_action_model.py
@@ -1,0 +1,281 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LingBot-VA adapter for RLinf embodied rollout."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+from scipy.spatial.transform import Rotation as R
+
+from rlinf.models.embodiment.base_policy import BasePolicy
+from rlinf.models.embodiment.lingbotva.history_buffer import (
+    LingbotVAEpisodeState,
+    select_key_frames,
+)
+from rlinf.models.embodiment.lingbotva.native_backend import LingbotVANativeBackend
+from rlinf.models.embodiment.lingbotva.observation_adapter import (
+    LingbotVAObservationAdapter,
+)
+
+
+class LingbotVAActionModel(nn.Module, BasePolicy):
+    """RLinf action model wrapper for official single-session LingBot-VA eval."""
+
+    def __init__(self, cfg: Any, torch_dtype: torch.dtype = torch.bfloat16):
+        super().__init__()
+        self.config = cfg
+        self.torch_dtype = torch_dtype
+        self.num_action_chunks = int(getattr(cfg, "num_action_chunks", 32))
+        self.action_dim = int(getattr(cfg, "action_dim", 16))
+        self.action_env_dim = int(getattr(cfg, "action_env_dim", self.action_dim))
+        self._backend: LingbotVANativeBackend | None = None
+        # Runtime guards keep LingBot-VA single-session today; the dict is retained
+        # to keep the existing reset/refill helpers simple around env_idx.
+        self._episode_states: dict[int, LingbotVAEpisodeState] = {}
+        self.action_per_frame = int(getattr(cfg.lingbotva, "action_per_frame", 16))
+
+    @staticmethod
+    def _get_extra_obs(env_obs: dict[str, Any]) -> dict[str, Any]:
+        extra_obs = env_obs.get("extra_obs")
+        if isinstance(extra_obs, dict):
+            return extra_obs
+        if isinstance(extra_obs, (list, tuple)):
+            merged: dict[str, Any] = {}
+            for item in extra_obs:
+                if not isinstance(item, dict):
+                    continue
+                for key, value in item.items():
+                    if key not in merged:
+                        merged[key] = value
+                        continue
+                    existing = merged[key]
+                    if isinstance(existing, list):
+                        if isinstance(value, list):
+                            existing.extend(value)
+                        else:
+                            existing.append(value)
+                        continue
+                    if isinstance(existing, tuple):
+                        if isinstance(value, tuple):
+                            merged[key] = existing + value
+                        else:
+                            merged[key] = existing + (value,)
+                        continue
+                    if torch.is_tensor(existing):
+                        if torch.is_tensor(value):
+                            try:
+                                merged[key] = torch.cat([existing, value], dim=0)
+                            except Exception:
+                                merged[key] = value
+                        else:
+                            merged[key] = value
+                        continue
+                    merged[key] = value
+            return merged
+        return {}
+
+    def _get_env_meta(self, env_obs: dict[str, Any], key: str) -> Any:
+        extra_obs = self._get_extra_obs(env_obs)
+        if key in extra_obs:
+            return extra_obs[key]
+        return env_obs.get(key)
+
+    def default_forward(self, **kwargs):
+        raise NotImplementedError(
+            "LingBot-VA currently supports rollout/evaluation via predict_action_batch only."
+        )
+
+    def _ensure_backend(self) -> LingbotVANativeBackend:
+        if self._backend is None:
+            self._backend = LingbotVANativeBackend(self.config, self.torch_dtype)
+        return self._backend
+
+    def _get_prompt(self, env_obs: dict[str, Any], env_idx: int) -> str:
+        prompts = env_obs.get("task_descriptions")
+        if prompts is None:
+            raise ValueError(
+                "LingBot-VA requires task_descriptions in env observations."
+            )
+        return str(prompts[env_idx])
+
+    def _get_state(self, env_idx: int) -> LingbotVAEpisodeState:
+        if env_idx not in self._episode_states:
+            self._episode_states[env_idx] = LingbotVAEpisodeState()
+        return self._episode_states[env_idx]
+
+    def _format_initial_eef_pose(
+        self, env_obs: dict[str, Any], env_idx: int
+    ) -> np.ndarray | None:
+        eef_poses = self._get_env_meta(env_obs, "eef_poses")
+        if eef_poses is None:
+            return None
+        if isinstance(eef_poses, torch.Tensor):
+            pose = eef_poses[env_idx].detach().cpu().numpy().astype(np.float32)
+        else:
+            pose = np.asarray(eef_poses[env_idx], dtype=np.float32)
+        if pose.shape[-1] != 16:
+            raise ValueError(f"Expected 16D reset ee pose, got shape {pose.shape}.")
+        return pose.copy()
+
+    @staticmethod
+    def _add_eef_pose(delta_pose: np.ndarray, init_pose: np.ndarray) -> np.ndarray:
+        delta_rot = R.from_quat(delta_pose[3:7][None])
+        init_rot = R.from_quat(init_pose[3:7][None])
+        out_rot = (init_rot * delta_rot).as_quat().reshape(-1)
+        out_trans = delta_pose[:3] + init_pose[:3]
+        return np.concatenate([out_trans, out_rot, delta_pose[7:8]], axis=0)
+
+    def _add_init_pose(
+        self, delta_action: np.ndarray, initial_pose: np.ndarray
+    ) -> np.ndarray:
+        left = self._add_eef_pose(delta_action[:8], initial_pose[:8])
+        right = self._add_eef_pose(delta_action[8:], initial_pose[8:])
+        out = np.concatenate([left, right], axis=0).astype(np.float32)
+        out[3:7] = out[3:7] / np.linalg.norm(out[3:7])
+        out[11:15] = out[11:15] / np.linalg.norm(out[11:15])
+        return out
+
+    def _flatten_raw_action(self, raw_action: np.ndarray) -> np.ndarray:
+        return np.transpose(raw_action, (1, 2, 0)).reshape(-1, raw_action.shape[0])
+
+    def _select_executable_actions(
+        self, raw_action: np.ndarray, first_chunk: bool
+    ) -> np.ndarray:
+        start_idx = 1 if first_chunk else 0
+        selected = raw_action[:, start_idx:, :]
+        return np.transpose(selected, (1, 2, 0)).reshape(-1, raw_action.shape[0])
+
+    def _convert_raw_to_env_actions(
+        self,
+        raw_action: np.ndarray,
+        initial_eef_pose: np.ndarray,
+        first_chunk: bool,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        flattened_model = self._flatten_raw_action(raw_action)
+        executable_model = self._select_executable_actions(raw_action, first_chunk)
+        env_actions = np.stack(
+            [self._add_init_pose(step, initial_eef_pose) for step in executable_model],
+            axis=0,
+        )
+        return flattened_model, env_actions
+
+    def _reset_episode(
+        self, env_idx: int, prompt: str, env_obs: dict[str, Any]
+    ) -> LingbotVAEpisodeState:
+        state = self._get_state(env_idx)
+        initial_eef_pose = self._format_initial_eef_pose(env_obs, env_idx)
+        if initial_eef_pose is None:
+            raise ValueError(
+                "LingBot-VA requires reset-time eef_poses from RoboTwinEnv."
+            )
+        state.reset(prompt=prompt, initial_eef_pose=initial_eef_pose)
+        self._ensure_backend().reset(prompt)
+        return state
+
+    def _refill_action_queue(
+        self, env_idx: int, env_obs: dict[str, Any], state: LingbotVAEpisodeState
+    ) -> None:
+        prompt = state.prompt or self._get_prompt(env_obs, env_idx)
+        backend = self._ensure_backend()
+        if state.first_chunk:
+            first_obs = LingbotVAObservationAdapter.format_observation(
+                env_obs, env_idx, prompt
+            )
+            state.first_obs = first_obs
+            raw_action = backend.infer(first_obs, prompt)
+        else:
+            action_per_frame = state.last_action_per_frame or self.action_per_frame
+            key_frames = select_key_frames(
+                chunk_observations=self._get_env_meta(env_obs, "chunk_observations"),
+                env_idx=env_idx,
+                prompt=prompt,
+                action_per_frame=action_per_frame,
+            )
+            if not key_frames:
+                raise ValueError(
+                    "LingBot-VA follow-up chunk requires non-empty key_frame_list."
+                )
+            if state.first_obs is None:
+                raise ValueError(
+                    "LingBot-VA follow-up chunk requires cached first_obs from the first infer."
+                )
+            backend.compute_kv_cache(key_frames, state.prev_model_action)
+            raw_action = backend.infer(state.first_obs, prompt)
+
+        state.prev_model_action = raw_action.astype(np.float32)
+        state.last_action_per_frame = max(1, raw_action.shape[2] // 4)
+        _, env_actions = self._convert_raw_to_env_actions(
+            raw_action=raw_action,
+            initial_eef_pose=state.initial_eef_pose,
+            first_chunk=state.first_chunk,
+        )
+        state.action_queue.clear()
+        for action in env_actions:
+            state.action_queue.append(action.astype(np.float32))
+        state.first_chunk = False
+        state.chunk_id += 1
+
+    def predict_action_batch(
+        self, env_obs: dict[str, Any], mode: str = "eval", **_: Any
+    ):
+        del mode
+        states_tensor = env_obs.get("states")
+        if states_tensor is None:
+            raise ValueError("LingBot-VA requires batched states in env observations.")
+        batch_size = states_tensor.shape[0]
+        if batch_size != 1:
+            raise ValueError(
+                "Official LingBot-VA websocket backend is stateful and currently "
+                "only supports single-session evaluation with batch_size == 1."
+            )
+        actions = []
+        for env_idx in range(batch_size):
+            prompt = self._get_prompt(env_obs, env_idx)
+            episode_done = False
+            episode_dones = self._get_env_meta(env_obs, "episode_dones")
+            if isinstance(episode_dones, torch.Tensor):
+                if episode_dones.dim() == 1:
+                    episode_done = bool(episode_dones[env_idx].item())
+                else:
+                    episode_done = bool(episode_dones[env_idx, -1].item())
+            state = self._get_state(env_idx)
+            if state.prompt != prompt or state.prompt is None or episode_done:
+                state = self._reset_episode(env_idx, prompt, env_obs)
+            if not state.action_queue:
+                self._refill_action_queue(env_idx, env_obs, state)
+            if not state.action_queue:
+                raise RuntimeError("LingBot-VA refill produced an empty action queue.")
+            chunk_actions = np.stack(list(state.action_queue), axis=0)
+            state.action_queue.clear()
+            actions.append(torch.from_numpy(chunk_actions))
+
+        chunk_lengths = [action.shape[0] for action in actions]
+        if len(set(chunk_lengths)) != 1:
+            raise RuntimeError(
+                "LingBot-VA chunk lengths must match across batch: "
+                + str(chunk_lengths)
+            )
+
+        action_tensor = torch.stack(actions, dim=0).to(dtype=torch.float32)
+        result = {
+            "prev_logprobs": torch.zeros(action_tensor.shape[:2], dtype=torch.float32),
+            "prev_values": torch.zeros(action_tensor.shape[:2], dtype=torch.float32),
+            "forward_inputs": {"action": action_tensor},
+        }
+        return action_tensor, result

--- a/rlinf/models/embodiment/lingbotva/native_backend.py
+++ b/rlinf/models/embodiment/lingbotva/native_backend.py
@@ -1,0 +1,234 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Websocket client backend for the official LingBot-VA server."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from rlinf.utils.logging import get_logger
+
+logger = get_logger()
+
+
+class LingbotVANativeBackend:
+    """Thin wrapper around the official stateful single-session websocket server."""
+
+    def __init__(self, cfg: Any, torch_dtype: torch.dtype) -> None:
+        self.cfg = cfg
+        self.torch_dtype = torch_dtype
+        self.repo_path = Path(getattr(cfg.lingbotva, "repo_path"))
+        self.model_path = Path(cfg.model_path)
+        self.save_root = str(
+            getattr(cfg.lingbotva, "save_root", "/tmp/lingbotva_rlinf")
+        )
+        self._validate_attn_mode(self.model_path)
+        self._server_process: subprocess.Popen[str] | None = None
+        self._server_log_path: str | None = None
+        self._owns_server_process = False
+        self._client = self._build_client()
+        atexit.register(self.close)
+
+    @staticmethod
+    def _validate_attn_mode(model_path: Path) -> None:
+        config_path = model_path / "transformer" / "config.json"
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"LingBot-VA transformer config not found at {config_path}."
+            )
+        config_data = json.loads(config_path.read_text())
+        attn_mode = config_data.get("attn_mode")
+        if attn_mode not in {"torch", "flashattn"}:
+            raise ValueError(
+                "LingBot-VA inference requires transformer/config.json attn_mode "
+                f'to be "torch" or "flashattn", but got {attn_mode!r}.'
+            )
+
+    @staticmethod
+    def _dtype_to_arg(torch_dtype: torch.dtype) -> str:
+        if torch_dtype == torch.bfloat16:
+            return "bf16"
+        if torch_dtype == torch.float16:
+            return "fp16"
+        if torch_dtype == torch.float32:
+            return "fp32"
+        raise ValueError(
+            f"Unsupported torch dtype for LingBot-VA backend: {torch_dtype!r}."
+        )
+
+    @staticmethod
+    def _find_free_port() -> int:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(1)
+            return int(sock.getsockname()[1])
+
+    def _import_client_cls(self):
+        sys.path.insert(0, str(self.repo_path))
+        sys.path.insert(0, str(self.repo_path / "wan_va"))
+        from utils.Simple_Remote_Infer.deploy.websocket_client_policy import (
+            WebsocketClientPolicy,
+        )
+
+        return WebsocketClientPolicy
+
+    @staticmethod
+    def _can_connect(host: str, port: int, timeout: float = 1.0) -> bool:
+        try:
+            with socket.create_connection((host, port), timeout=timeout):
+                return True
+        except OSError:
+            return False
+
+    def _launch_server_process(self, host: str, port: int) -> None:
+        launcher_path = Path(__file__).with_name("server_launcher.py")
+        if not launcher_path.exists():
+            repo_path = os.environ.get("REPO_PATH")
+            if repo_path:
+                candidate = (
+                    Path(repo_path)
+                    / "rlinf"
+                    / "models"
+                    / "embodiment"
+                    / "lingbotva"
+                    / "server_launcher.py"
+                )
+                if candidate.exists():
+                    launcher_path = candidate
+        if not launcher_path.exists():
+            raise FileNotFoundError(
+                f"LingBot-VA server launcher not found near {__file__}."
+            )
+        master_port = self._find_free_port()
+        save_root = Path(self.save_root)
+        save_root.mkdir(parents=True, exist_ok=True)
+        self._server_log_path = str(save_root / f"lingbotva_server_{port}.log")
+        env = os.environ.copy()
+        env["MASTER_ADDR"] = "127.0.0.1"
+        env["MASTER_PORT"] = str(master_port)
+        env["RANK"] = "0"
+        env["WORLD_SIZE"] = "1"
+        env["LOCAL_RANK"] = "0"
+        server_cuda_visible_devices = getattr(
+            self.cfg.lingbotva, "server_cuda_visible_devices", None
+        )
+        if server_cuda_visible_devices is not None:
+            env["CUDA_VISIBLE_DEVICES"] = str(server_cuda_visible_devices)
+        server_threads = str(
+            getattr(self.cfg.lingbotva, "server_torch_num_threads", 32)
+        )
+        env["LINGBOTVA_TORCH_NUM_THREADS"] = server_threads
+        env["OMP_NUM_THREADS"] = server_threads
+        env["MKL_NUM_THREADS"] = server_threads
+        env["OPENBLAS_NUM_THREADS"] = server_threads
+        env["NUMEXPR_NUM_THREADS"] = server_threads
+        pythonpath_parts = [str(self.repo_path), str(self.repo_path / "wan_va")]
+        existing = env.get("PYTHONPATH", "")
+        if existing:
+            pythonpath_parts.append(existing)
+        env["PYTHONPATH"] = ":".join(pythonpath_parts)
+        cmd = [
+            sys.executable,
+            str(launcher_path),
+            "--repo-path",
+            str(self.repo_path),
+            "--config-name",
+            "robotwin",
+            "--model-path",
+            str(self.model_path),
+            "--save-root",
+            self.save_root,
+            "--host",
+            host,
+            "--port",
+            str(port),
+            "--enable-offload",
+            "true"
+            if bool(getattr(self.cfg.lingbotva, "enable_offload", True))
+            else "false",
+            "--param-dtype",
+            self._dtype_to_arg(self.torch_dtype),
+        ]
+        log_file = open(self._server_log_path, "w", encoding="utf-8")
+        self._server_process = subprocess.Popen(
+            cmd,
+            cwd=str(self.repo_path),
+            env=env,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        self._owns_server_process = True
+        logger.info(
+            "Launched LingBot-VA official server subprocess on ws://%s:%s", host, port
+        )
+
+    def _build_client(self):
+        # LingBot-VA official websocket inference keeps prompt/cache state inside a
+        # single server session, so RLinf intentionally reuses one client/session
+        # per rollout worker and guards batch size at higher levels.
+        host = "127.0.0.1"
+        reuse_server = bool(getattr(self.cfg.lingbotva, "reuse_server", False))
+        fixed_port = getattr(self.cfg.lingbotva, "fixed_server_port", None)
+        port = int(fixed_port) if fixed_port is not None else self._find_free_port()
+        client_cls = self._import_client_cls()
+
+        if reuse_server and self._can_connect(host, port):
+            logger.info("Reusing existing LingBot-VA server at ws://%s:%s", host, port)
+            return client_cls(host=host, port=port)
+
+        self._launch_server_process(host, port)
+        return client_cls(host=host, port=port)
+
+    def reset(self, prompt: str) -> None:
+        self._client.infer({"reset": True, "prompt": prompt})
+
+    def infer(self, obs: dict[str, Any], prompt: str) -> np.ndarray:
+        result = self._client.infer({"obs": obs, "prompt": prompt})
+        action = result.get("action")
+        if action is None:
+            raise RuntimeError("LingBot-VA server infer returned no action tensor.")
+        return np.asarray(action)
+
+    def compute_kv_cache(self, obs: list[dict[str, Any]], state: np.ndarray) -> None:
+        self._client.infer({"obs": obs, "compute_kv_cache": True, "state": state})
+
+    def close(self) -> None:
+        if self._server_process is None or not self._owns_server_process:
+            return
+        if self._server_process.poll() is None:
+            self._server_process.terminate()
+            try:
+                self._server_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._server_process.kill()
+                self._server_process.wait(timeout=10)
+        self._server_process = None
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/rlinf/models/embodiment/lingbotva/observation_adapter.py
+++ b/rlinf/models/embodiment/lingbotva/observation_adapter.py
@@ -1,0 +1,116 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Observation conversion utilities for LingBot-VA."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+
+
+class LingbotVAObservationAdapter:
+    """Convert RLinf RoboTwin observations into LingBot-VA official format."""
+
+    @staticmethod
+    def _to_numpy(value: Any) -> np.ndarray:
+        if isinstance(value, torch.Tensor):
+            return value.detach().cpu().numpy()
+        return np.asarray(value)
+
+    @staticmethod
+    def _select_image_tensor(image_tensor: Any, env_idx: int) -> np.ndarray:
+        if image_tensor is None:
+            raise ValueError("LingBot-VA requires image observations, but got None.")
+        if isinstance(image_tensor, torch.Tensor):
+            return image_tensor[env_idx].detach().cpu().numpy()
+        return np.asarray(image_tensor[env_idx])
+
+    @staticmethod
+    def _select_state_tensor(state_tensor: Any, env_idx: int) -> np.ndarray:
+        if state_tensor is None:
+            raise ValueError("LingBot-VA requires proprio/state observations.")
+        if isinstance(state_tensor, torch.Tensor):
+            return state_tensor[env_idx].detach().cpu().numpy()
+        return np.asarray(state_tensor[env_idx])
+
+    @classmethod
+    def format_raw_step_observation(
+        cls,
+        raw_obs: dict[str, Any],
+        prompt: str,
+    ) -> dict[str, Any]:
+        """Convert one raw RoboTwin step observation to LingBot-VA official format."""
+        left_wrist = raw_obs.get("left_wrist_image")
+        right_wrist = raw_obs.get("right_wrist_image")
+        if left_wrist is None or right_wrist is None:
+            raise ValueError(
+                "LingBot-VA raw RoboTwin step observation expects both left and right wrist images."
+            )
+
+        state = raw_obs.get("state")
+        if state is None:
+            raise ValueError("LingBot-VA raw RoboTwin step observation expects state.")
+
+        main_image = raw_obs.get("full_image")
+        if main_image is None:
+            raise ValueError(
+                "LingBot-VA raw RoboTwin step observation expects full_image."
+            )
+
+        return {
+            "observation.images.cam_high": cls._to_numpy(main_image),
+            "observation.images.cam_left_wrist": cls._to_numpy(left_wrist),
+            "observation.images.cam_right_wrist": cls._to_numpy(right_wrist),
+            "observation.state": cls._to_numpy(state),
+            "task": prompt,
+        }
+
+    @classmethod
+    def format_observation(
+        cls,
+        env_obs: dict[str, Any],
+        env_idx: int,
+        prompt: str,
+    ) -> dict[str, Any]:
+        """Convert one batch element to the official LingBot-VA RoboTwin format."""
+        wrist_images = env_obs.get("wrist_images")
+        left_wrist = None
+        right_wrist = None
+        if wrist_images is not None:
+            if isinstance(wrist_images, torch.Tensor):
+                wrist_np = wrist_images[env_idx].detach().cpu().numpy()
+            else:
+                wrist_np = np.asarray(wrist_images[env_idx])
+            if wrist_np.ndim == 4 and wrist_np.shape[0] >= 2:
+                left_wrist = wrist_np[0]
+                right_wrist = wrist_np[1]
+
+        if left_wrist is None or right_wrist is None:
+            raise ValueError(
+                "LingBot-VA RoboTwin adapter expects both left and right wrist images."
+            )
+        main_image = cls._select_image_tensor(env_obs.get("main_images"), env_idx)
+
+        return {
+            "observation.images.cam_high": main_image,
+            "observation.images.cam_left_wrist": left_wrist,
+            "observation.images.cam_right_wrist": right_wrist,
+            "observation.state": cls._select_state_tensor(
+                env_obs.get("states"), env_idx
+            ),
+            "task": prompt,
+        }

--- a/rlinf/models/embodiment/lingbotva/server_launcher.py
+++ b/rlinf/models/embodiment/lingbotva/server_launcher.py
@@ -1,0 +1,149 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch the official LingBot-VA websocket server in a subprocess."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib.machinery
+import json
+import os
+import sys
+import types
+from argparse import Namespace
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+
+
+def _install_flash_attn_shim_if_needed(model_path: Path) -> None:
+    config_path = model_path / "transformer" / "config.json"
+    if not config_path.exists():
+        return
+    attn_mode = json.loads(config_path.read_text()).get("attn_mode")
+    if attn_mode != "torch":
+        return
+    try:
+        import flash_attn  # noqa: F401
+
+        return
+    except Exception:
+        pass
+
+    def flash_attn_func(
+        query,
+        key,
+        value,
+        dropout_p=0.0,
+        softmax_scale=None,
+        causal=False,
+        *args,
+        **kwargs,
+    ):
+        out = F.scaled_dot_product_attention(
+            query.transpose(1, 2),
+            key.transpose(1, 2),
+            value.transpose(1, 2),
+            dropout_p=dropout_p,
+            scale=softmax_scale,
+            is_causal=causal,
+        )
+        return out.transpose(1, 2)
+
+    shim = types.ModuleType("flash_attn")
+    shim.flash_attn_func = flash_attn_func
+    shim.__spec__ = importlib.machinery.ModuleSpec("flash_attn", loader=None)
+    interface_shim = types.ModuleType("flash_attn_interface")
+    interface_shim.flash_attn_func = flash_attn_func
+    interface_shim.__spec__ = importlib.machinery.ModuleSpec(
+        "flash_attn_interface", loader=None
+    )
+    sys.modules.setdefault("flash_attn", shim)
+    sys.modules.setdefault("flash_attn_interface", interface_shim)
+
+
+def _parse_dtype(name: str) -> torch.dtype:
+    mapping = {
+        "bf16": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "fp16": torch.float16,
+        "float16": torch.float16,
+        "fp32": torch.float32,
+        "float32": torch.float32,
+    }
+    if name not in mapping:
+        raise ValueError(f"Unsupported LingBot-VA dtype override: {name!r}.")
+    return mapping[name]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-path", required=True)
+    parser.add_argument("--config-name", default="robotwin")
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--save-root", required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--enable-offload", choices=["true", "false"], default="true")
+    parser.add_argument("--param-dtype", default="bf16")
+    args = parser.parse_args()
+
+    repo_path = Path(args.repo_path)
+    model_path = Path(args.model_path)
+    torch_num_threads = int(os.environ.get("LINGBOTVA_TORCH_NUM_THREADS", "32"))
+    try:
+        torch.set_num_threads(torch_num_threads)
+    except Exception:
+        pass
+    try:
+        torch.set_num_interop_threads(max(1, min(8, torch_num_threads // 4)))
+    except Exception:
+        pass
+    sys.path.insert(0, str(repo_path))
+    sys.path.insert(0, str(repo_path / "wan_va"))
+
+    _install_flash_attn_shim_if_needed(model_path)
+
+    import wan_va.wan_va_server as wan_va_server
+    from wan_va.configs import VA_CONFIGS
+    from wan_va.utils import init_logger, logger
+
+    init_logger()
+    config = copy.deepcopy(VA_CONFIGS[args.config_name])
+    config.wan22_pretrained_model_name_or_path = str(model_path)
+    config.save_root = args.save_root
+    config.host = args.host
+    config.port = args.port
+    config.enable_offload = args.enable_offload == "true"
+    config.param_dtype = _parse_dtype(args.param_dtype)
+
+    VA_CONFIGS[args.config_name] = config
+    if hasattr(wan_va_server, "VA_CONFIGS"):
+        wan_va_server.VA_CONFIGS[args.config_name] = config
+
+    logger.info("Launching LingBot-VA official websocket server via wan_va_server.run.")
+    wan_va_server.run(
+        Namespace(
+            config_name=args.config_name,
+            port=args.port,
+            save_root=args.save_root,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/rlinf/runners/embodied_eval_runner.py
+++ b/rlinf/runners/embodied_eval_runner.py
@@ -62,7 +62,7 @@ class EmbodiedEvalRunner:
     def evaluate(self):
         env_handle: Handle = self.env.evaluate(
             input_channel=self.rollout_channel,
-            output_channel=self.env_channel,
+            rollout_channel=self.env_channel,
         )
         rollout_handle: Handle = self.rollout.evaluate(
             input_channel=self.env_channel,

--- a/rlinf/workers/rollout/hf/huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/huggingface_worker.py
@@ -72,6 +72,20 @@ class MultiStepRolloutWorker(Worker):
         self.enable_cuda_graph = cfg.rollout.get("enable_cuda_graph", False)
         self.enable_eval = cfg.runner.val_check_interval > 0 or cfg.runner.only_eval
 
+        if SupportedModel(self.cfg.actor.model.model_type) == SupportedModel.LINGBOTVA:
+            if not self.cfg.runner.only_eval:
+                raise ValueError(
+                    "Official LingBot-VA websocket backend is stateful and currently "
+                    "only supports single-session evaluation per rollout worker. "
+                    "Please set runner.only_eval=True."
+                )
+            if self.eval_batch_size != 1:
+                raise ValueError(
+                    "Official LingBot-VA websocket backend is stateful and currently "
+                    "only supports single-session evaluation per rollout worker. "
+                    f"Expected eval_batch_size == 1, got {self.eval_batch_size}."
+                )
+
         self.n_train_chunk_steps = (
             cfg.env.train.max_steps_per_rollout_epoch
             // cfg.actor.model.num_action_chunks
@@ -253,6 +267,7 @@ class MultiStepRolloutWorker(Worker):
             SupportedModel.MLP_POLICY,
             SupportedModel.GR00T,
             SupportedModel.CNN_POLICY,
+            SupportedModel.LINGBOTVA,
         ]:
             if self.cfg.algorithm.loss_type == "embodied_dagger":
                 kwargs = {"mode": "eval"}

--- a/tests/e2e_tests/embodied/robotwin_eval_lingbotva.yaml
+++ b/tests/e2e_tests/embodied/robotwin_eval_lingbotva.yaml
@@ -1,0 +1,234 @@
+defaults:
+  - env/robotwin_click_bell@env.train
+  - env/robotwin_click_bell@env.eval
+  - model/lingbotva@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+  - _self_
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/embodiment/config
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,rollout: 0
+    env: 0
+
+runner:
+  task_type: embodied
+  logger:
+    log_path: /workspace/results/robotwin_eval_lingbotva
+    project_name: rlinf
+    experiment_name: "ci-test"
+    logger_backends: ["tensorboard"]
+  max_epochs: 1
+  max_steps: -1
+  only_eval: true
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+
+algorithm:
+  normalize_advantages: true
+  kl_penalty: kl
+  group_size: 2
+  rollout_epoch: 1
+  eval_rollout_epoch: 1
+  reward_type: action_level
+  logprob_type: token_level
+  entropy_type: token_level
+  adv_type: grpo
+  loss_type: actor
+  loss_agg_func: "token-mean"
+  kl_beta: 0.0
+  entropy_bonus: 0
+  clip_ratio_high: 0.28
+  clip_ratio_low: 0.2
+  clip_ratio_c: 3.0
+  value_clip: 0.2
+  huber_delta: 10.0
+  gamma: 1.0
+  gae_lambda: 0.95
+  reward_coef: 1.0
+  filter_rewards: false
+  rewards_lower_bound: 0.5
+  rewards_upper_bound: 4.5
+  sampling_params:
+    do_sample: false
+    temperature_train: 1.0
+    temperature_eval: -1
+    top_k: -1
+    top_p: 1.0
+    repetition_penalty: 1.0
+  length_params:
+    max_new_token: null
+    max_length: 512
+    min_length: 1
+
+env:
+  group_name: "EnvGroup"
+  train:
+    env_type: robotwin
+    total_num_envs: 1
+    use_custom_reward: false
+    use_rel_reward: true
+    max_episode_steps: 400
+    reward_coef: ${algorithm.reward_coef}
+    max_steps_per_rollout_epoch: 416
+    group_size: 2
+    assets_path: "/workspace/dataset/RoboTwin"
+    seeds_path: ${oc.env:REPO_PATH}/rlinf/envs/robotwin/seeds/train_seeds.json
+    enable_offload: false
+    task_config:
+      render_freq: 0
+      episode_num: 50
+      use_seed: false
+      save_freq: 15
+      embodiment:
+        - aloha-agilex
+      language_num: 100
+      domain_randomization:
+        random_background: false
+        cluttered_table: false
+        clean_background_rate: 1
+        random_head_camera_dis: 0
+        random_table_height: 0
+        random_light: false
+        crazy_random_light_rate: 0
+      camera:
+        head_camera_type: D435
+        wrist_camera_type: D435
+        collect_head_camera: true
+        collect_wrist_camera: true
+      planner_backend: curobo
+      action_type: ee
+      data_type:
+        rgb: true
+        third_view: false
+        depth: false
+        pointcloud: false
+        observer: false
+        endpose: true
+        qpos: true
+        mesh_segmentation: false
+        actor_segmentation: false
+      pcd_down_sample_num: 1024
+      pcd_crop: true
+      save_path: ./data
+      clear_cache_freq: 5
+      collect_data: true
+      eval_video_log: true
+  eval:
+    env_type: robotwin
+    total_num_envs: 1
+    auto_reset: true
+    ignore_terminations: false
+    use_custom_reward: false
+    use_rel_reward: true
+    max_episode_steps: 400
+    reward_coef: ${algorithm.reward_coef}
+    max_steps_per_rollout_epoch: 416
+    group_size: 1
+    use_fixed_reset_state_ids: true
+    is_eval: true
+    assets_path: "/workspace/dataset/RoboTwin"
+    seeds_path: ${oc.env:REPO_PATH}/rlinf/envs/robotwin/seeds/eval_seeds.json
+    enable_offload: false
+    task_config:
+      render_freq: 0
+      episode_num: 50
+      use_seed: false
+      save_freq: 15
+      embodiment:
+        - aloha-agilex
+      language_num: 100
+      domain_randomization:
+        random_background: false
+        cluttered_table: false
+        clean_background_rate: 1
+        random_head_camera_dis: 0
+        random_table_height: 0
+        random_light: false
+        crazy_random_light_rate: 0
+      camera:
+        head_camera_type: D435
+        wrist_camera_type: D435
+        collect_head_camera: true
+        collect_wrist_camera: true
+      planner_backend: curobo
+      action_type: ee
+      data_type:
+        rgb: true
+        third_view: false
+        depth: false
+        pointcloud: false
+        observer: false
+        endpose: true
+        qpos: true
+        mesh_segmentation: false
+        actor_segmentation: false
+      pcd_down_sample_num: 1024
+      pcd_crop: true
+      save_path: ./data
+      clear_cache_freq: 5
+      collect_data: true
+      eval_video_log: true
+    video_cfg:
+      save_video: true
+      video_base_dir: ${runner.logger.log_path}/video/eval
+
+rollout:
+  group_name: "RolloutGroup"
+  backend: huggingface
+  enable_offload: false
+  pipeline_stage_num: 1
+  model:
+    model_type: lingbotva
+    model_path: ${actor.model.model_path}
+    precision: ${actor.model.precision}
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 1
+  global_batch_size: 1
+  seed: 1234
+  enable_offload: false
+  model:
+    model_type: lingbotva
+    model_path: ${oc.env:LINGBOT_VA_MODEL_PATH}
+    precision: bf16
+    num_action_chunks: 32
+    action_dim: 16
+    lingbotva:
+      repo_path: ${oc.env:LINGBOT_VA_REPO_PATH}
+      enable_offload: false
+      save_root: /tmp/rlinf_lingbotva
+      action_per_frame: 16
+  optim:
+    lr: 5.0e-5
+    value_lr: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_eps: 1.0e-05
+    weight_decay: 0.01
+    clip_grad: 1.0
+  fsdp_config:
+    strategy: "fsdp"
+    gradient_checkpointing: false
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+
+reward:
+  use_reward_model: false
+
+critic:
+  use_critic_model: false

--- a/tests/e2e_tests/embodied/run_eval.sh
+++ b/tests/e2e_tests/embodied/run_eval.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+set -eo pipefail
+
+CONFIG=$1
+BACKEND=${2:-"egl"}
+shift 2 || true
+
+export MUJOCO_GL=${BACKEND}
+export PYOPENGL_PLATFORM=${BACKEND}
+export PYTHONPATH=${REPO_PATH}:$PYTHONPATH
+
+python ${REPO_PATH}/examples/embodiment/eval_embodied_agent.py --config-path ${REPO_PATH}/tests/e2e_tests/embodied --config-name ${CONFIG} "$@"


### PR DESCRIPTION
### Description

This PR adds official LingBot-VA checkpoint support for RoboTwin evaluation in RLinf.

The main changes include:
- registering `lingbotva` as an embodied model in RLinf
- adding LingBot-VA rollout/evaluation integration on RoboTwin
- adding RoboTwin `ee` action support required by the official LingBot-VA inference workflow
- adding LingBot-VA install and asset download support
- adding Docker / install / embodied e2e / CI wiring for LingBot-VA on RoboTwin
- adding English and Chinese documentation pages for LingBot-VA evaluation

Current scope of this PR:
- RoboTwin evaluation only
- official LingBot-VA checkpoint inference only
- single-session evaluation per rollout worker
- `batch_size == 1`

This PR does **not** add SFT support for LingBot-VA yet.

### Motivation and Context

This change is required to integrate the official LingBot-VA RoboTwin checkpoint into RLinf, so that it can be loaded and evaluated inside RLinf's RoboTwin pipeline rather than only through the standalone upstream evaluation scripts.

The integration keeps the key model-side evaluation semantics required by LingBot-VA, including:
- 16D end-effector actions
- `add_init_pose`
- key-frame based chunk updates
- `compute_kv_cache` between chunks

At the same time, the implementation follows RLinf's embodied model conventions for config, install, docker, e2e, and documentation.

### How has this been tested?

Static checks:
- Python syntax checks passed for the LingBot-VA integration files via `py_compile`
- shell syntax checks passed for:
  - `requirements/install.sh`
  - `requirements/embodied/download_assets.sh`
  - `tests/e2e_tests/embodied/run_eval.sh`
- YAML parsing checks passed for:
  - `install.yml`
  - `docker-build.yml`
  - `embodied-e2e-tests.yml`
  - LingBot-VA example configs
  - LingBot-VA embodied e2e config
- `pre-commit run --all-files` passed

Runtime validation:
- `bash requirements/install.sh embodied --model lingbotva --env robotwin`
- `bash requirements/embodied/download_assets.sh --assets lingbotva`
- RoboTwin evaluation smoke tests on the latest code:
  - `robotwin_click_bell_eval_lingbotva`: `eval/success_once = 1.0`
  - `robotwin_place_empty_cup_eval_lingbotva`: `eval/success_once = 1.0`

Notes on metrics:
- RLinf evaluation metrics are reported in RLinf's rollout aggregation format
- LingBot-VA is currently wired as RoboTwin evaluation only
- the evaluation configs keep `total_num_envs: 1` and `ignore_terminations: false`

### Additional information (optional, e.g., figures and logs):

Notes:
- This PR focuses on LingBot-VA RoboTwin evaluation support only.
- LingBot-VA SFT support is intentionally left for follow-up work.
- The install workflow step for LingBot-VA is guarded by `nvcc` availability, because the RoboTwin install path depends on CUDA toolchain support.
- Docker / CI wiring for LingBot-VA on RoboTwin is included in this PR.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
