### PR TITLE
docs: fix embodied pics

### DIFF
--- a/docs/source-en/rst_source/examples/embodied/index.rst
+++ b/docs/source-en/rst_source/examples/embodied/index.rst
@@ -344,7 +344,7 @@ as well as reinforcement learning training examples on real robots.
      </div>
 
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_arm_small.jpg"
+       <img src="https://github.com/RLinf/misc/raw/main/pic/co_training.jpeg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
        <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
          <a href="co_training.html" style="text-decoration: underline; color: blue;">
@@ -366,8 +366,7 @@ as well as reinforcement learning training examples on real robots.
      </div>
 
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-       <!-- TODO(thumbnail): replace placeholder cover image URL for franka_reward_model -->
-       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_arm_small.jpg"
+       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_reward_model.jpeg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
        <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
          <a href="franka_reward_model.html" style="text-decoration: underline; color: blue;">

--- a/docs/source-en/rst_source/examples/embodied/index.rst
+++ b/docs/source-en/rst_source/examples/embodied/index.rst
@@ -246,6 +246,9 @@ as well as reinforcement learning training examples on real robots.
        </p>
      </div>
 
+  </div>
+
+   <div style="display: flex; justify-content: center; gap: 20px; align-items: flex-start; flex-wrap: wrap;">
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
        <img src="https://github.com/RLinf/misc/raw/main/pic/3_layer_mlp.jpg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);"
@@ -281,6 +284,9 @@ as well as reinforcement learning training examples on real robots.
        </p>
      </div>
 
+   </div>
+
+   <div style="display: flex; justify-content: center; gap: 20px; align-items: flex-start; flex-wrap: wrap;">
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
        <img src="https://github.com/RLinf/misc/raw/main/pic/release_0.2/qwen2_5_sft_vlm.png"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />

--- a/docs/source-en/rst_source/examples/embodied/index.rst
+++ b/docs/source-en/rst_source/examples/embodied/index.rst
@@ -378,8 +378,7 @@ as well as reinforcement learning training examples on real robots.
      </div>
 
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-       <!-- TODO(thumbnail): replace placeholder cover image URL for franka_zed_robotiq -->
-       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_arm_small.jpg"
+       <img src="https://github.com/RLinf/misc/raw/main/pic/robotiq_zed.jpeg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
        <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
          <a href="franka_zed_robotiq.html" style="text-decoration: underline; color: blue;">
@@ -390,8 +389,7 @@ as well as reinforcement learning training examples on real robots.
      </div>
 
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-       <!-- TODO(thumbnail): replace placeholder cover image URL for franka_gello -->
-       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_arm_small.jpg"
+       <img src="https://github.com/RLinf/misc/raw/main/pic/gello.jpeg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
        <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
          <a href="franka_gello.html" style="text-decoration: underline; color: blue;">

--- a/docs/source-zh/rst_source/examples/embodied/index.rst
+++ b/docs/source-zh/rst_source/examples/embodied/index.rst
@@ -369,8 +369,7 @@
       </div>
 
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-       <!-- TODO(thumbnail): replace placeholder cover image URL for franka_zed_robotiq -->
-       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_arm_small.jpg"
+       <img src="https://github.com/RLinf/misc/raw/main/pic/robotiq_zed.jpeg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
        <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
          <a href="franka_zed_robotiq.html" style="text-decoration: underline; color: blue;">
@@ -380,8 +379,7 @@
        </p>
      </div>
     <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-      <!-- TODO(thumbnail): replace placeholder cover image URL for franka_gello -->
-      <img src="https://github.com/RLinf/misc/raw/main/pic/franka_arm_small.jpg"
+      <img src="https://github.com/RLinf/misc/raw/main/pic/gello.jpeg"
            style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
       <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
         <a href="franka_gello.html" style="text-decoration: underline; color: blue;">

--- a/docs/source-zh/rst_source/examples/embodied/index.rst
+++ b/docs/source-zh/rst_source/examples/embodied/index.rst
@@ -239,6 +239,9 @@
        </p>
      </div>
 
+   </div>
+
+   <div style="display: flex; justify-content: center; gap: 20px; align-items: flex-start; flex-wrap: wrap;">
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
        <img src="https://github.com/RLinf/misc/raw/main/pic/3_layer_mlp.jpg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);"
@@ -250,16 +253,18 @@
          使用 PPO/SAC/GRPO 训练 PPO 策略
        </p>
      </div>
-    <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-      <img src="https://github.com/RLinf/misc/raw/main/pic/sac-flow-overview.png"
-           style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
-      <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
-        <a href="sac_flow.html" style="text-decoration: underline; color: blue;">
-          <b>SAC-Flow 策略训练</b>
-        </a><br>
-        使用 SAC 训练 Flow Matching 策略 (Sim & Real)
-      </p>
-    </div>
+
+     <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
+       <img src="https://github.com/RLinf/misc/raw/main/pic/sac-flow-overview.png"
+            style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
+       <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
+         <a href="sac_flow.html" style="text-decoration: underline; color: blue;">
+           <b>SAC-Flow 策略训练</b>
+         </a><br>
+         使用 SAC 训练 Flow Matching 策略 (Sim & Real)
+       </p>
+     </div>
+
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
        <!-- TODO(thumbnail): replace placeholder cover image URL for sft_openpi -->
        <img src="https://github.com/RLinf/misc/raw/main/pic/pi0_icon.jpg"
@@ -272,6 +277,9 @@
        </p>
      </div>
    
+   </div>
+
+   <div style="display: flex; justify-content: center; gap: 20px; align-items: flex-start; flex-wrap: wrap;">
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
        <img src="https://github.com/RLinf/misc/raw/main/pic/release_0.2/qwen2_5_sft_vlm.png"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />

--- a/docs/source-zh/rst_source/examples/embodied/index.rst
+++ b/docs/source-zh/rst_source/examples/embodied/index.rst
@@ -336,7 +336,7 @@
      </div>
 
      <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_arm_small.jpg"
+       <img src="https://github.com/RLinf/misc/raw/main/pic/co_training.jpeg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
        <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
          <a href="co_training.html" style="text-decoration: underline; color: blue;">
@@ -357,8 +357,7 @@
      </div>
 
       <div style="flex: 1 1 30%; max-width: 300px; text-align: center;">
-      <!-- TODO(thumbnail): replace placeholder cover image URL for franka_reward_model -->
-       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_arm_small.jpg"
+       <img src="https://github.com/RLinf/misc/raw/main/pic/franka_reward_model.jpeg"
             style="width: 100%; height: 200px; object-fit: cover; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.15);" />
        <p style="margin-top: 8px; font-size: 14px; line-height: 1.4;">
          <a href="franka_reward_model.html" style="text-decoration: underline; color: blue;">


### PR DESCRIPTION
## Summary
- Fix embodied docs card layout and images

Supersedes #1063 (auto-closed after branch rename from `docs/fix_embodied` → `chore/fix_embodied` to satisfy branch-name policy).