### PR TITLE
feat(embodied): bootstrap-training overlap when possible

### DIFF
--- a/docs/source-en/rst_source/tutorials/user/yaml.rst
+++ b/docs/source-en/rst_source/tutorials/user/yaml.rst
@@ -3,10 +3,10 @@ YAML Configuration
 
 
 Below is a complete reference for the configuration file used in the RLinf
-Every important key in the YAML is documented below so that you can confidently adapt the file to your own cluster, model, or research ideas.  
+Every important key in the YAML is documented below so that you can confidently adapt the file to your own cluster, model, or research ideas.
 Parameters are grouped exactly by their top-level key.
 
-For clarity, this section includes the following three main parts: 
+For clarity, this section includes the following three main parts:
 **Basic Configuration**, **MATH-specific Configuration**, and **Embody-specific Configuration**.
 Therefore, users can find the corresponding configuration information according to their own needs.
 
@@ -25,7 +25,7 @@ hydra
   hydra:
     run:
       dir: .
-    output_subdir: null 
+    output_subdir: null
 
 ``hydra.run.dir``: Working directory for Hydra runs.
 
@@ -45,7 +45,7 @@ cluster
 
 ``cluster.num_nodes``: Physical nodes to use for training.
 
-``cluster.component_placement``: 
+``cluster.component_placement``:
 The *placement strategy* for each component.
 Each line of component placement config is a dictionary of ``component_names: resource_ranks``.
 In this simple example of running on GPU nodes, the meaning is:
@@ -118,18 +118,18 @@ algorithm
   algorithm:
     group_size: 2
 
-    logprob_forward_micro_batch_size: 1 
+    logprob_forward_micro_batch_size: 1
 
-    val_rollout_batch_size_per_gpu: 4 
+    val_rollout_batch_size_per_gpu: 4
 
     loss_type: ppo
     loss_agg_func: "token-mean"
-    kl_beta: 0.0 
+    kl_beta: 0.0
     kl_penalty_type: low_var_kl
     ratio_clip_eps: 0.2
     entropy_bonus: 0.0
     calculate_entropy: False
-    clip_ratio_c: null 
+    clip_ratio_c: null
 
     adv_type: grpo
     normalize_advantages: True
@@ -285,8 +285,8 @@ algorithm
   algorithm:
 
     n_minibatches: 4
-    training_batch_size_per_gpu: 1 
-    rollout_batch_size_per_gpu: null 
+    training_batch_size_per_gpu: 1
+    rollout_batch_size_per_gpu: null
 
     sampling_params:
       max_new_tokens: ${subtract:${runner.seq_length}, ${data.max_prompt_length}}
@@ -325,7 +325,7 @@ rollout
 
     tensor_parallel_size: 1
     pipeline_parallel_size: 1
-    
+
     validate_weight: False # whether to send all weights at first for weight comparison.
     validate_save_dir: null # the directory to save the weights for comparison. If validate_weight is True, this will be used to save the weights for comparison.
     print_outputs: False         # whether to print the outputs (token ids, texts, etc.) of rollout engine.
@@ -351,7 +351,7 @@ rollout
 
 ``rollout.eos``: EOS token id override; null uses tokenizer.eos id.
 
-``rollout.attention_backend``: Attention kernel backend (e.g., triton). 
+``rollout.attention_backend``: Attention kernel backend (e.g., triton).
 
 ``rollout.tensor_parallel_size``: TP degree inside the generation backend.
 
@@ -510,15 +510,15 @@ actor
       ckpt_format: torch
       use_dist_ckpt: False
       tp_comm_bootstrap_backend: nccl
-      tp_comm_overlap_cfg: null 
+      tp_comm_overlap_cfg: null
       use_hf_ckpt: True # if true, will transfer hf model to generate megatron checkpoint and use it for training.
-      
+
       ckpt: # config for ckpt convertor
         model: DeepSeek-R1-Distill-Qwen-1.5B
         hf_model_path: ${rollout.model.model_path} # path to the hf model
         save_path: ${runner.output_dir}/${runner.experiment_name}/actor/megatron_ckpt_from_hf
         use_gpu_num : 0
-        use_gpu_index: null # 
+        use_gpu_index: null #
         process_num: 16 # number of processes to use for checkpointing
         tensor_model_parallel_size: ${actor.model.tensor_model_parallel_size}
         pipeline_model_parallel_size: ${actor.model.pipeline_model_parallel_size}
@@ -546,30 +546,30 @@ actor
         param_dtype: ${actor.model.precision}
         reduce_dtype: ${actor.model.precision}
         buffer_dtype: ${actor.model.precision}
-     
-      amp_autocast:                                
-        enabled: False                    
-        precision: "bf16"                 
-      
+
+      amp_autocast:
+        enabled: False
+        precision: "bf16"
+
       grad_scaler:
-        enabled: False               
+        enabled: False
 
 **Top-level**
 
 
 ``actor.training_backend``: Training backend (megatron).
 
-``actor.mcore_gpt``: Use Megatron-Core GPT stack. 
+``actor.mcore_gpt``: Use Megatron-Core GPT stack.
 
-``actor.spec_name``: Model spec/preset name (e.g., decoder-only GPT). 
+``actor.spec_name``: Model spec/preset name (e.g., decoder-only GPT).
 
 ``actor.offload_optimizer``: Offload optimizer state to CPU to reduce GPU memory.
 
-``actor.offload_weight``: Offload model weights to CPU when possible (ZeRO-style). 
+``actor.offload_weight``: Offload model weights to CPU when possible (ZeRO-style).
 
 ``actor.offload_grad``: Offload gradients to CPU to reduce GPU memory.
 
-``actor.enable_dp_load_balance``: Enable data-parallel load balancing. 
+``actor.enable_dp_load_balance``: Enable data-parallel load balancing.
 
 ``actor.calculate_flops``: Compute and log FLOPs for profiling.
 
@@ -604,19 +604,19 @@ actor
 
 ``actor.model.apply_rope_fusion``: Use fused RoPE kernels if available.
 
-``actor.model.bias_dropout_fusion``: Fuse bias + dropout kernels. 
+``actor.model.bias_dropout_fusion``: Fuse bias + dropout kernels.
 
-``actor.model.persist_layer_norm``: Persist LN params in higher precision. 
+``actor.model.persist_layer_norm``: Persist LN params in higher precision.
 
-``actor.model.bias_activation_fusion``: Fuse bias + activation kernels. 
+``actor.model.bias_activation_fusion``: Fuse bias + activation kernels.
 
 ``actor.model.attention_softmax_in_fp32``: Compute attention softmax in FP32 for stability.
 
-``actor.model.batch_p2p_comm``: Batch P2P communications across layers. 
+``actor.model.batch_p2p_comm``: Batch P2P communications across layers.
 
 ``actor.model.variable_seq_lengths``: Allow variable sequence lengths per micro-batch.
 
-``actor.model.gradient_accumulation_fusion``: Fused gradient accumulation. 
+``actor.model.gradient_accumulation_fusion``: Fused gradient accumulation.
 
 ``actor.model.moe_token_dispatcher_type``: MoE token dispatcher (e.g., alltoall).
 
@@ -642,13 +642,13 @@ actor
 
 ``actor.optim.overlap_param_gather``: Overlap parameter all-gather with forward pass.
 
-``actor.optim.optimizer_enable_pin``: Pin optimizer memory. 
+``actor.optim.optimizer_enable_pin``: Pin optimizer memory.
 
-``actor.optim.overlap_param_gather_with_optimizer_step``: Overlap param gather with step. 
+``actor.optim.overlap_param_gather_with_optimizer_step``: Overlap param gather with step.
 
 ``actor.optim.clip_grad``: Global gradient clipping norm.
 
-``actor.optim.loss_scale_window``: Dynamic loss scale window for FP16. 
+``actor.optim.loss_scale_window``: Dynamic loss scale window for FP16.
 
 **LR schedule**
 
@@ -676,7 +676,7 @@ actor
 
 **Megatron integration**
 
-``actor.megatron.ddp_bucket_size``: DDP gradient bucket size. 
+``actor.megatron.ddp_bucket_size``: DDP gradient bucket size.
 
 ``actor.megatron.distributed_backend``: Distributed backend (nccl or gloo).
 
@@ -684,11 +684,11 @@ actor
 
 ``actor.megatron.ckpt_format``: Checkpoint format (e.g., torch).
 
-``actor.megatron.use_dist_ckpt``: Use distributed checkpointing (sharded). 
+``actor.megatron.use_dist_ckpt``: Use distributed checkpointing (sharded).
 
 ``actor.megatron.tp_comm_bootstrap_backend``: Backend used for TP bootstrap (e.g., nccl).
 
-``actor.megatron.tp_comm_overlap_cfg``: YAML path for TP comm/compute overlap. 
+``actor.megatron.tp_comm_overlap_cfg``: YAML path for TP comm/compute overlap.
 
 ``actor.megatron.use_hf_ckpt``: Convert/load from a HuggingFace checkpoint for training.
 
@@ -700,9 +700,9 @@ actor
 
 ``actor.megatron.ckpt.save_path``: Target directory to write Megatron checkpoints.
 
-``actor.megatron.ckpt.use_gpu_num``: Number of GPUs to use for conversion. 
+``actor.megatron.ckpt.use_gpu_num``: Number of GPUs to use for conversion.
 
-``actor.megatron.ckpt.use_gpu_index``: Specific GPU index to use. 
+``actor.megatron.ckpt.use_gpu_index``: Specific GPU index to use.
 
 ``actor.megatron.ckpt.process_num``: CPU processes for conversion work.
 
@@ -802,10 +802,17 @@ runner
   runner:
     only_eval: False
     max_prompt_length: 30
+    overlap_env_bootstrap: False
 
 ``runner.only_eval``: Run evaluation only without training.
 
 ``runner.max_prompt_length``: Maximum prompt length in tokens.
+
+``runner.overlap_env_bootstrap``:
+Overlap environment bootstrap (reset) with actor training to hide reset latency.
+This is particularly useful when environment reset is slow.
+**Note:** This is only effective when ``env.train.enable_offload`` is False.
+Enabling this may increase GPU memory pressure if the environment and actor share the same accelerator.
 
 algorithm
 ~~~~~~~~~~~~~~~
@@ -957,7 +964,7 @@ actor
       val_micro_batch_size: 8
       center_crop: True
       do_sample: False
-      
+
       precision: "bf16"
       add_bias_linear: False
       add_qkv_bias: True
@@ -980,7 +987,7 @@ actor
       use_fast: False
       trust_remote_code: True
       padding_side: "right"
-    
+
     optim:
       lr: 1.0e-4
       value_lr: 3.0e-3
@@ -1080,12 +1087,12 @@ actor
 
 
 
-Env-based 
+Env-based
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following configuration describes the key parameters of the environment, using Libero-10 as an example.
 
-The path is 
+The path is
 
 **Environment Type**
 

--- a/docs/source-zh/rst_source/tutorials/user/yaml.rst
+++ b/docs/source-zh/rst_source/tutorials/user/yaml.rst
@@ -1,11 +1,11 @@
 YAML 配置
 =====================
 
-下面给出 RLinf 使用的配置文件的完整参考说明。  
-我们对 YAML 中每个重要键做了说明，便于你针对自己的集群、模型或研究需求进行调整。  
+下面给出 RLinf 使用的配置文件的完整参考说明。
+我们对 YAML 中每个重要键做了说明，便于你针对自己的集群、模型或研究需求进行调整。
 各参数按顶层键分组组织。
 
-为便于查阅，本节分为三部分：**基础配置**、**MATH 专用配置** 与 **具身智能（Embodied）专用配置**。  
+为便于查阅，本节分为三部分：**基础配置**、**MATH 专用配置** 与 **具身智能（Embodied）专用配置**。
 你可根据实际需求查找对应的小节。
 
 .. contents::
@@ -23,7 +23,7 @@ hydra
   hydra:
     run:
       dir: .
-    output_subdir: null 
+    output_subdir: null
 
 ``hydra.run.dir``：Hydra 运行的工作目录。
 
@@ -42,8 +42,8 @@ cluster
 
 ``cluster.num_nodes``：用于训练的物理节点数量。
 
-``cluster.component_placement``：  
-各组件（进程）的 *放置策略*。  
+``cluster.component_placement``：
+各组件（进程）的 *放置策略*。
 
 在上面运行于GPU节点的简单示例中：
 
@@ -86,23 +86,23 @@ runner
 
 **logger：**
 
-``runner.logger.log_path``：日志输出的根目录。  
+``runner.logger.log_path``：日志输出的根目录。
 
-``runner.logger.project_name``：实验跟踪的项目名。  
+``runner.logger.project_name``：实验跟踪的项目名。
 
-``runner.logger.experiment_name``：实验名称。  
+``runner.logger.experiment_name``：实验名称。
 
 ``runner.logger.logger_backends``：日志后端（tensorboard、wandb、swanlab）。
 
 关于日志后端详见 :doc:`../advance/logger`。
 
-``runner.max_epochs``：最大训练 epoch 数。  
+``runner.max_epochs``：最大训练 epoch 数。
 
-``runner.max_steps``：最大全局步数；为 -1 时，依据 ``runner.max_epochs`` 自动确定。  
+``runner.max_steps``：最大全局步数；为 -1 时，依据 ``runner.max_epochs`` 自动确定。
 
-``runner.val_check_interval``：验证 rollout 的触发频率（-1 关闭）。  
+``runner.val_check_interval``：验证 rollout 的触发频率（-1 关闭）。
 
-``runner.save_interval``：保存 checkpoint 的步数间隔。  
+``runner.save_interval``：保存 checkpoint 的步数间隔。
 
 ``runner.seq_length``：输入到模型的总序列长度（提示 + 生成）。
 
@@ -114,18 +114,18 @@ algorithm
   algorithm:
     group_size: 2
 
-    logprob_forward_micro_batch_size: 1 
+    logprob_forward_micro_batch_size: 1
 
-    val_rollout_batch_size_per_gpu: 4 
+    val_rollout_batch_size_per_gpu: 4
 
     loss_type: ppo
     loss_agg_func: "token-mean"
-    kl_beta: 0.0 
+    kl_beta: 0.0
     kl_penalty_type: low_var_kl
     ratio_clip_eps: 0.2
     entropy_bonus: 0.0
     calculate_entropy: False
-    clip_ratio_c: null 
+    clip_ratio_c: null
 
     adv_type: grpo
     normalize_advantages: True
@@ -139,43 +139,43 @@ algorithm
       top_p: 1.0
       repetition_penalty: 1.0
 
-``algorithm.group_size``：每个提示采样的响应个数（>1 时启用组基线）。  
+``algorithm.group_size``：每个提示采样的响应个数（>1 时启用组基线）。
 
 ``algorithm.logprob_forward_micro_batch_size``：log-prob 前向的微批大小。
 
 ``algorithm.val_rollout_batch_size_per_gpu``：验证阶段每 GPU 的 rollout 微批大小。
 
-``algorithm.loss_type``：策略损失类型（如 ppo）。  
+``algorithm.loss_type``：策略损失类型（如 ppo）。
 
-``algorithm.loss_agg_func``：token 损失的聚合方式（如 token-mean）。  
+``algorithm.loss_agg_func``：token 损失的聚合方式（如 token-mean）。
 
-``algorithm.kl_beta``：加入到奖励中的 KL 权重。  
+``algorithm.kl_beta``：加入到奖励中的 KL 权重。
 
-``algorithm.kl_penalty_type``：KL 形态（如 low_var_kl）。  
+``algorithm.kl_penalty_type``：KL 形态（如 low_var_kl）。
 
-``algorithm.ratio_clip_eps``：PPO 比率裁剪阈值。  
+``algorithm.ratio_clip_eps``：PPO 比率裁剪阈值。
 
-``algorithm.entropy_bonus``：熵奖励系数。  
+``algorithm.entropy_bonus``：熵奖励系数。
 
-``algorithm.calculate_entropy``：是否计算/记录熵项。  
+``algorithm.calculate_entropy``：是否计算/记录熵项。
 
-``algorithm.adv_type``：优势函数估计类型（如 grpo）。  
+``algorithm.adv_type``：优势函数估计类型（如 grpo）。
 
-``algorithm.normalize_advantages``：是否对优势进行归一化。  
+``algorithm.normalize_advantages``：是否对优势进行归一化。
 
-``algorithm.early_stop_imp_ratio``：当重要性比超出阈值时提前终止本次更新。 
+``algorithm.early_stop_imp_ratio``：当重要性比超出阈值时提前终止本次更新。
 
 ``algorithm.use_valid_token_scale``：是否按有效 token 掩码缩放损失/优势。
 
 **sampling_params：**
 
 ``algorithm.sampling_params.do_sample``：False 时使用贪心解码。
- 
-``algorithm.sampling_params.temperature``：采样温度。  
 
-``algorithm.sampling_params.top_k``：top-k 截断（设很大值等于禁用）。  
+``algorithm.sampling_params.temperature``：采样温度。
 
-``algorithm.sampling_params.top_p``：nucleus 采样阈值。  
+``algorithm.sampling_params.top_k``：top-k 截断（设很大值等于禁用）。
+
+``algorithm.sampling_params.top_p``：nucleus 采样阈值。
 
 ``algorithm.sampling_params.repetition_penalty``：重复惩罚系数。
 
@@ -195,13 +195,13 @@ rollout
 
     recompute_logprobs: True
 
-``rollout.gpu_memory_utilization``：目标 GPU 显存占用比例。  
+``rollout.gpu_memory_utilization``：目标 GPU 显存占用比例。
 
-``rollout.group_name``：rollout / inference worker 的逻辑分组名。  
+``rollout.group_name``：rollout / inference worker 的逻辑分组名。
 
-``rollout.model.model_path``：生成后端所用 HF 模型路径。  
+``rollout.model.model_path``：生成后端所用 HF 模型路径。
 
-``rollout.model.model_type``：后端内部使用的模型架构标记（如 qwen2.5）。  
+``rollout.model.model_type``：后端内部使用的模型架构标记（如 qwen2.5）。
 
 ``rollout.recompute_logprobs``：是否为采样序列重新计算对数概率。
 
@@ -220,9 +220,9 @@ actor
 
 **顶层：**
 
-``actor.group_name``：训练（actor）worker 的逻辑分组名。  
+``actor.group_name``：训练（actor）worker 的逻辑分组名。
 
-``actor.model.megatron_checkpoint``：训练前加载的模型 Megatron checkpoint 路径。 
+``actor.model.megatron_checkpoint``：训练前加载的模型 Megatron checkpoint 路径。
 
 ``actor.seed``：全局随机种子，便于复现。
 
@@ -258,7 +258,7 @@ runner
     enable_dynamic_batch_size: False
     max_tokens_per_mbs: 2048
 
-``runner.enable_dynamic_batch_size``：使用 Megatron 训练时是否启用动态批大小。 
+``runner.enable_dynamic_batch_size``：使用 Megatron 训练时是否启用动态批大小。
 
 ``runner.max_tokens_per_mbs``：启用动态批时每个微批的 token 上限。
 
@@ -271,23 +271,23 @@ algorithm
   algorithm:
 
     n_minibatches: 4
-    training_batch_size_per_gpu: 1 
-    rollout_batch_size_per_gpu: null 
+    training_batch_size_per_gpu: 1
+    rollout_batch_size_per_gpu: null
 
     sampling_params:
       max_new_tokens: ${subtract:${runner.seq_length}, ${data.max_prompt_length}}
       min_new_tokens: 1
 
-``algorithm.n_minibatches``：每个 batch 的梯度更新次数。  
+``algorithm.n_minibatches``：每个 batch 的梯度更新次数。
 
-``algorithm.training_batch_size_per_gpu``：每张 actor GPU 的训练微批大小。  
+``algorithm.training_batch_size_per_gpu``：每张 actor GPU 的训练微批大小。
 
 ``algorithm.rollout_batch_size_per_gpu``：每 GPU 的推理微批大小；为 null 时按全局大小平均分配。
 
 
 **sampling_params：**
 
-``algorithm.sampling_params.max_new_tokens``：最大生成长度（由 runner.seq_length 与 data.max_prompt_length 计算）。  
+``algorithm.sampling_params.max_new_tokens``：最大生成长度（由 runner.seq_length 与 data.max_prompt_length 计算）。
 
 ``algorithm.sampling_params.min_new_tokens``：最小生成长度。
 
@@ -308,7 +308,7 @@ rollout
 
     tensor_parallel_size: 1
     pipeline_parallel_size: 1
-    
+
     validate_weight: False # 是否在开始时发送全部权重进行一致性校验
     validate_save_dir: null # 若启用校验，保存用于比对的权重目录
     print_outputs: False         # 是否打印 rollout 引擎的输出（token id/文本等）
@@ -320,39 +320,39 @@ rollout
     use_torch_compile: False # 在 SGLang 中为 rollout 启用 torch.compile
     torch_compile_max_bs: 128 # 启用 torch.compile 的最大 batch size；超过则不使用
 
-``rollout.enforce_eager``：True 时禁用 CUDA graph，加快预热启动。  
+``rollout.enforce_eager``：True 时禁用 CUDA graph，加快预热启动。
 
 ``rollout.distributed_executor_backend``：rollout worker 的启动后端（mp 或 ray）。
 
-``rollout.disable_log_stats``：是否关闭后端周期性统计日志。  
+``rollout.disable_log_stats``：是否关闭后端周期性统计日志。
 
-``rollout.detokenize``：是否将输出 detokenize（调试用）。  
+``rollout.detokenize``：是否将输出 detokenize（调试用）。
 
-``rollout.padding``：pad token id 重载；null 则用 tokenizer 的 pad id。  
+``rollout.padding``：pad token id 重载；null 则用 tokenizer 的 pad id。
 
-``rollout.eos``：EOS token id 重载；null 则用 tokenizer 的 eos id。  
+``rollout.eos``：EOS token id 重载；null 则用 tokenizer 的 eos id。
 
-``rollout.attention_backend``：注意力算子后端（如 triton）。  
+``rollout.attention_backend``：注意力算子后端（如 triton）。
 
-``rollout.tensor_parallel_size``：生成后端的张量并行度（TP）。  
+``rollout.tensor_parallel_size``：生成后端的张量并行度（TP）。
 
-``rollout.pipeline_parallel_size``：生成后端的流水并行度（PP）。  
+``rollout.pipeline_parallel_size``：生成后端的流水并行度（PP）。
 
 并行化细节见 :doc:`../advance/5D`。
 
-``rollout.validate_weight``：是否发送完整权重进行校验。  
+``rollout.validate_weight``：是否发送完整权重进行校验。
 
-``rollout.validate_save_dir``：启用校验时的权重保存目录。  
+``rollout.validate_save_dir``：启用校验时的权重保存目录。
 
-``rollout.print_outputs``：是否打印调试输出。  
+``rollout.print_outputs``：是否打印调试输出。
 
-``rollout.sglang_decode_log_interval``：SGLang 解码统计的间隔。 
- 
-``rollout.max_running_requests``：最大并发解码请求数。  
+``rollout.sglang_decode_log_interval``：SGLang 解码统计的间隔。
+
+``rollout.max_running_requests``：最大并发解码请求数。
 
 ``rollout.cuda_graph_max_bs``：可使用 CUDA graph 的最大批大小。
 
-``rollout.use_torch_compile``：启用 torch.compile。  
+``rollout.use_torch_compile``：启用 torch.compile。
 
 ``rollout.torch_compile_max_bs``：可使用 torch.compile 的最大批大小。
 
@@ -374,25 +374,25 @@ data
     train_data_paths: ["../../data/boba/AReaL-boba-106k.jsonl"]
     val_data_paths: ["../../data/boba/AReaL-boba-106k.jsonl"]
 
-``data.type``：数据集/任务类型（如 math）。  
+``data.type``：数据集/任务类型（如 math）。
 
-``data.max_prompt_length``：提示的最大 token 数。  
+``data.max_prompt_length``：提示的最大 token 数。
 
-``data.rollout_batch_size``：全局 rollout 批大小。  
+``data.rollout_batch_size``：全局 rollout 批大小。
 
-``data.val_rollout_batch_size``：全局验证批大小；为 null 则回退到 ``data.rollout_batch_size``。 
+``data.val_rollout_batch_size``：全局验证批大小；为 null 则回退到 ``data.rollout_batch_size``。
 
-``data.num_workers``：每个 actor rank 的数据加载进程数。  
+``data.num_workers``：每个 actor rank 的数据加载进程数。
 
-``data.prompt_key``：JSONL 中提示文本的键名。  
+``data.prompt_key``：JSONL 中提示文本的键名。
 
-``data.shuffle``：训练数据是否每 epoch 乱序。  
+``data.shuffle``：训练数据是否每 epoch 乱序。
 
-``data.validation_shuffle``：验证数据是否乱序（on-policy 评估通常建议 True）。  
+``data.validation_shuffle``：验证数据是否乱序（on-policy 评估通常建议 True）。
 
-``data.seed``：数据加载与采样用的随机种子。  
+``data.seed``：数据加载与采样用的随机种子。
 
-``data.train_data_paths``：训练 JSONL 文件列表。  
+``data.train_data_paths``：训练 JSONL 文件列表。
 
 ``data.val_data_paths``：验证 JSONL 文件列表。
 
@@ -488,15 +488,15 @@ actor
       ckpt_format: torch
       use_dist_ckpt: False
       tp_comm_bootstrap_backend: nccl
-      tp_comm_overlap_cfg: null 
+      tp_comm_overlap_cfg: null
       use_hf_ckpt: True # 为 True 时将 HF 模型转为 Megatron checkpoint 并用于训练
-      
+
       ckpt: # checkpoint 转换器配置
         model: DeepSeek-R1-Distill-Qwen-1.5B
         hf_model_path: ${rollout.model.model_path} # HF 模型所在路径
         save_path: ${runner.output_dir}/${runner.experiment_name}/actor/megatron_ckpt_from_hf
         use_gpu_num : 0
-        use_gpu_index: null # 
+        use_gpu_index: null #
         process_num: 16 # 转换使用的进程数
         tensor_model_parallel_size: ${actor.model.tensor_model_parallel_size}
         pipeline_model_parallel_size: ${actor.model.pipeline_model_parallel_size}
@@ -526,62 +526,62 @@ actor
         reduce_dtype: ${actor.model.precision}
         buffer_dtype: ${actor.model.precision}
 
-      amp_autocast:                                
-        enabled: False                    
-        precision: "bf16"                 
-      
+      amp_autocast:
+        enabled: False
+        precision: "bf16"
+
       grad_scaler:
-        enabled: False      
+        enabled: False
 
 **顶层：**
 
-``actor.training_backend``：训练后端（megatron）。  
+``actor.training_backend``：训练后端（megatron）。
 
-``actor.mcore_gpt``：是否使用 Megatron-Core GPT 栈。  
+``actor.mcore_gpt``：是否使用 Megatron-Core GPT 栈。
 
-``actor.spec_name``：模型规格/预设（如 decoder_gpt）。  
+``actor.spec_name``：模型规格/预设（如 decoder_gpt）。
 
-``actor.offload_optimizer/weight/grad``：将优化器/权重/梯度尽可能下放到 CPU 以节省显存。  
+``actor.offload_optimizer/weight/grad``：将优化器/权重/梯度尽可能下放到 CPU 以节省显存。
 
-``actor.enable_dp_load_balance``：是否启用数据并行负载均衡。  
+``actor.enable_dp_load_balance``：是否启用数据并行负载均衡。
 
 ``actor.calculate_flops``：是否计算并记录 FLOPs（分析用）。
 
 **Model 子项：**
 
-``actor.model.precision``：训练数值精度（fp16 等）。  
+``actor.model.precision``：训练数值精度（fp16 等）。
 
-``actor.model.add_bias_linear``：线性层是否带 bias。  
+``actor.model.add_bias_linear``：线性层是否带 bias。
 
-``actor.model.tensor_model_parallel_size``：actor 端 TP 并行度。  
+``actor.model.tensor_model_parallel_size``：actor 端 TP 并行度。
 
-``actor.model.pipeline_model_parallel_size``：actor 端 PP 并行度。  
+``actor.model.pipeline_model_parallel_size``：actor 端 PP 并行度。
 
-``actor.model.activation``：激活函数（如 swiglu）。  
+``actor.model.activation``：激活函数（如 swiglu）。
 
-``actor.model.sequence_parallel``：启用序列并行（需配合 TP）。  
+``actor.model.sequence_parallel``：启用序列并行（需配合 TP）。
 
-``actor.model.recompute_method/granularity/num_layers``：重计算策略/粒度/层数。  
+``actor.model.recompute_method/granularity/num_layers``：重计算策略/粒度/层数。
 
-``actor.model.seq_length / encoder_seq_length``：训练时解码/编码序列长度。  
+``actor.model.seq_length / encoder_seq_length``：训练时解码/编码序列长度。
 
-``actor.model.normalization``：归一化层类型（rmsnorm）。  
+``actor.model.normalization``：归一化层类型（rmsnorm）。
 
-``actor.model.position_embedding_type``：位置编码类型（rope）。  
+``actor.model.position_embedding_type``：位置编码类型（rope）。
 
-``actor.model.apply_rope_fusion``：是否使用融合的 RoPE 内核。  
+``actor.model.apply_rope_fusion``：是否使用融合的 RoPE 内核。
 
-``actor.model.*fusion``：若干算子融合开关。  
+``actor.model.*fusion``：若干算子融合开关。
 
-``actor.model.attention_softmax_in_fp32``：注意力 softmax 用 FP32 保稳。  
+``actor.model.attention_softmax_in_fp32``：注意力 softmax 用 FP32 保稳。
 
-``actor.model.batch_p2p_comm``：跨层批量 P2P 通信。  
+``actor.model.batch_p2p_comm``：跨层批量 P2P 通信。
 
-``actor.model.variable_seq_lengths``：允许不同微批序列长度。  
+``actor.model.variable_seq_lengths``：允许不同微批序列长度。
 
-``actor.model.gradient_accumulation_fusion``：梯度累积融合。  
+``actor.model.gradient_accumulation_fusion``：梯度累积融合。
 
-``actor.model.moe_token_dispatcher_type``：MoE token 分发方式（如 alltoall）。  
+``actor.model.moe_token_dispatcher_type``：MoE token 分发方式（如 alltoall）。
 
 ``actor.model.use_cpu_initialization``：在 CPU 上初始化权重以降低 GPU 峰值。
 
@@ -629,11 +629,11 @@ actor
 
 **分词器：**
 
-``actor.tokenizer.tokenizer_model``：分词器路径/名称。  
+``actor.tokenizer.tokenizer_model``：分词器路径/名称。
 
-``actor.tokenizer.use_fast``：是否使用 fast tokenizer。  
+``actor.tokenizer.use_fast``：是否使用 fast tokenizer。
 
-``actor.tokenizer.trust_remote_code``：允许自定义分词器代码。  
+``actor.tokenizer.trust_remote_code``：允许自定义分词器代码。
 
 ``actor.tokenizer.padding_side``：填充方向（left/right）。
 
@@ -710,7 +710,7 @@ reward
     reward_type: math
     reward_scale: 5.0
 
-``reward.reward_type``：训练所使用的奖励类型。  
+``reward.reward_type``：训练所使用的奖励类型。
 
 ``reward.reward_scale``：答对奖励为 ``reward_scale``，答错为 ``-reward_scale``。
 
@@ -747,10 +747,17 @@ runner
   runner:
     only_eval: False
     max_prompt_length: 30
+    overlap_env_bootstrap: False
 
-``runner.only_eval``：只运行评估，不进行训练。  
+``runner.only_eval``：只运行评估，不进行训练。
 
 ``runner.max_prompt_length``：最大提示长度（token 数）。
+
+``runner.overlap_env_bootstrap``：
+将环境的 bootstrap（重置/reset）过程与 Actor 训练过程重叠，以隐藏重置延迟。
+当环境重置较慢时，此功能非常有用。
+**注意：** 仅在 ``env.train.enable_offload`` 为 False 时生效。
+如果环境和 Actor 共享同一个加速器，开启此功能可能会增加重合期间的 GPU 显存压力。
 
 algorithm
 ~~~~~~~~~~~~~~~
@@ -784,9 +791,9 @@ algorithm
 
 **length_params：**
 
-``algorithm.length_params.max_new_token``：最大新增 token 数。  
+``algorithm.length_params.max_new_token``：最大新增 token 数。
 
-``algorithm.length_params.max_length``：最大总序列长度。  
+``algorithm.length_params.max_length``：最大总序列长度。
 
 ``algorithm.length_params.min_length``：最小序列长度。
 
@@ -817,13 +824,13 @@ env
       use_fixed_reset_state_ids: True
       max_episode_steps: 10
 
-``env.group_name``：环境 worker 组的逻辑名称。  
+``env.group_name``：环境 worker 组的逻辑名称。
 
-``env.channel.name``：进程间通信的共享内存通道名。  
+``env.channel.name``：进程间通信的共享内存通道名。
 
-``env.channel.queue_name``：观测缓冲区队列名。  
+``env.channel.queue_name``：观测缓冲区队列名。
 
-``env.channel.queue_size``：队列大小（0 表示不限制）。  
+``env.channel.queue_size``：队列大小（0 表示不限制）。
 
 ``env.enable_offload``：启用环境侧的下放以降低内存占用。
 
@@ -863,15 +870,15 @@ rollout
     enable_offload: True
     pipeline_stage_num: 2
 
-``rollout.channel.name``：共享内存通道（继承自 env）。  
+``rollout.channel.name``：共享内存通道（继承自 env）。
 
-``rollout.channel.queue_name``：动作缓冲区队列名。  
+``rollout.channel.queue_name``：动作缓冲区队列名。
 
-``rollout.channel.queue_size``：队列大小。  
+``rollout.channel.queue_size``：队列大小。
 
-``rollout.mode``：rollout 模式（collocate 表示**共享式**使用 GPU）。  
+``rollout.mode``：rollout 模式（collocate 表示**共享式**使用 GPU）。
 
-``rollout.backend``：模型后端（huggingface、vllm）。  
+``rollout.backend``：模型后端（huggingface、vllm）。
 
 ``rollout.pipeline_stage_num``：rollout 的流水线阶段数。
 
@@ -901,7 +908,7 @@ actor
       val_micro_batch_size: 8
       center_crop: True
       do_sample: False
-      
+
       precision: "bf16"
       add_bias_linear: False
       add_qkv_bias: True
@@ -924,7 +931,7 @@ actor
       use_fast: False
       trust_remote_code: True
       padding_side: "right"
-    
+
     optim:
       lr: 1.0e-4
       value_lr: 3.0e-3
@@ -933,81 +940,81 @@ actor
       adam_eps: 1.0e-05
       clip_grad: 10.0
 
-``actor.channel.name``：共享内存通道（继承自 env）。  
+``actor.channel.name``：共享内存通道（继承自 env）。
 
-``actor.channel.queue_name``：回放缓冲区队列名。  
+``actor.channel.queue_name``：回放缓冲区队列名。
 
-``actor.training_backend``：训练后端（分布式 FSDP）。  
+``actor.training_backend``：训练后端（分布式 FSDP）。
 
-``actor.micro_batch_size``：每张 GPU 的微批大小。  
+``actor.micro_batch_size``：每张 GPU 的微批大小。
 
-``actor.global_batch_size``：全局批大小（跨所有 GPU）。  
+``actor.global_batch_size``：全局批大小（跨所有 GPU）。
 
 ``actor.enable_offload``：启用模型下放以降低内存占用。
 
 **模型配置：**
 
-``actor.model.model_type``：模型类型（openvla_oft）。  
+``actor.model.model_type``：模型类型（openvla_oft）。
 
-``actor.model.action_dim``：动作空间维度。  
+``actor.model.action_dim``：动作空间维度。
 
-``actor.model.num_action_chunks``：每条序列的动作块数量。  
+``actor.model.num_action_chunks``：每条序列的动作块数量。
 
-``actor.model.use_proprio``：是否使用本体感知信息。  
+``actor.model.use_proprio``：是否使用本体感知信息。
 
-``actor.model.unnorm_key``：动作反归一化的键。  
+``actor.model.unnorm_key``：动作反归一化的键。
 
-``actor.model.value_type``：价值函数类型（继承自 algorithm.reward_type）。  
+``actor.model.value_type``：价值函数类型（继承自 algorithm.reward_type）。
 
-``actor.model.val_micro_batch_size``：价值函数计算的微批大小。  
+``actor.model.val_micro_batch_size``：价值函数计算的微批大小。
 
-``actor.model.center_crop``：是否对输入图像做中心裁剪。  
+``actor.model.center_crop``：是否对输入图像做中心裁剪。
 
-``actor.model.do_sample``：推理时是否采样。  
+``actor.model.do_sample``：推理时是否采样。
 
-``actor.model.precision``：数值精度（bf16/fp16/fp32）。  
+``actor.model.precision``：数值精度（bf16/fp16/fp32）。
 
-``actor.model.add_bias_linear / add_qkv_bias``：线性/QKV 是否加 bias。  
+``actor.model.add_bias_linear / add_qkv_bias``：线性/QKV 是否加 bias。
 
-``actor.model.vocab_size / hidden_size``：词表大小与隐藏维度。  
+``actor.model.vocab_size / hidden_size``：词表大小与隐藏维度。
 
-``actor.model.policy_setup``：策略配置（widowx_bridge）。  
+``actor.model.policy_setup``：策略配置（widowx_bridge）。
 
-``actor.model.image_size``：输入图像尺寸 [H, W]。  
+``actor.model.image_size``：输入图像尺寸 [H, W]。
 
-``actor.model.is_lora / lora_rank / lora_path``：是否使用 LoRA、秩与权重路径。  
+``actor.model.is_lora / lora_rank / lora_path``：是否使用 LoRA、秩与权重路径。
 
-``actor.model.megatron_checkpoint``：模型 checkpoint 路径。  
+``actor.model.megatron_checkpoint``：模型 checkpoint 路径。
 
-``actor.model.num_images_in_input``：输入的图像数量。  
+``actor.model.num_images_in_input``：输入的图像数量。
 
-``actor.model.attn_implementation``：注意力实现（flash_attention_2）。  
+``actor.model.attn_implementation``：注意力实现（flash_attention_2）。
 
-``actor.model.low_cpu_mem_usage``：低内存初始化。  
+``actor.model.low_cpu_mem_usage``：低内存初始化。
 
 ``actor.model.trust_remote_code``：加载模型时信任远程代码。
 
 **分词器配置：**
 
-``actor.tokenizer.tokenizer_type``：分词器类型（HuggingFaceTokenizer）。  
+``actor.tokenizer.tokenizer_type``：分词器类型（HuggingFaceTokenizer）。
 
-``actor.tokenizer.tokenizer_model``：分词器模型路径。  
+``actor.tokenizer.tokenizer_model``：分词器模型路径。
 
-``actor.tokenizer.extra_vocab_size``：额外词表大小。  
+``actor.tokenizer.extra_vocab_size``：额外词表大小。
 
-``actor.tokenizer.use_fast``：是否使用 fast 版本。  
+``actor.tokenizer.use_fast``：是否使用 fast 版本。
 
-``actor.tokenizer.trust_remote_code``：信任远程代码。  
+``actor.tokenizer.trust_remote_code``：信任远程代码。
 
 ``actor.tokenizer.padding_side``：填充方向（left/right）。
 
 **优化器配置：**
 
-``actor.optim.lr``：策略网络学习率。  
+``actor.optim.lr``：策略网络学习率。
 
-``actor.optim.value_lr``：价值网络学习率。  
+``actor.optim.value_lr``：价值网络学习率。
 
-``actor.optim.adam_beta1/beta2/eps``：Adam 超参数。  
+``actor.optim.adam_beta1/beta2/eps``：Adam 超参数。
 
 ``actor.optim.clip_grad``：梯度裁剪阈值。
 
@@ -1016,7 +1023,7 @@ actor
 
 以下示例以 Libero-10 为例说明环境关键参数。
 
-路径为 
+路径为
 
 **环境类型**
 
@@ -1025,7 +1032,7 @@ actor
   env_type: libero
   task_suite_name: libero_10
 
-``env_type``：模拟器类型（libero 表示 Libero 基准）。  
+``env_type``：模拟器类型（libero 表示 Libero 基准）。
 
 ``task_suite_name``：任务集合（libero_10 表示 10 个任务的基准）。
 
@@ -1037,9 +1044,9 @@ actor
   ignore_terminations: ${algorithm.ignore_terminations}
   max_episode_steps: 512
 
-``auto_reset``：episode 结束时是否自动重置（继承自 algorithm）。  
+``auto_reset``：episode 结束时是否自动重置（继承自 algorithm）。
 
-``ignore_terminations``：训练时是否忽略终止（继承自 algorithm）。  
+``ignore_terminations``：训练时是否忽略终止（继承自 algorithm）。
 
 ``max_episode_steps``：每个 episode 的最大步数（复杂 Libero 任务通常取 512）。
 
@@ -1050,7 +1057,7 @@ actor
   use_rel_reward: true
   reward_coef: 5.0
 
-``use_rel_reward``：使用相对奖励（当前步与前一状态的差值）。  
+``use_rel_reward``：使用相对奖励（当前步与前一状态的差值）。
 
 ``reward_coef``：奖励缩放系数（如 5.0 强化奖励信号）。
 
@@ -1062,9 +1069,9 @@ actor
   group_size: 1
   use_fixed_reset_state_ids: True
 
-``seed``：环境初始化随机种子（0 便于复现）。  
+``seed``：环境初始化随机种子（0 便于复现）。
 
-``group_size``：每个分组的环境数（继承自 algorithm.group_size）。  
+``group_size``：每个分组的环境数（继承自 algorithm.group_size）。
 
 ``use_fixed_reset_state_ids``：是否使用固定 reset 状态（GRPO 为 True，PPO 默认 False）。
 
@@ -1085,9 +1092,9 @@ actor
     info_on_video: true
     video_base_dir: ${runner.logger.log_path}/video/train
 
-``video_cfg.save_video``：训练时保存视频。  
+``video_cfg.save_video``：训练时保存视频。
 
-``video_cfg.info_on_video``：在视频上叠加训练信息。  
+``video_cfg.info_on_video``：在视频上叠加训练信息。
 
 ``video_cfg.video_base_dir``：视频保存目录。
 
@@ -1099,6 +1106,6 @@ actor
     camera_heights: 256
     camera_widths: 256
 
-``init_params.camera_heights``：相机图像高度（像素）。  
+``init_params.camera_heights``：相机图像高度（像素）。
 
 ``init_params.camera_widths``：相机图像宽度（像素）。

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -875,8 +875,12 @@ def validate_embodied_cfg(cfg):
         weight_sync_interval = cfg.runner.get("weight_sync_interval", 1)
         assert weight_sync_interval > 0, "weight_sync_interval must be greater than 0"
         cfg.runner.weight_sync_interval = weight_sync_interval
+        # Overlap environment bootstrap (reset) with actor training to hide reset latency.
+        # This is enabled only when offload is disabled to avoid resource contention.
+        # Note: If EnvWorker and Actor share the same accelerator, this may increase GPU memory
+        # pressure during the overlap period.
         cfg.runner.overlap_env_bootstrap = bool(
-            cfg.runner.get("overlap_env_bootstrap", True)
+            cfg.runner.get("overlap_env_bootstrap", False)
         ) and not cfg.env.train.get("enable_offload", False)
         if (
             SupportedEnvType(cfg.env.train.env_type) == SupportedEnvType.MANISKILL

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -875,6 +875,9 @@ def validate_embodied_cfg(cfg):
         weight_sync_interval = cfg.runner.get("weight_sync_interval", 1)
         assert weight_sync_interval > 0, "weight_sync_interval must be greater than 0"
         cfg.runner.weight_sync_interval = weight_sync_interval
+        cfg.runner.overlap_env_bootstrap = bool(
+            cfg.runner.get("overlap_env_bootstrap", True)
+        ) and not cfg.env.train.get("enable_offload", False)
         if (
             SupportedEnvType(cfg.env.train.env_type) == SupportedEnvType.MANISKILL
             or SupportedEnvType(cfg.env.eval.env_type) == SupportedEnvType.MANISKILL

--- a/rlinf/runners/embodied_runner.py
+++ b/rlinf/runners/embodied_runner.py
@@ -71,6 +71,9 @@ class EmbodiedRunner:
         self.critic = critic
         self.reward = reward
         self.weight_sync_interval = self.cfg.runner.weight_sync_interval
+        self.overlap_env_bootstrap = bool(
+            self.cfg.runner.get("overlap_env_bootstrap", False)
+        )
         # Data channels
         self.env_channel = Channel.create("Env")
         self.rollout_channel = Channel.create("Rollout")
@@ -308,8 +311,15 @@ class EmbodiedRunner:
 
                 # actor training.
                 actor_training_handle: Handle = self.actor.run_training()
+                env_bootstrap_handle: Handle | None = None
+                if self.overlap_env_bootstrap and _step + 1 < self.max_steps:
+                    env_bootstrap_handle = self.env.prefetch_train_bootstrap(
+                        rollout_channel=self.rollout_channel
+                    )
 
                 actor_training_metrics = actor_training_handle.wait()
+                if env_bootstrap_handle is not None:
+                    env_bootstrap_handle.wait()
 
                 self.global_step += 1
 

--- a/rlinf/workers/env/env_worker.py
+++ b/rlinf/workers/env/env_worker.py
@@ -55,6 +55,7 @@ class EnvWorker(Worker):
 
         self.last_obs_list = []
         self.last_intervened_info_list = []
+        self._prefetched_train_bootstrap: list[EnvOutput] | None = None
         self.rollout_epoch = self.cfg.algorithm.get("rollout_epoch", 1)
         self._component_placement = HybridComponentPlacement(cfg, Cluster())
 
@@ -876,6 +877,36 @@ class EnvWorker(Worker):
 
         return env_outputs
 
+    def _send_train_bootstrap(
+        self, rollout_channel: Channel, env_outputs: list[EnvOutput]
+    ) -> None:
+        for stage_id in range(self.stage_num):
+            env_output: EnvOutput = env_outputs[stage_id]
+            env_batch = env_output.to_dict()
+            self.send_env_batch(
+                rollout_channel,
+                {
+                    "obs": env_batch["obs"],
+                    "final_obs": env_batch["final_obs"],
+                },
+            )
+
+    def _bootstrap_and_send_train(self, rollout_channel: Channel) -> list[EnvOutput]:
+        env_outputs = self.bootstrap_step()
+        self._send_train_bootstrap(rollout_channel, env_outputs)
+        return env_outputs
+
+    def prefetch_train_bootstrap(self, rollout_channel: Channel) -> None:
+        """Prepare and send the first env batch for the next training rollout."""
+        if self._prefetched_train_bootstrap is not None:
+            raise RuntimeError(
+                "A prefetched train bootstrap already exists. "
+                "Call interact() to consume it before prefetching again."
+            )
+        self._prefetched_train_bootstrap = self._bootstrap_and_send_train(
+            rollout_channel
+        )
+
     def record_env_metrics(
         self, env_metrics: dict[str, list], env_info: dict[str, Any], epoch: int
     ):
@@ -926,17 +957,11 @@ class EnvWorker(Worker):
         env_metrics = defaultdict(list)
 
         for epoch in range(self.rollout_epoch):
-            env_outputs = self.bootstrap_step()
-            for stage_id in range(self.stage_num):
-                env_output: EnvOutput = env_outputs[stage_id]
-                env_batch = env_output.to_dict()
-                self.send_env_batch(
-                    rollout_channel,
-                    {
-                        "obs": env_batch["obs"],
-                        "final_obs": env_batch["final_obs"],
-                    },
-                )
+            if epoch == 0 and self._prefetched_train_bootstrap is not None:
+                env_outputs = self._prefetched_train_bootstrap
+                self._prefetched_train_bootstrap = None
+            else:
+                env_outputs = self._bootstrap_and_send_train(rollout_channel)
 
             for chunk_step_idx in range(self.n_train_chunk_steps):
                 for stage_id in range(self.stage_num):

--- a/tests/unit_tests/test_overlap_env_bootstrap.py
+++ b/tests/unit_tests/test_overlap_env_bootstrap.py
@@ -1,0 +1,181 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+from omegaconf import OmegaConf
+
+from rlinf.data.embodied_io_struct import EnvOutput
+
+# Mock gymnasium and rlinf.envs.wrappers before importing EnvWorker
+# to avoid ModuleNotFoundError when gymnasium is not installed.
+# We do this here at the very top to satisfy functional requirements
+# while using # noqa for linter satisfaction if needed.
+if "gymnasium" not in sys.modules:
+    sys.modules["gymnasium"] = MagicMock()
+
+if "rlinf.envs.wrappers" not in sys.modules:
+    sys.modules["rlinf.envs.wrappers"] = MagicMock()
+
+from rlinf.workers.env.env_worker import EnvWorker  # noqa: E402
+
+
+class TestOverlapEnvBootstrap(unittest.TestCase):
+    def setUp(self):
+        self.cfg = OmegaConf.create(
+            {
+                "env": {
+                    "train": {
+                        "total_num_envs": 2,
+                        "max_steps_per_rollout_epoch": 8,
+                        "env_type": "dummy",
+                        "auto_reset": True,
+                        "video_cfg": {"save_video": False},
+                        "max_episode_steps": 10,
+                    },
+                    "eval": {
+                        "total_num_envs": 2,
+                        "max_steps_per_rollout_epoch": 8,
+                        "env_type": "dummy",
+                        "video_cfg": {"save_video": False},
+                        "max_episode_steps": 10,
+                    },
+                },
+                "actor": {
+                    "model": {
+                        "model_type": "dummy",
+                        "num_action_chunks": 4,
+                        "action_dim": 7,
+                    }
+                },
+                "rollout": {
+                    "pipeline_stage_num": 1,
+                    "collect_transitions": False,
+                },
+                "runner": {
+                    "val_check_interval": -1,
+                },
+                "algorithm": {
+                    "rollout_epoch": 1,
+                },
+                "cluster": {},
+            }
+        )
+
+        # Create EnvWorker instance without calling __init__
+        self.worker = object.__new__(EnvWorker)
+
+        # Manually set required attributes
+        self.worker.cfg = self.cfg
+        self.worker._rank = 0
+        self.worker._world_size = 1
+        self.worker._group_name = "EnvGroup"
+        self.worker._timer_metrics = {}
+        self.worker.stage_num = 1
+        self.worker.train_num_envs_per_stage = 2
+        self.worker.n_train_chunk_steps = 2
+        self.worker.rollout_epoch = 1
+        self.worker.enable_offload = False
+        self.worker.collect_transitions = False
+        self.worker.collect_prev_infos = True
+        self.worker._prefetched_train_bootstrap = None
+
+        # Mock env_list
+        mock_env = MagicMock()
+        self.worker.env_list = [mock_env]
+
+        # Initialize last_obs_list for auto_reset=True
+        self.worker.last_obs_list = [{"main_images": torch.zeros(2, 3, 224, 224)}]
+        self.worker.last_intervened_info_list = [(None, None)]
+
+    def test_prefetch_consumption(self):
+        """Test that prefetched bootstrap is correctly consumed in interact()."""
+        rollout_channel = MagicMock()
+        input_channel = MagicMock()
+
+        # Mock recv_rollout_results to return a dummy RolloutResult
+        mock_rollout_result = MagicMock()
+        mock_rollout_result.actions = torch.zeros(2, 28)
+        mock_rollout_result.bootstrap_values = None
+        mock_rollout_result.forward_inputs = {"action": torch.zeros(2, 28)}
+        mock_rollout_result.versions = torch.zeros(2, 1)
+        mock_rollout_result.save_flags = None
+
+        # Patch methods on the instance
+        self.worker.recv_rollout_results = MagicMock(return_value=mock_rollout_result)
+        self.worker.env_interact_step = MagicMock(
+            return_value=(
+                EnvOutput(
+                    obs={"main_images": torch.zeros(2, 3, 224, 224)},
+                    dones=torch.zeros(2, 4, dtype=torch.bool),
+                    truncations=torch.zeros(2, 4, dtype=torch.bool),
+                    terminations=torch.zeros(2, 4, dtype=torch.bool),
+                ),
+                {},
+            )
+        )
+        self.worker.send_env_batch = MagicMock()
+        self.worker.store_last_obs_and_intervened_info = MagicMock()
+        self.worker.finish_rollout = MagicMock()
+        self.worker.compute_bootstrap_rewards = MagicMock(
+            return_value=torch.zeros(2, 4)
+        )
+
+        # 1. Prefetch
+        # We need to mock _bootstrap_and_send_train as it's called by prefetch_train_bootstrap
+        dummy_bootstrap = [
+            EnvOutput(obs={"m": torch.zeros(1)}, dones=torch.zeros(1, 4))
+        ]
+        self.worker._bootstrap_and_send_train = MagicMock(return_value=dummy_bootstrap)
+
+        self.worker.prefetch_train_bootstrap(rollout_channel)
+        self.assertEqual(self.worker._prefetched_train_bootstrap, dummy_bootstrap)
+
+        # 2. Interact (should consume the prefetch)
+        import asyncio
+
+        loop = asyncio.get_event_loop()
+        # Mock send_rollout_trajectories as it's awaited
+        self.worker.send_rollout_trajectories = MagicMock(return_value=asyncio.Future())
+        self.worker.send_rollout_trajectories.return_value.set_result(None)
+
+        loop.run_until_complete(
+            self.worker.interact(input_channel, rollout_channel, None, None)
+        )
+
+        self.assertIsNone(self.worker._prefetched_train_bootstrap)
+        # Verify that _bootstrap_and_send_train was NOT called during interact
+        # (it was only called once during prefetch)
+        self.worker._bootstrap_and_send_train.assert_called_once()
+
+    def test_duplicate_prefetch_protection(self):
+        """Test that multiple prefetch calls raise RuntimeError."""
+        rollout_channel = MagicMock()
+        self.worker._bootstrap_and_send_train = MagicMock()
+
+        # First prefetch
+        self.worker.prefetch_train_bootstrap(rollout_channel)
+
+        # Second prefetch should raise RuntimeError
+        with self.assertRaises(RuntimeError) as cm:
+            self.worker.prefetch_train_bootstrap(rollout_channel)
+
+        self.assertIn("A prefetched train bootstrap already exists", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Recreated the PR as commit checks require branch names to satisfy some rules. See #942 for the original PR and comments.

Performance Improvement: Asynchronous Environment Bootstrapping and Training Overlap

### Description
~~This PR introduces a new `warmup` method to the `EnvWorker` class to enable asynchronous environment preparation. The `warmup` function is designed to be called prior to `interact`, allowing environment bootstrapping to occur in parallel with `run_training`.
We also add a new `-1` configuration option for environment settings to explicitly denote CPU-only physics and rendering, and the function `get_group_accelerators` in `embodied_runner.py` to check if there is resource overlap.~~
Updated the PR based on feedback and copied suggested changes. Main difference is that warmup is not a function but an async handle (it is not called warmup anymore) and class member holding the bootstrap data is freed after consumption (e.g. set to `None`). 
There is also a new configuration for `runner`, `overlap_env_bootstrap`. This parameter needs to be set to True in the yaml file:
```
runner:
     overlap_env_bootstrap: True
``` 

### Motivation and Context
Currently, environment bootstrap time accounts for a significant portion (5%–20%) of each global step. In hardware configurations where `EnvWorker` processes do not compete for resources with the training actor (e.g., CPU-based rendering vs. NPU/GPU-based training), this bootstrap latency can be masked by overlapping it with the training phase.

While the initial global step time remains unchanged, subsequent steps see significant improvement in throughput.
*Preliminary Results:*
In a CPU + NPU environment (benchmarked on `libero_10` with Pi0.5 and PPO, with changes for minimal configuration), we observed a reduction in per-global-step time from 720s to approximately 620–640s.

### How has this been tested?
Validation is ongoing on our internal clusters using standard RLinf examples. Specifically:
Execution Script: `run_embodiment.sh`
Configuration: `libero_10_ppo_openpi_pi05.yaml` (with some selected minor adjustments from [Section 2.4 Minimum Test Case](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/pi0.html)).

### Additional information (optional, e.g., figures and logs):
Initial performance figures are posted in [comment](https://github.com/RLinf/RLinf/pull/942#issuecomment-4145842761).
_Further logs and performance figures will be attached upon completion of the test run._

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
(We are doing our due diligence to ensure that our changes do not break existing functionality. However, we are marking this box in case we miss something. If we are confident that our changes are non-breaking, we will remove the tick.)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.