### PR TITLE
fix(fsdp): make FSDP can be fully offloaded

### DIFF
--- a/rlinf/hybrid_engines/fsdp/__init__.py
+++ b/rlinf/hybrid_engines/fsdp/__init__.py
@@ -24,6 +24,7 @@ except ImportError:
 if version.parse(torch.__version__) >= version.parse("2.6.0"):
     from torch.distributed.fsdp import (
         BackwardPrefetch,
+        CPUOffload,
         CPUOffloadPolicy,
         FSDPModule,
         MixedPrecisionPolicy,
@@ -41,7 +42,11 @@ elif version.parse(torch.__version__) >= version.parse("2.4.0"):
         OffloadPolicy,
         fully_shard,
     )
-    from torch.distributed.fsdp import BackwardPrefetch, ShardingStrategy  # noqa: F401
+    from torch.distributed.fsdp import (  # noqa: F401
+        BackwardPrefetch,
+        CPUOffload,
+        ShardingStrategy,
+    )
     from torch.distributed.fsdp.fully_sharded_data_parallel import (
         FullyShardedDataParallel as FSDP,  # noqa: F401
     )

--- a/rlinf/hybrid_engines/fsdp/strategy/fsdp.py
+++ b/rlinf/hybrid_engines/fsdp/strategy/fsdp.py
@@ -26,7 +26,7 @@ from torch.distributed.fsdp import (
 from torch.optim import Optimizer
 
 from rlinf.config import torch_dtype_from_precision
-from rlinf.hybrid_engines.fsdp import FSDP
+from rlinf.hybrid_engines.fsdp import FSDP, CPUOffload
 from rlinf.hybrid_engines.fsdp.strategy.base import FSDPStrategyBase
 from rlinf.hybrid_engines.fsdp.utils import (
     FSDPVersion,
@@ -41,6 +41,96 @@ from rlinf.utils.utils import clear_memory
 
 
 class FSDPStrategy(FSDPStrategyBase):
+    _FSDP_CACHE_ATTRS = (
+        "_mp_shard",
+        "_full_param_padded",
+        "_full_prec_full_param_padded",
+        "_unsharded_flat_param_for_skipped_views",
+    )
+    _FSDP_GRAD_ATTRS = ("_saved_grad_shard", "_cpu_grad")
+
+    @staticmethod
+    def _iter_fsdp_handles(model: FSDP) -> list:
+        handles = []
+        seen_handle_ids = set()
+        for module in model.modules():
+            handle = getattr(module, "_handle", None)
+            if handle is not None and id(handle) not in seen_handle_ids:
+                seen_handle_ids.add(id(handle))
+                handles.append(handle)
+
+            all_handles = getattr(module, "_all_handles", None)
+            if all_handles is None:
+                continue
+            for inner_handle in all_handles:
+                if inner_handle is None or id(inner_handle) in seen_handle_ids:
+                    continue
+                seen_handle_ids.add(id(inner_handle))
+                handles.append(inner_handle)
+        return handles
+
+    @staticmethod
+    def _move_tensor(
+        tensor: torch.Tensor | None, device: torch.device | str
+    ) -> torch.Tensor | None:
+        if tensor is None or tensor.device == torch.device(device):
+            return tensor
+        return tensor.to(device, non_blocking=True)
+
+    @staticmethod
+    def _free_tensor_storage(tensor: torch.Tensor | None) -> None:
+        if tensor is None:
+            return
+        try:
+            storage = tensor.untyped_storage()
+            if storage.size() > 0:
+                storage.resize_(0)
+        except Exception:
+            pass
+
+    @staticmethod
+    def _rebind_sharded_tensor_views(handle) -> None:
+        flat_param = handle.flat_param
+        if not handle.uses_sharded_strategy:
+            handle._use_unsharded_views(as_params=False)
+            return
+
+        size_0_empty_tensor = torch.empty(
+            0,
+            dtype=flat_param.dtype,
+            device=flat_param.device,
+            requires_grad=False,
+        )
+        for shard_param_info, (param_name, module, _) in zip(
+            flat_param._shard_param_infos,
+            flat_param._param_infos,
+        ):
+            if not shard_param_info.in_shard:
+                tensor = size_0_empty_tensor
+            else:
+                offset = shard_param_info.offset_in_shard
+                numel_in_shard = shard_param_info.numel_in_shard
+                tensor = flat_param[offset : offset + numel_in_shard]
+            handle._setattr_tensor(module, param_name, tensor)
+
+        for (
+            param_name,
+            module,
+            _,
+            prim_param_name,
+            prim_module,
+            _,
+        ) in flat_param._shared_param_infos:
+            handle._setattr_tensor(
+                module, param_name, getattr(prim_module, prim_param_name)
+            )
+
+    def _rebind_handle_views(self, handle) -> None:
+        if handle._use_orig_params:
+            handle._use_sharded_views()
+            return
+        self._rebind_sharded_tensor_views(handle)
+
     def wrap_model(self, model: nn.Module, device_mesh: DeviceMesh) -> FSDP:
         """
         Wrap the model with FSDP using the specified configuration,
@@ -78,6 +168,8 @@ class FSDPStrategy(FSDPStrategyBase):
             self.cfg.fsdp_config.backward_prefetch
         )
 
+        cpu_offload = CPUOffload(offload_params=self.cfg.fsdp_config.cpu_offload)
+
         fsdp_model = FSDP(
             module=model,
             param_init_fn=init_fn,
@@ -91,6 +183,7 @@ class FSDPStrategy(FSDPStrategyBase):
             backward_prefetch=backward_prefetch,
             limit_all_gathers=self.cfg.fsdp_config.limit_all_gathers,
             use_orig_params=self.cfg.fsdp_config.use_orig_params,
+            cpu_offload=cpu_offload,
         )
         return fsdp_model
 
@@ -123,27 +216,41 @@ class FSDPStrategy(FSDPStrategyBase):
             - model (FSDP): The FSDP wrapped model.
             - offload_grad (bool): Whether to offload gradients or not.
         """
+        for handle in self._iter_fsdp_handles(model):
+            flat_param = handle.flat_param
+
+            if hasattr(flat_param, "_local_shard"):
+                flat_param._local_shard = self._move_tensor(
+                    flat_param._local_shard, "cpu"
+                )
+            flat_param.data = self._move_tensor(flat_param.data, "cpu")
+            if hasattr(flat_param, "_local_shard") and flat_param.data is not None:
+                flat_param._local_shard = flat_param.data
+
+            if offload_grad:
+                flat_param.grad = self._move_tensor(flat_param.grad, "cpu")
+                for attr_name in self._FSDP_GRAD_ATTRS:
+                    if hasattr(flat_param, attr_name):
+                        setattr(
+                            flat_param,
+                            attr_name,
+                            self._move_tensor(getattr(flat_param, attr_name), "cpu"),
+                        )
+
+            for attr_name in self._FSDP_CACHE_ATTRS:
+                if hasattr(flat_param, attr_name):
+                    self._free_tensor_storage(getattr(flat_param, attr_name))
+
+            self._rebind_handle_views(handle)
+
         for _, param in model.named_parameters():
-            if hasattr(param, "_handle") and param._handle is not None:
-                flat_param = param._handle.flat_param
-                if (
-                    hasattr(flat_param, "_local_shard")
-                    and flat_param._local_shard is not None
-                ):
-                    flat_param._local_shard = flat_param._local_shard.to(
-                        "cpu", non_blocking=True
-                    )
-                if flat_param.data is not None:
-                    flat_param.data = flat_param.data.to("cpu", non_blocking=True)
-                    flat_param._local_shard = flat_param.data
-            elif hasattr(param, "_local_shard") and param._local_shard is not None:
-                param._local_shard = param._local_shard.to("cpu", non_blocking=True)
+            param.data = self._move_tensor(param.data, "cpu")
+            if offload_grad:
+                param.grad = self._move_tensor(param.grad, "cpu")
 
-            if param.data is not None:
-                param.data = param.data.to("cpu", non_blocking=True)
+        for _, buffer in model.named_buffers():
+            buffer.data = self._move_tensor(buffer.data, "cpu")
 
-            if offload_grad and param.grad is not None:
-                param.grad = param.grad.to("cpu", non_blocking=True)
         clear_memory()
 
     @torch.no_grad()
@@ -159,27 +266,37 @@ class FSDPStrategy(FSDPStrategyBase):
             - onload_grad (bool): Whether to load gradients or not.
 
         """
+        for handle in self._iter_fsdp_handles(model):
+            flat_param = handle.flat_param
+
+            if hasattr(flat_param, "_local_shard"):
+                flat_param._local_shard = self._move_tensor(
+                    flat_param._local_shard, device
+                )
+            flat_param.data = self._move_tensor(flat_param.data, device)
+            if hasattr(flat_param, "_local_shard") and flat_param.data is not None:
+                flat_param._local_shard = flat_param.data
+
+            if onload_grad:
+                flat_param.grad = self._move_tensor(flat_param.grad, device)
+                for attr_name in self._FSDP_GRAD_ATTRS:
+                    if hasattr(flat_param, attr_name):
+                        setattr(
+                            flat_param,
+                            attr_name,
+                            self._move_tensor(getattr(flat_param, attr_name), device),
+                        )
+
+            self._rebind_handle_views(handle)
+
         for _, param in model.named_parameters():
-            if hasattr(param, "_handle") and param._handle is not None:
-                flat_param = param._handle.flat_param
-                if (
-                    hasattr(flat_param, "_local_shard")
-                    and flat_param._local_shard is not None
-                ):
-                    flat_param._local_shard = flat_param._local_shard.to(
-                        device, non_blocking=True
-                    )
-                if flat_param.data is not None:
-                    flat_param.data = flat_param.data.to(device, non_blocking=True)
-                    flat_param._local_shard = flat_param.data
-            elif hasattr(param, "_local_shard") and param._local_shard is not None:
-                param._local_shard = param._local_shard.to(device, non_blocking=True)
+            param.data = self._move_tensor(param.data, device)
+            if onload_grad:
+                param.grad = self._move_tensor(param.grad, device)
 
-            if param.data is not None:
-                param.data = param.data.to(device, non_blocking=True)
+        for _, buffer in model.named_buffers():
+            buffer.data = self._move_tensor(buffer.data, device)
 
-            if onload_grad and param.grad is not None:
-                param.grad = param.grad.to(device, non_blocking=True)
         clear_memory()
 
     @torch.no_grad()


### PR DESCRIPTION
### Description

Current FSDP offload implement only tries to move every Parameter to cpu, ignore FSDP's existing cached attrs which are all possibly on gpus. More importantly, there are raw param's tensor view hang on flat_param, pointing to former gpu storages and causes these storages can not be released. 

This PR also adds official CPUOffload to FSDP.

### Motivation and Context

Make FSDP able to be fully offloaded.

### How has this been tested?
TODO.

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.