### PR TITLE
feat(nsys): support nsys trace for worker groups

### DIFF
--- a/docs/source-en/rst_source/tutorials/advance/index.rst
+++ b/docs/source-en/rst_source/tutorials/advance/index.rst
@@ -44,6 +44,11 @@ offering practical guidance to help you fully optimize your RL post-training wor
    embodied training, including the ``patch`` and ``bucket`` modes, their
    configuration, recommended use cases, and performance considerations.
 
+- :doc:`nsight`
+   Introduces the Hydra-based ``cluster.nsight`` configuration used to wrap
+   selected Ray worker groups with ``nsys profile``, including how to enable,
+   disable, and target worker groups for system-level traces.
+
 
 .. toctree::
    :hidden:
@@ -57,4 +62,5 @@ offering practical guidance to help you fully optimize your RL post-training wor
    hetero
    cloud-edge
    logger
+   nsight
    weight_syncer

--- a/docs/source-en/rst_source/tutorials/advance/nsight.rst
+++ b/docs/source-en/rst_source/tutorials/advance/nsight.rst
@@ -1,0 +1,167 @@
+Nsight Systems
+==============================
+
+This document introduces the ``cluster.nsight`` configuration in RLinf for
+system-level profiling with NVIDIA Nsight Systems.
+
+RLinf supports wrapping selected Ray worker groups with ``nsys profile`` so you
+can collect traces for CUDA kernels, cuDNN, cuBLAS, NVTX ranges, and optionally
+CPU-side runtime activity.
+
+
+How To Enable It
+------------------------------
+
+In an embodied YAML, add the Nsight preset to ``defaults``:
+
+.. code-block:: yaml
+
+   defaults:
+     - training_backend/fsdp@actor.fsdp_config
+     - weight_syncer/patch_syncer@weight_syncer
+     - nsight/default@cluster.nsight
+
+The corresponding config files are:
+
+- ``examples/embodiment/config/nsight/default.yaml``
+
+
+Default Preset
+------------------------------
+
+The built-in default preset looks like this:
+
+.. code-block:: yaml
+
+   enabled: true
+   worker_groups: [ActorGroup, RolloutGroup, EnvGroup, Actor, Rollout, Env]
+   options:
+     t: cuda,cudnn,cublas,nvtx,osrt
+     sample: process-tree
+     cpuctxsw: process-tree
+     osrt-threshold: 1000
+
+This preset targets the most common embodied compute and communication workers by default:
+
+- ``ActorGroup``
+- ``RolloutGroup``
+- ``EnvGroup``
+- ``Actor``
+- ``Rollout``
+- ``Env``
+
+These names must match real worker group names such as ``actor.group_name`` and
+``rollout.group_name``. They are not the component aliases ``actor`` or
+``rollout``.
+
+
+The ``enabled`` Flag
+------------------------------
+
+The ``enabled`` field is the main switch for Nsight wrapping:
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       enabled: false
+
+When ``enabled: false``:
+
+- RLinf does not wrap workers with ``nsys profile``
+- RLinf does not reserve the default Nsight output directory
+- the rest of the config can stay in place for later reuse
+
+So there is no need to maintain a separate ``disabled.yaml``. You can keep the
+same preset and override ``cluster.nsight.enabled: false`` in the main YAML.
+
+
+How To Override Worker Groups
+------------------------------
+
+You can override the preset directly in the main YAML:
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       worker_groups: [EnvGroup, RolloutGroup, ActorGroup, Env, Rollout, Actor]
+
+This is especially useful when you want to profile:
+
+- compute workers such as ``ActorGroup`` or ``RolloutGroup``
+- channel workers such as ``Env``, ``Rollout``, and ``Actor``
+- environment workers such as ``EnvGroup``
+
+If ``worker_groups`` is omitted, RLinf profiles all worker groups.
+
+One subtle point is that ``ChannelWorker`` is not launched as a child process of
+``ActorGroup`` or ``RolloutGroup`` ranks. In the current implementation,
+``Channel.create(name)`` launches a separate worker group whose group name is
+usually ``Env``, ``Rollout``, or ``Actor``. So profiling ``ActorGroup`` does
+not automatically include the ``Actor`` channel worker. If you want channel-side
+traces, add those channel group names explicitly to ``worker_groups``.
+
+
+How To Override Nsight Options
+------------------------------
+
+``cluster.nsight.options`` maps directly to ``nsys profile`` CLI flags:
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       options:
+         t: cuda,cudnn,cublas,nvtx,osrt
+         sample: process-tree
+         cpuctxsw: process-tree
+
+Useful options include:
+
+- ``t``: traced APIs such as ``cuda``, ``cudnn``, ``cublas``, ``nvtx``, and ``osrt``
+- ``sample``: CPU sampling mode
+- ``cpuctxsw``: CPU thread scheduling trace
+- ``capture-range`` and ``capture-range-end``: restrict collection to NVTX or CUDA-profiler-controlled ranges
+- ``o`` or ``output``: explicit output prefix
+
+If you enable ``capture-range: nvtx``, make sure your code actually emits NVTX
+ranges. Otherwise Nsight may generate an almost empty report.
+
+
+Output Path
+------------------------------
+
+When ``cluster.nsight.enabled`` is true and you do not explicitly set ``o`` or
+``output``, RLinf writes reports under:
+
+.. code-block:: text
+
+   runner.logger.log_path/runner.logger.experiment_name/nsights
+
+For example:
+
+.. code-block:: text
+
+   ../results/libero_spatial_ppo_openpi/nsights/
+
+If you want a custom path, set it explicitly:
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       options:
+         o: /mnt/public/profiles/my_run/worker_trace
+
+
+Recommended Workflow
+------------------------------
+
+For a first pass, the simplest setup is:
+
+- start with ``nsight/default@cluster.nsight``
+- keep ``enabled: true``
+- use the preset as-is if you want both CUDA-side traces and CPU/channel-side runtime visibility
+- avoid ``capture-range: nvtx`` until you have confirmed the target workers
+  really emit NVTX ranges

--- a/docs/source-en/rst_source/tutorials/advance/nsight.rst
+++ b/docs/source-en/rst_source/tutorials/advance/nsight.rst
@@ -39,7 +39,9 @@ The built-in default preset looks like this:
      t: cuda,cudnn,cublas,nvtx,osrt
      sample: process-tree
      cpuctxsw: process-tree
+     cudabacktrace: all
      osrt-threshold: 1000
+   flags: []
 
 This preset targets the most common embodied compute and communication workers by default:
 
@@ -53,6 +55,10 @@ This preset targets the most common embodied compute and communication workers b
 These names must match real worker group names such as ``actor.group_name`` and
 ``rollout.group_name``. They are not the component aliases ``actor`` or
 ``rollout``.
+
+The preset also keeps CPU sampling enabled and turns on ``cudabacktrace`` by
+default, so the resulting report includes both CUDA-side activity and CUDA API
+backtraces during the first profiling pass.
 
 
 The ``enabled`` Flag
@@ -102,11 +108,27 @@ usually ``Env``, ``Rollout``, or ``Actor``. So profiling ``ActorGroup`` does
 not automatically include the ``Actor`` channel worker. If you want channel-side
 traces, add those channel group names explicitly to ``worker_groups``.
 
+For the built-in embodied runners, these channel worker group names are created
+directly from the channel names in code:
+
+- ``ActorGroup``: actor compute workers
+- ``RolloutGroup``: rollout compute workers
+- ``EnvGroup``: environment compute workers
+- ``Actor``: the channel worker behind ``Channel.create("Actor")``
+- ``Rollout``: the channel worker behind ``Channel.create("Rollout")``
+- ``Env``: the channel worker behind ``Channel.create("Env")``
+
+So ``worker_groups: [Actor]`` means "profile the Actor channel worker", not
+"profile all actor-side compute". The current matching rule is by worker group
+name, which is why the channel names matter here. If you create your own
+channels with other names, use those exact channel names in ``worker_groups``.
+
 
 How To Override Nsight Options
 ------------------------------
 
-``cluster.nsight.options`` maps directly to ``nsys profile`` CLI flags:
+``cluster.nsight.options`` maps directly to ``nsys profile`` flags that take
+values, while ``cluster.nsight.flags`` emits bare flags:
 
 .. code-block:: yaml
 
@@ -116,17 +138,93 @@ How To Override Nsight Options
          t: cuda,cudnn,cublas,nvtx,osrt
          sample: process-tree
          cpuctxsw: process-tree
+         cudabacktrace: all
 
 Useful options include:
 
 - ``t``: traced APIs such as ``cuda``, ``cudnn``, ``cublas``, ``nvtx``, and ``osrt``
 - ``sample``: CPU sampling mode
+- ``backtrace``: CPU backtrace method used with sampling, for example ``lbr``, ``fp``, or ``dwarf``
 - ``cpuctxsw``: CPU thread scheduling trace
+- ``cudabacktrace``: collect CUDA API backtraces; this requires CPU sampling to stay enabled and can add noticeable overhead
 - ``capture-range`` and ``capture-range-end``: restrict collection to NVTX or CUDA-profiler-controlled ranges
 - ``o`` or ``output``: explicit output prefix
 
 If you enable ``capture-range: nvtx``, make sure your code actually emits NVTX
 ranges. Otherwise Nsight may generate an almost empty report.
+
+You are not limited to the keys shown in ``nsight/default``. RLinf forwards
+arbitrary entries in ``cluster.nsight.options`` to ``nsys profile``:
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       options:
+         t: cuda,cudnn,cublas,nvtx,osrt
+         sample: process-tree
+         backtrace: fp
+         capture-range: cudaProfilerApi
+         capture-range-end: stop
+         samples-per-backtrace: 4
+       flags: [python-backtrace]
+
+This works because RLinf treats ``cluster.nsight.options`` as a free-form
+mapping:
+
+- one-character keys are rendered like ``-t cuda,...``
+- longer keys are rendered like ``--backtrace=fp``
+- ``flags`` entries are rendered like ``--python-backtrace``
+
+To emit a flag without a value, put it in ``cluster.nsight.flags``:
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       flags: [python-backtrace]
+
+You can do the same from the Hydra CLI:
+
+.. code-block:: bash
+
+   python ... 'cluster.nsight.flags=[python-backtrace]'
+
+This is especially useful for ``nsys`` options whose value is optional and where
+the bare flag form has special meaning.
+
+Nsight Systems options are not perfectly stable across versions and host
+platforms. In particular, the supported or recommended ``backtrace`` mode may
+vary between machines. If a flag is rejected on your target node, or if
+``lbr``-style backtraces do not work well on that machine, check
+``nsys profile --help`` on the target node and override
+``cluster.nsight.options`` accordingly, for example by switching
+``backtrace`` to ``fp`` or ``dwarf``.
+
+
+How To Emit NVTX Ranges
+------------------------------
+
+RLinf already provides a small helper for emitting NVTX ranges:
+
+.. code-block:: python
+
+   from rlinf.utils.utils import nvtx_range
+
+   with nvtx_range("actor.forward", color="green"):
+       run_actor_forward()
+
+This is the easiest way to mark higher-level phases before you turn on
+``capture-range: nvtx`` or when you want named ranges in the Nsight timeline.
+
+The helper first tries the optional ``nvtx`` Python package. If that package is
+not installed, it falls back to ``torch.cuda.nvtx`` when CUDA is available. If
+neither backend is available, the context manager becomes a no-op, so it is
+safe to leave in code paths that also run without NVTX support.
+
+When you use ``capture-range: nvtx``, make sure the profiled workers actually
+execute code inside these ranges. Otherwise Nsight may collect very little or no
+data.
 
 
 Output Path

--- a/docs/source-zh/rst_source/tutorials/advance/index.rst
+++ b/docs/source-zh/rst_source/tutorials/advance/index.rst
@@ -43,6 +43,10 @@
    介绍具身训练中 actor 到 rollout 的权重同步优化机制，
    包括 ``patch`` 与 ``bucket`` 两种同步模式、配置方法、适用场景以及性能注意事项。
 
+- :doc:`nsight`
+   介绍基于 Hydra 的 ``cluster.nsight`` 配置，用于通过 ``nsys profile``
+   包装指定的 Ray worker group，并说明如何启用、关闭以及选择需要采样的 worker。
+
 
 .. toctree::
    :hidden:
@@ -56,4 +60,5 @@
    hetero
    cloud-edge
    logger
+   nsight
    weight_syncer

--- a/docs/source-zh/rst_source/tutorials/advance/nsight.rst
+++ b/docs/source-zh/rst_source/tutorials/advance/nsight.rst
@@ -1,0 +1,163 @@
+Nsight Systems
+==============================
+
+本文介绍 RLinf 中基于 ``cluster.nsight`` 的系统级 Profiling 配置，用于通过
+NVIDIA Nsight Systems 对指定 Ray worker group 执行 ``nsys profile`` 包装。
+
+借助这套机制，你可以采集 CUDA kernel、cuDNN、cuBLAS、NVTX，以及可选的
+CPU runtime 相关时间线。
+
+如何启用
+------------------------------
+
+在具身 YAML 的 ``defaults`` 中引入 Nsight 预设：
+
+.. code-block:: yaml
+
+   defaults:
+     - training_backend/fsdp@actor.fsdp_config
+     - weight_syncer/patch_syncer@weight_syncer
+     - nsight/default@cluster.nsight
+
+对应的配置文件是：
+
+- ``examples/embodiment/config/nsight/default.yaml``
+
+
+默认预设
+------------------------------
+
+内置的默认预设如下：
+
+.. code-block:: yaml
+
+   enabled: true
+   worker_groups: [ActorGroup, RolloutGroup, EnvGroup, Actor, Rollout, Env]
+   options:
+     t: cuda,cudnn,cublas,nvtx,osrt
+     sample: process-tree
+     cpuctxsw: process-tree
+     osrt-threshold: 1000
+
+这份默认配置会优先采样具身训练里最常见的计算 worker 和通信 worker：
+
+- ``ActorGroup``
+- ``RolloutGroup``
+- ``EnvGroup``
+- ``Actor``
+- ``Rollout``
+- ``Env``
+
+这里的名字必须和真实的 worker group 名一致，例如 ``actor.group_name``、
+``rollout.group_name``，而不是组件别名 ``actor`` 或 ``rollout``。
+
+
+``enabled`` 开关
+------------------------------
+
+``enabled`` 是 Nsight 的总开关：
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       enabled: false
+
+当 ``enabled: false`` 时：
+
+- RLinf 不会用 ``nsys profile`` 包装 worker
+- RLinf 不会预留默认的 Nsight 输出目录
+- 其余 profiling 配置可以保留，方便后续再次开启
+
+因此不需要单独维护一份 ``disabled.yaml``，直接在主 YAML 里覆盖
+``cluster.nsight.enabled: false`` 即可。
+
+
+如何覆盖 worker_groups
+------------------------------
+
+你可以直接在主 YAML 里覆盖这份预设：
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       worker_groups: [EnvGroup, RolloutGroup, ActorGroup, Env, Rollout, Actor]
+
+这对以下场景很有用：
+
+- 采 actor / rollout 这类计算 worker
+- 采 ``Env``、``Rollout``、``Actor`` 这类 channel worker
+- 采 ``EnvGroup`` 这类环境 worker
+
+如果省略 ``worker_groups``，RLinf 会对所有 worker group 开启 profiling。
+
+这里有一个容易混淆的点：当前实现里的 ``ChannelWorker`` 不是
+``ActorGroup`` / ``RolloutGroup`` 某个 rank 的子进程，而是通过
+``Channel.create(name)`` 单独 launch 出来的独立 worker group，名字通常就是
+``Env``、``Rollout``、``Actor``。因此只 profile ``ActorGroup`` 并不会自动
+覆盖 ``Actor`` 这个 channel worker；如果你想看 channel 本身，需要把这些名字
+显式加进 ``worker_groups``。
+
+
+如何覆盖 Nsight 参数
+------------------------------
+
+``cluster.nsight.options`` 会被直接映射到 ``nsys profile`` 的 CLI 参数：
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       options:
+         t: cuda,cudnn,cublas,nvtx,osrt
+         sample: process-tree
+         cpuctxsw: process-tree
+
+常用参数包括：
+
+- ``t``: 需要采集的 API，例如 ``cuda``、``cudnn``、``cublas``、``nvtx``、``osrt``
+- ``sample``: CPU sampling 模式
+- ``cpuctxsw``: CPU 线程调度时间线
+- ``capture-range`` 和 ``capture-range-end``: 用 NVTX 或 CUDA profiler API 控制采样窗口
+- ``o`` 或 ``output``: 显式指定输出前缀
+
+如果你开启了 ``capture-range: nvtx``，请确认代码里确实发出了 NVTX range；
+否则 Nsight 很可能只会生成几乎没有内容的空 report。
+
+
+输出路径
+------------------------------
+
+当 ``cluster.nsight.enabled`` 为 true，且没有显式指定 ``o`` / ``output`` 时，
+RLinf 默认会把 report 写到：
+
+.. code-block:: text
+
+   runner.logger.log_path/runner.logger.experiment_name/nsights
+
+例如：
+
+.. code-block:: text
+
+   ../results/libero_spatial_ppo_openpi/nsights/
+
+如果你希望写入固定目录，可以显式覆盖：
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       options:
+         o: /mnt/public/profiles/my_run/worker_trace
+
+
+推荐使用方式
+------------------------------
+
+第一轮定位问题时，最简单的用法通常是：
+
+- 先用 ``nsight/default@cluster.nsight``
+- 保持 ``enabled: true``
+- 如果你既想看 CUDA timeline，也想看 CPU/channel 侧 runtime 行为，默认 preset 可以直接用
+- 在确认目标 worker 已经打出 NVTX 之前，不要急着加 ``capture-range: nvtx``

--- a/docs/source-zh/rst_source/tutorials/advance/nsight.rst
+++ b/docs/source-zh/rst_source/tutorials/advance/nsight.rst
@@ -37,7 +37,9 @@ CPU runtime 相关时间线。
      t: cuda,cudnn,cublas,nvtx,osrt
      sample: process-tree
      cpuctxsw: process-tree
+     cudabacktrace: all
      osrt-threshold: 1000
+   flags: []
 
 这份默认配置会优先采样具身训练里最常见的计算 worker 和通信 worker：
 
@@ -50,6 +52,9 @@ CPU runtime 相关时间线。
 
 这里的名字必须和真实的 worker group 名一致，例如 ``actor.group_name``、
 ``rollout.group_name``，而不是组件别名 ``actor`` 或 ``rollout``。
+
+这份 preset 默认会保留 CPU sampling，并额外开启 ``cudabacktrace``，因此第一轮
+profiling 时就能同时看到 CUDA 侧时间线和 CUDA API 调用栈。
 
 
 ``enabled`` 开关
@@ -68,10 +73,6 @@ CPU runtime 相关时间线。
 - RLinf 不会用 ``nsys profile`` 包装 worker
 - RLinf 不会预留默认的 Nsight 输出目录
 - 其余 profiling 配置可以保留，方便后续再次开启
-
-因此不需要单独维护一份 ``disabled.yaml``，直接在主 YAML 里覆盖
-``cluster.nsight.enabled: false`` 即可。
-
 
 如何覆盖 worker_groups
 ------------------------------
@@ -99,11 +100,26 @@ CPU runtime 相关时间线。
 覆盖 ``Actor`` 这个 channel worker；如果你想看 channel 本身，需要把这些名字
 显式加进 ``worker_groups``。
 
+对于内置的具身 runner，这几类名字和实际含义可以直接对应起来：
+
+- ``ActorGroup``: actor 计算 worker
+- ``RolloutGroup``: rollout 计算 worker
+- ``EnvGroup``: env 计算 worker
+- ``Actor``: 由 ``Channel.create("Actor")`` 创建出来的 channel worker
+- ``Rollout``: 由 ``Channel.create("Rollout")`` 创建出来的 channel worker
+- ``Env``: 由 ``Channel.create("Env")`` 创建出来的 channel worker
+
+所以 ``worker_groups: [Actor]`` 的含义是“profile Actor 这个 channel worker”，
+而不是“profile 所有 actor 侧计算”。当前这套匹配机制本来就是按 worker group
+name 做判断，因此这里必须填写真实的 group name。若你在自定义 runner 里创建了
+别的 channel 名字，也应当把那个精确名字写进 ``worker_groups``。
+
 
 如何覆盖 Nsight 参数
 ------------------------------
 
-``cluster.nsight.options`` 会被直接映射到 ``nsys profile`` 的 CLI 参数：
+``cluster.nsight.options`` 会被直接映射到那些“带值”的 ``nsys profile`` 参数，
+而 ``cluster.nsight.flags`` 则用于输出裸 flag：
 
 .. code-block:: yaml
 
@@ -113,17 +129,87 @@ CPU runtime 相关时间线。
          t: cuda,cudnn,cublas,nvtx,osrt
          sample: process-tree
          cpuctxsw: process-tree
+         cudabacktrace: all
 
 常用参数包括：
 
 - ``t``: 需要采集的 API，例如 ``cuda``、``cudnn``、``cublas``、``nvtx``、``osrt``
 - ``sample``: CPU sampling 模式
+- ``backtrace``: CPU sampling 搭配使用的回溯方式，例如 ``lbr``、``fp``、``dwarf``
 - ``cpuctxsw``: CPU 线程调度时间线
+- ``cudabacktrace``: 采集 CUDA API 调用栈；它依赖 CPU sampling，并且可能明显增加 overhead
 - ``capture-range`` 和 ``capture-range-end``: 用 NVTX 或 CUDA profiler API 控制采样窗口
 - ``o`` 或 ``output``: 显式指定输出前缀
 
 如果你开启了 ``capture-range: nvtx``，请确认代码里确实发出了 NVTX range；
 否则 Nsight 很可能只会生成几乎没有内容的空 report。
+
+你并不局限于 ``nsight/default`` 里已经出现的那些 key。RLinf 会把
+``cluster.nsight.options`` 中的任意新增项继续透传给 ``nsys profile``：
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       options:
+         t: cuda,cudnn,cublas,nvtx,osrt
+         sample: process-tree
+         backtrace: fp
+         capture-range: cudaProfilerApi
+         capture-range-end: stop
+         samples-per-backtrace: 4
+       flags: [python-backtrace]
+
+这是因为 RLinf 会把 ``cluster.nsight.options`` 当作一个自由字典来渲染：
+
+- 单字符 key 会被渲染成 ``-t cuda,...`` 这种形式
+- 多字符 key 会被渲染成 ``--backtrace=fp`` 这种形式
+- ``flags`` 里的项会被渲染成 ``--python-backtrace`` 这种形式
+
+如果你想输出一个“不带值”的 flag，可以把它写进 ``cluster.nsight.flags``：
+
+.. code-block:: yaml
+
+   cluster:
+     nsight:
+       flags: [python-backtrace]
+
+同样也可以通过 Hydra CLI 覆盖：
+
+.. code-block:: bash
+
+   python ... 'cluster.nsight.flags=[python-backtrace]'
+
+这对那些“值是可选的”，并且裸 flag 形式有特殊语义的 ``nsys`` 参数尤其有用。
+
+不同 Nsight Systems 版本、不同主机平台支持的参数和推荐取值并不完全一致。尤其是
+``backtrace`` 的可用模式和效果，可能需要按机器调整。如果目标节点上的某个参数
+不被接受，或者 ``lbr`` 效果不好，请直接在目标节点执行 ``nsys profile --help``，
+然后覆盖 ``cluster.nsight.options``，例如把 ``backtrace`` 改成 ``fp`` 或
+``dwarf``。
+
+
+如何打 NVTX Range
+------------------------------
+
+RLinf 已经提供了一个现成的 NVTX helper：
+
+.. code-block:: python
+
+   from rlinf.utils.utils import nvtx_range
+
+   with nvtx_range("actor.forward", color="green"):
+       run_actor_forward()
+
+如果你准备开启 ``capture-range: nvtx``，或者只是希望在 Nsight 时间线里看到更高层
+的命名区间，这通常是最方便的用法。
+
+这个 helper 会优先尝试可选的 ``nvtx`` Python 包；如果没装这个包，则会在 CUDA
+可用时回退到 ``torch.cuda.nvtx``；如果两者都不可用，它就会退化成 no-op。因此把
+它留在同时支持“带 NVTX / 不带 NVTX”两种环境的代码路径里通常也是安全的。
+
+如果你使用了 ``capture-range: nvtx``，请确认被 profile 的 worker 确实会执行到
+这些 range；否则 Nsight 可能只会采到很少的数据，甚至得到几乎为空的 report。
 
 
 输出路径

--- a/examples/embodiment/config/nsight/default.yaml
+++ b/examples/embodiment/config/nsight/default.yaml
@@ -4,4 +4,6 @@ options:
   t: cuda,cudnn,cublas,nvtx,osrt
   sample: process-tree
   cpuctxsw: process-tree
+  cudabacktrace: all
   osrt-threshold: 1000
+flags: []

--- a/examples/embodiment/config/nsight/default.yaml
+++ b/examples/embodiment/config/nsight/default.yaml
@@ -1,0 +1,7 @@
+enabled: true
+worker_groups: [ActorGroup, RolloutGroup, EnvGroup, Actor, Rollout, Env]
+options:
+  t: cuda,cudnn,cublas,nvtx,osrt
+  sample: process-tree
+  cpuctxsw: process-tree
+  osrt-threshold: 1000

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -1183,9 +1183,23 @@ def validate_cfg(cfg: DictConfig) -> DictConfig:
             cfg.runner.per_worker_log_path = os.path.join(
                 cfg.runner.logger.log_path, "worker_logs"
             )
+        cfg.runner.nsight_output_path = None
+        nsight_cfg = cfg.cluster.get("nsight", None)
+        if nsight_cfg is not None and bool(nsight_cfg.get("enabled", True)):
+            cfg.runner.nsight_output_path = os.path.abspath(
+                os.path.join(
+                    cfg.runner.logger.log_path,
+                    cfg.runner.logger.experiment_name,
+                    "nsights",
+                )
+            )
 
     # Init cluster
-    Cluster(cluster_cfg=cfg.cluster, distributed_log_dir=cfg.runner.per_worker_log_path)
+    Cluster(
+        cluster_cfg=cfg.cluster,
+        distributed_log_dir=cfg.runner.per_worker_log_path,
+        nsight_output_dir=cfg.runner.nsight_output_path,
+    )
 
     assert cfg.runner.task_type in SUPPORTED_TASK_TYPE, (
         f"task_type must be one of {SUPPORTED_TASK_TYPE}"

--- a/rlinf/scheduler/cluster/cluster.py
+++ b/rlinf/scheduler/cluster/cluster.py
@@ -530,7 +530,7 @@ class Cluster:
         return os.path.join(output_dir, f"rlinf_nsight_{safe_worker_name}_%p")
 
     @classmethod
-    def build_worker_py_executable(
+    def maybe_prepend_nsight_to_py_executable(
         cls,
         python_interpreter_path: str,
         worker_name: str,
@@ -623,7 +623,7 @@ class Cluster:
         cfg_python_path = node_group.get_node_python_interpreter_path(node_rank)
         if cfg_python_path is not None:
             python_interpreter_path = cfg_python_path
-        python_interpreter_path = self.build_worker_py_executable(
+        python_interpreter_path = self.maybe_prepend_nsight_to_py_executable(
             python_interpreter_path=python_interpreter_path,
             worker_name=worker_name,
             nsight_cfg=self._cluster_cfg.nsight

--- a/rlinf/scheduler/cluster/cluster.py
+++ b/rlinf/scheduler/cluster/cluster.py
@@ -522,11 +522,9 @@ class Cluster:
     def _get_default_nsight_output_prefix(
         cls,
         worker_name: str,
-        output_dir: Optional[str] = None,
+        output_dir: str,
     ) -> str:
         safe_worker_name = cls._sanitize_worker_name_for_path(worker_name)
-        if output_dir is None:
-            output_dir = tempfile.gettempdir()
         return os.path.join(output_dir, f"rlinf_nsight_{safe_worker_name}_%p")
 
     @classmethod
@@ -547,7 +545,16 @@ class Cluster:
         if not nsight_cfg.profiles_worker_group(worker_group_name):
             return python_interpreter_path
 
-        output_dir = nsight_output_dir or tempfile.gettempdir()
+        if nsight_output_dir is None:
+            output_dir = tempfile.gettempdir()
+
+            from rlinf.utils.logging import get_logger
+
+            get_logger().warning(
+                f"Nsight profiling is enabled for worker group '{worker_group_name}' but no output directory is configured. Nsight reports will be saved to the system temporary directory: {output_dir}."
+            )
+        else:
+            output_dir = nsight_output_dir
         os.makedirs(output_dir, exist_ok=True)
         default_output_prefix = cls._get_default_nsight_output_prefix(
             worker_name,

--- a/rlinf/scheduler/cluster/cluster.py
+++ b/rlinf/scheduler/cluster/cluster.py
@@ -161,11 +161,6 @@ class Cluster:
             nsight_output_dir (Optional[str]): Default directory for Nsight reports when ``cluster.nsight`` is enabled and no explicit ``o``/``output`` option is configured.
         """
         if self._has_initialized:
-            if (
-                nsight_output_dir is not None
-                and getattr(self, "_nsight_output_dir", None) is None
-            ):
-                self._nsight_output_dir = nsight_output_dir
             return
         self._setup_logger()
         self._distributed_log_collector: Optional[DistributedRayLogCollector] = None
@@ -519,11 +514,6 @@ class Cluster:
         return self._nodes[node_rank].node_ip
 
     @staticmethod
-    def _get_worker_group_name(worker_name: str) -> str:
-        """Extract the root worker group name from a worker address string."""
-        return worker_name.split(":", 1)[0]
-
-    @staticmethod
     def _sanitize_worker_name_for_path(worker_name: str) -> str:
         """Sanitize worker names for use in output filenames."""
         return re.sub(r"[^A-Za-z0-9._-]", "_", worker_name)
@@ -532,39 +522,18 @@ class Cluster:
     def _get_default_nsight_output_prefix(
         cls,
         worker_name: str,
-        worker_rank: int,
         output_dir: Optional[str] = None,
     ) -> str:
         safe_worker_name = cls._sanitize_worker_name_for_path(worker_name)
         if output_dir is None:
             output_dir = tempfile.gettempdir()
-        else:
-            os.makedirs(output_dir, exist_ok=True)
-        return os.path.join(
-            output_dir,
-            f"rlinf_nsight_{safe_worker_name}_rank{worker_rank}_%p",
-        )
-
-    @staticmethod
-    def _build_nsight_option_tokens(nsight_options: dict[str, str]) -> list[str]:
-        option_tokens = []
-        for option_name, option_value in nsight_options.items():
-            option_name = str(option_name)
-            option_value = str(option_value)
-            if option_name == "":
-                raise ValueError("Nsight option names must not be empty.")
-            if len(option_name) > 1:
-                option_tokens.append(f"--{option_name}={option_value}")
-            else:
-                option_tokens.extend([f"-{option_name}", option_value])
-        return option_tokens
+        return os.path.join(output_dir, f"rlinf_nsight_{safe_worker_name}_%p")
 
     @classmethod
     def build_worker_py_executable(
         cls,
         python_interpreter_path: str,
         worker_name: str,
-        worker_rank: int,
         nsight_cfg: Optional[NsightConfig],
         nsight_output_dir: Optional[str] = None,
     ) -> str:
@@ -572,22 +541,23 @@ class Cluster:
         if nsight_cfg is None:
             return python_interpreter_path
 
-        worker_group_name = cls._get_worker_group_name(worker_name)
+        from ..manager import WorkerAddress
+
+        worker_group_name = WorkerAddress.from_name(worker_name).root_group_name
         if not nsight_cfg.profiles_worker_group(worker_group_name):
             return python_interpreter_path
 
-        nsight_options = dict(nsight_cfg.options or {})
-        if "o" not in nsight_options and "output" not in nsight_options:
-            nsight_options["o"] = cls._get_default_nsight_output_prefix(
-                worker_name,
-                worker_rank,
-                output_dir=nsight_output_dir,
-            )
+        output_dir = nsight_output_dir or tempfile.gettempdir()
+        os.makedirs(output_dir, exist_ok=True)
+        default_output_prefix = cls._get_default_nsight_output_prefix(
+            worker_name,
+            output_dir=output_dir,
+        )
 
         nsight_cmd = [
             "nsys",
             "profile",
-            *cls._build_nsight_option_tokens(nsight_options),
+            *nsight_cfg.to_cli_tokens(default_output_prefix=default_output_prefix),
             python_interpreter_path,
         ]
         return " ".join(shlex.quote(token) for token in nsight_cmd)
@@ -656,7 +626,6 @@ class Cluster:
         python_interpreter_path = self.build_worker_py_executable(
             python_interpreter_path=python_interpreter_path,
             worker_name=worker_name,
-            worker_rank=worker_rank,
             nsight_cfg=self._cluster_cfg.nsight
             if self._cluster_cfg is not None
             else None,

--- a/rlinf/scheduler/cluster/cluster.py
+++ b/rlinf/scheduler/cluster/cluster.py
@@ -14,8 +14,11 @@
 
 import logging
 import os
+import re
+import shlex
 import signal
 import sys
+import tempfile
 import time
 from enum import Enum
 from importlib.metadata import version
@@ -29,7 +32,7 @@ from ray._private import ray_logging
 from ray.actor import ActorHandle
 from ray.util.state import list_actors
 
-from .config import ClusterConfig
+from .config import ClusterConfig, NsightConfig
 from .node import NodeGroupInfo, NodeInfo, NodeProbe
 from .utils import DistributedRayLogCollector, without_http_proxies
 
@@ -147,6 +150,7 @@ class Cluster:
         num_nodes: Optional[int] = None,
         cluster_cfg: Optional[DictConfig] = None,
         distributed_log_dir: Optional[str] = None,
+        nsight_output_dir: Optional[str] = None,
     ):
         """Initialize the cluster.
 
@@ -154,17 +158,27 @@ class Cluster:
             num_nodes (int): The number of nodes in the cluster. When you wish to acquire the cluster instance in a processes other than the main driver process, do not pass this argument. Instead, use the `Cluster()` constructor without arguments. If num_nodes is 0, it will initialize the cluster with all ray-connected nodes.
             cluster_cfg (Optional[DictConfig]): The cluster's configuration dictionary. If set, num_nodes will be ignored and inferred from the config.
             distributed_log_dir (Optional[str]): Output directory for split logs. This must be provided when ``distributed_logging`` is True.
+            nsight_output_dir (Optional[str]): Default directory for Nsight reports when ``cluster.nsight`` is enabled and no explicit ``o``/``output`` option is configured.
         """
         if self._has_initialized:
+            if (
+                nsight_output_dir is not None
+                and getattr(self, "_nsight_output_dir", None) is None
+            ):
+                self._nsight_output_dir = nsight_output_dir
             return
         self._setup_logger()
         self._distributed_log_collector: Optional[DistributedRayLogCollector] = None
+        self._nsight_output_dir: Optional[str] = nsight_output_dir
         if num_nodes is not None or cluster_cfg is not None:
             self._ray_instance_count = 0
             while True:
                 try:
                     self._init_and_launch_managers(
-                        num_nodes, cluster_cfg, distributed_log_dir
+                        num_nodes,
+                        cluster_cfg,
+                        distributed_log_dir,
+                        nsight_output_dir,
                     )
                     break
                 except Cluster.NamespaceConflictError:
@@ -184,6 +198,7 @@ class Cluster:
                 return self.__init__(
                     num_nodes=0,
                     distributed_log_dir=distributed_log_dir,
+                    nsight_output_dir=nsight_output_dir,
                 )
 
         self._has_initialized = True
@@ -242,6 +257,7 @@ class Cluster:
         num_nodes: int,
         cluster_cfg: Optional[DictConfig],
         distributed_log_dir: Optional[str],
+        nsight_output_dir: Optional[str],
     ):
         if ray.is_initialized():
             if self._ray_instance_count > 0:
@@ -267,6 +283,7 @@ class Cluster:
         self._cluster_cfg = (
             ClusterConfig.from_dict_cfg(cluster_cfg) if cluster_cfg else None
         )
+        self._nsight_output_dir = nsight_output_dir
         if (
             self._cluster_cfg is not None
             and num_nodes is not None
@@ -501,6 +518,80 @@ class Cluster:
         """Get the IP address of a specific node by its rank."""
         return self._nodes[node_rank].node_ip
 
+    @staticmethod
+    def _get_worker_group_name(worker_name: str) -> str:
+        """Extract the root worker group name from a worker address string."""
+        return worker_name.split(":", 1)[0]
+
+    @staticmethod
+    def _sanitize_worker_name_for_path(worker_name: str) -> str:
+        """Sanitize worker names for use in output filenames."""
+        return re.sub(r"[^A-Za-z0-9._-]", "_", worker_name)
+
+    @classmethod
+    def _get_default_nsight_output_prefix(
+        cls,
+        worker_name: str,
+        worker_rank: int,
+        output_dir: Optional[str] = None,
+    ) -> str:
+        safe_worker_name = cls._sanitize_worker_name_for_path(worker_name)
+        if output_dir is None:
+            output_dir = tempfile.gettempdir()
+        else:
+            os.makedirs(output_dir, exist_ok=True)
+        return os.path.join(
+            output_dir,
+            f"rlinf_nsight_{safe_worker_name}_rank{worker_rank}_%p",
+        )
+
+    @staticmethod
+    def _build_nsight_option_tokens(nsight_options: dict[str, str]) -> list[str]:
+        option_tokens = []
+        for option_name, option_value in nsight_options.items():
+            option_name = str(option_name)
+            option_value = str(option_value)
+            if option_name == "":
+                raise ValueError("Nsight option names must not be empty.")
+            if len(option_name) > 1:
+                option_tokens.append(f"--{option_name}={option_value}")
+            else:
+                option_tokens.extend([f"-{option_name}", option_value])
+        return option_tokens
+
+    @classmethod
+    def build_worker_py_executable(
+        cls,
+        python_interpreter_path: str,
+        worker_name: str,
+        worker_rank: int,
+        nsight_cfg: Optional[NsightConfig],
+        nsight_output_dir: Optional[str] = None,
+    ) -> str:
+        """Build the worker ``py_executable``, optionally wrapped with Nsight."""
+        if nsight_cfg is None:
+            return python_interpreter_path
+
+        worker_group_name = cls._get_worker_group_name(worker_name)
+        if not nsight_cfg.profiles_worker_group(worker_group_name):
+            return python_interpreter_path
+
+        nsight_options = dict(nsight_cfg.options or {})
+        if "o" not in nsight_options and "output" not in nsight_options:
+            nsight_options["o"] = cls._get_default_nsight_output_prefix(
+                worker_name,
+                worker_rank,
+                output_dir=nsight_output_dir,
+            )
+
+        nsight_cmd = [
+            "nsys",
+            "profile",
+            *cls._build_nsight_option_tokens(nsight_options),
+            python_interpreter_path,
+        ]
+        return " ".join(shlex.quote(token) for token in nsight_cmd)
+
     def allocate(
         self,
         cls: type["Worker"],
@@ -562,6 +653,15 @@ class Cluster:
         cfg_python_path = node_group.get_node_python_interpreter_path(node_rank)
         if cfg_python_path is not None:
             python_interpreter_path = cfg_python_path
+        python_interpreter_path = self.build_worker_py_executable(
+            python_interpreter_path=python_interpreter_path,
+            worker_name=worker_name,
+            worker_rank=worker_rank,
+            nsight_cfg=self._cluster_cfg.nsight
+            if self._cluster_cfg is not None
+            else None,
+            nsight_output_dir=self._nsight_output_dir,
+        )
 
         options = {
             "runtime_env": {

--- a/rlinf/scheduler/cluster/config.py
+++ b/rlinf/scheduler/cluster/config.py
@@ -171,6 +171,9 @@ class NsightConfig:
     options: Optional[dict[str, str]] = None
     """Additional ``nsys profile`` options keyed by flag name."""
 
+    flags: Optional[list[str] | str] = None
+    """Additional bare ``nsys profile`` flags emitted without values."""
+
     @staticmethod
     def _stringify_option_value(option_value: object) -> str:
         if isinstance(option_value, bool):
@@ -178,7 +181,10 @@ class NsightConfig:
         return str(option_value)
 
     @staticmethod
-    def _normalize_capture_range_end_alias(option_value: str) -> str:
+    def _normalize_capture_range_end_alias(option_value: object) -> str:
+        assert option_value is not None, (
+            "Nsight option 'stop-on-range-end' must have an explicit value."
+        )
         normalized_value = str(option_value).strip().lower()
         if normalized_value in {"true", "1", "yes", "on"}:
             return "stop"
@@ -187,7 +193,7 @@ class NsightConfig:
         return str(option_value)
 
     def __post_init__(self):
-        """Normalize Nsight worker groups and CLI options after parsing YAML."""
+        """Normalize Nsight worker groups, options, and flags after parsing YAML."""
         if self.worker_groups is not None:
             worker_groups = self.worker_groups
             if isinstance(worker_groups, str):
@@ -199,6 +205,21 @@ class NsightConfig:
                     f"But got {type(worker_groups)}: {worker_groups}"
                 )
                 self.worker_groups = [str(group_name) for group_name in worker_groups]
+
+        if self.flags is not None:
+            flags = self.flags
+            if isinstance(flags, str):
+                self.flags = [flags]
+            else:
+                assert isinstance(flags, (list, ListConfig)), (
+                    "flags must be a list of strings or a single string "
+                    "in cluster nsight config. "
+                    f"But got {type(flags)}: {flags}"
+                )
+                self.flags = [str(flag_name) for flag_name in flags]
+            assert all(flag_name != "" for flag_name in self.flags), (
+                "Nsight flags must not contain empty names."
+            )
 
         if self.options is not None:
             assert hasattr(self.options, "keys"), (
@@ -222,6 +243,12 @@ class NsightConfig:
             assert not ("o" in self.options and "output" in self.options), (
                 "Nsight options must not specify both 'o' and 'output'."
             )
+        if self.flags is not None and self.options is not None:
+            overlapping_names = sorted(set(self.flags).intersection(self.options))
+            assert not overlapping_names, (
+                "Nsight flags and options must not specify the same names. "
+                f"Got duplicates: {overlapping_names}"
+            )
 
     def profiles_worker_group(self, worker_group_name: str) -> bool:
         """Return whether this config should profile the given worker group."""
@@ -236,6 +263,29 @@ class NsightConfig:
             "all" in normalized_group_names
             or worker_group_name.lower() in normalized_group_names
         )
+
+    def to_cli_tokens(self, default_output_prefix: Optional[str] = None) -> list[str]:
+        """Render ``nsys profile`` options into CLI tokens."""
+        flags = list(self.flags or [])
+        options = dict(self.options or {})
+        if default_output_prefix is not None:
+            options.setdefault("o", default_output_prefix)
+
+        option_tokens = []
+        for flag_name in flags:
+            if flag_name == "":
+                raise ValueError("Nsight option names must not be empty.")
+            option_tokens.append(
+                f"--{flag_name}" if len(flag_name) > 1 else f"-{flag_name}"
+            )
+        for option_name, option_value in options.items():
+            if option_name == "":
+                raise ValueError("Nsight option names must not be empty.")
+            if len(option_name) > 1:
+                option_tokens.append(f"--{option_name}={option_value}")
+            else:
+                option_tokens.extend([f"-{option_name}", option_value])
+        return option_tokens
 
 
 @dataclass
@@ -345,7 +395,9 @@ class ClusterConfig:
 
             - `enabled` controls whether RLinf wraps matching workers with `nsys profile`.
             - `worker_groups` matches worker group names such as `cfg.actor.group_name`. If omitted, all worker groups are profiled.
-            - `options` maps directly to `nsys profile` CLI flags. Use `capture-range-end: stop` with `capture-range: nvtx` when you want collection to stop after the profiled NVTX range ends.
+            - `options` maps directly to `nsys profile` CLI flags that take explicit values.
+            - `flags` emits bare `nsys profile` flags without values.
+            - Use `capture-range-end: stop` with `capture-range: nvtx` when you want collection to stop after the profiled NVTX range ends.
             - `o` or `output` overrides the default report filename prefix.
 
         **Multi-node-group placement**: A worker group can be placed across multiple node groups with heterogeneous hardware types by specifying multiple node group labels. For example:

--- a/rlinf/scheduler/cluster/config.py
+++ b/rlinf/scheduler/cluster/config.py
@@ -159,6 +159,86 @@ class NodeGroupConfig:
 
 
 @dataclass
+class NsightConfig:
+    """Configuration for profiling worker processes with Nsight Systems."""
+
+    enabled: bool = True
+    """Whether to enable Nsight wrapping for matching worker groups."""
+
+    worker_groups: Optional[list[str] | str] = None
+    """Worker group names to profile. If omitted, all worker groups are profiled."""
+
+    options: Optional[dict[str, str]] = None
+    """Additional ``nsys profile`` options keyed by flag name."""
+
+    @staticmethod
+    def _stringify_option_value(option_value: object) -> str:
+        if isinstance(option_value, bool):
+            return str(option_value).lower()
+        return str(option_value)
+
+    @staticmethod
+    def _normalize_capture_range_end_alias(option_value: str) -> str:
+        normalized_value = str(option_value).strip().lower()
+        if normalized_value in {"true", "1", "yes", "on"}:
+            return "stop"
+        if normalized_value in {"false", "0", "no", "off"}:
+            return "none"
+        return str(option_value)
+
+    def __post_init__(self):
+        """Normalize Nsight worker groups and CLI options after parsing YAML."""
+        if self.worker_groups is not None:
+            worker_groups = self.worker_groups
+            if isinstance(worker_groups, str):
+                self.worker_groups = [worker_groups]
+            else:
+                assert isinstance(worker_groups, (list, ListConfig)), (
+                    "worker_groups must be a list of strings or a single string "
+                    "in cluster nsight config. "
+                    f"But got {type(worker_groups)}: {worker_groups}"
+                )
+                self.worker_groups = [str(group_name) for group_name in worker_groups]
+
+        if self.options is not None:
+            assert hasattr(self.options, "keys"), (
+                "Nsight options must be a dictionary in cluster nsight config. "
+                f"But got {type(self.options)}: {self.options}"
+            )
+            self.options = {
+                str(option_name): self._stringify_option_value(option_value)
+                for option_name, option_value in self.options.items()
+            }
+            if "stop-on-range-end" in self.options:
+                assert "capture-range-end" not in self.options, (
+                    "Nsight options must not specify both 'stop-on-range-end' "
+                    "and 'capture-range-end'."
+                )
+                self.options["capture-range-end"] = (
+                    self._normalize_capture_range_end_alias(
+                        self.options.pop("stop-on-range-end")
+                    )
+                )
+            assert not ("o" in self.options and "output" in self.options), (
+                "Nsight options must not specify both 'o' and 'output'."
+            )
+
+    def profiles_worker_group(self, worker_group_name: str) -> bool:
+        """Return whether this config should profile the given worker group."""
+        if not self.enabled:
+            return False
+        if self.worker_groups is None:
+            return True
+        normalized_group_names = {
+            group_name.lower() for group_name in self.worker_groups
+        }
+        return (
+            "all" in normalized_group_names
+            or worker_group_name.lower() in normalized_group_names
+        )
+
+
+@dataclass
 class ClusterConfig:
     """Configuration for the entire cluster.
 
@@ -170,6 +250,14 @@ class ClusterConfig:
 
     cluster:
       num_nodes: 18
+      nsight:
+        enabled: true
+        worker_groups: [ActorGroup, RolloutGroup]
+        options:
+          t: cuda,cudnn,cublas,nvtx
+          sample: none
+          capture-range: nvtx
+          capture-range-end: stop
       component_placement:
         actor:
           node_group: a800
@@ -253,6 +341,13 @@ class ClusterConfig:
         When using `node_group` in the component_placement, the specified hardware ranks are thus (1) `hardware.type` hardware if it is specified in the node group; (2) automatically detected accelerator hardware if it exists; (3) node itself as hardware resource if no accelerator hardware is found.
         When using the reserved `node` node_group in the component_placement, it is a group with all nodes but no hardware. And so it can be used to perform hardware-agnostic placement of processes on specific nodes.
 
+        6. nsight (optional): An `NsightConfig` describing how to wrap matching worker groups with `nsys profile`.
+
+            - `enabled` controls whether RLinf wraps matching workers with `nsys profile`.
+            - `worker_groups` matches worker group names such as `cfg.actor.group_name`. If omitted, all worker groups are profiled.
+            - `options` maps directly to `nsys profile` CLI flags. Use `capture-range-end: stop` with `capture-range: nvtx` when you want collection to stop after the profiled NVTX range ends.
+            - `o` or `output` overrides the default report filename prefix.
+
         **Multi-node-group placement**: A worker group can be placed across multiple node groups with heterogeneous hardware types by specifying multiple node group labels. For example:
 
         .. code-block:: yaml
@@ -273,6 +368,9 @@ class ClusterConfig:
 
     node_groups: Optional[list[NodeGroupConfig]] = None
     """List of node group configurations in the cluster."""
+
+    nsight: Optional[NsightConfig] = None
+    """Optional Nsight profiling configuration for worker processes."""
 
     @staticmethod
     def from_dict_cfg(cfg_dict: DictConfig) -> "ClusterConfig":
@@ -356,6 +454,18 @@ class ClusterConfig:
 
     def __post_init__(self):
         """Post-initialization to convert nodes dicts to their respective dataclass instances."""
+        if self.nsight is not None:
+            assert hasattr(self.nsight, "keys"), (
+                "cluster.nsight must be a dictionary. "
+                f"But got {type(self.nsight)}: {self.nsight}"
+            )
+            dataclass_arg_check(
+                NsightConfig,
+                self.nsight,
+                error_suffix="in cluster nsight yaml config",
+            )
+            self.nsight = NsightConfig(**self.nsight)
+
         if self.node_groups is not None:
             # Arg check
             for node_group in self.node_groups:

--- a/rlinf/scheduler/cluster/config.py
+++ b/rlinf/scheduler/cluster/config.py
@@ -252,10 +252,8 @@ class NsightConfig:
 
     def profiles_worker_group(self, worker_group_name: str) -> bool:
         """Return whether this config should profile the given worker group."""
-        if not self.enabled:
+        if not self.enabled or not self.worker_groups:
             return False
-        if self.worker_groups is None:
-            return True
         normalized_group_names = {
             group_name.lower() for group_name in self.worker_groups
         }

--- a/rlinf/utils/utils.py
+++ b/rlinf/utils/utils.py
@@ -14,6 +14,7 @@
 
 import atexit
 import gc
+import importlib
 import os
 import random
 import sys
@@ -123,6 +124,36 @@ def cpu_weight_swap(resident_model, cpu_weights, offloaded_buffer=None):
 
     finally:
         swap_dict(resident_model, offloaded_buffer, offload_onto_cpu=False)
+
+
+def _get_nvtx_module():
+    try:
+        return importlib.import_module("nvtx")
+    except ImportError:
+        return None
+
+
+@contextmanager
+def nvtx_range(name: str, color: str | int | None = None):
+    """Annotate a code range for Nsight or other NVTX-aware profilers."""
+    nvtx_module = _get_nvtx_module()
+    if nvtx_module is not None:
+        annotate_kwargs = {"message": name}
+        if color is not None:
+            annotate_kwargs["color"] = color
+        with nvtx_module.annotate(**annotate_kwargs):
+            yield
+        return
+
+    if hasattr(torch.cuda, "nvtx") and torch.cuda.is_available():
+        torch.cuda.nvtx.range_push(name)
+        try:
+            yield
+        finally:
+            torch.cuda.nvtx.range_pop()
+        return
+
+    yield
 
 
 def configure_batch_sizes(rank, mbs, gbs, dp=1):

--- a/rlinf/utils/utils.py
+++ b/rlinf/utils/utils.py
@@ -145,6 +145,13 @@ def nvtx_range(name: str, color: str | int | None = None):
             yield
         return
 
+    from rlinf.utils.logging import get_logger
+
+    get_logger().warning(
+        "nvtx_range: NVTX module not found, NVTX annotations are disabled. "
+        "Using torch.cuda.nvtx instead",
+    )
+
     if hasattr(torch.cuda, "nvtx") and torch.cuda.is_available():
         torch.cuda.nvtx.range_push(name)
         try:
@@ -152,7 +159,9 @@ def nvtx_range(name: str, color: str | int | None = None):
         finally:
             torch.cuda.nvtx.range_pop()
         return
-
+    get_logger().warning(
+        "nvtx_range: torch.cuda.nvtx is not available, NVTX annotations are disabled."
+    )
     yield
 
 

--- a/tests/unit_tests/test_cluster_config.py
+++ b/tests/unit_tests/test_cluster_config.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -536,32 +535,69 @@ def test_cluster_config_nsight_options_must_be_mapping():
         ClusterConfig.from_dict_cfg(config)
 
 
-def test_build_worker_py_executable_wraps_nsight_for_matching_group():
-    py_executable = Cluster.build_worker_py_executable(
-        python_interpreter_path=sys.executable,
-        worker_name="actor:0",
-        worker_rank=0,
-        nsight_cfg=NsightConfig(
-            worker_groups=["actor"],
-            options={"t": "cuda,cudnn,cublas,nvtx", "sample": "none"},
-        ),
+def test_cluster_config_parses_nsight_flags():
+    config = DictConfig(
+        {
+            "num_nodes": 1,
+            "component_placement": {},
+            "nsight": {
+                "flags": ["python-backtrace"],
+            },
+        }
     )
 
-    assert py_executable.startswith("nsys profile ")
-    assert "-t cuda,cudnn,cublas,nvtx" in py_executable
-    assert "--sample=none" in py_executable
-    expected_prefix = os.path.join(
-        tempfile.gettempdir(), "rlinf_nsight_actor_0_rank0_%p"
+    cluster_cfg = ClusterConfig.from_dict_cfg(config)
+
+    assert cluster_cfg.nsight is not None
+    assert cluster_cfg.nsight.flags == ["python-backtrace"]
+
+
+def test_cluster_config_rejects_duplicate_nsight_flag_and_option():
+    config = DictConfig(
+        {
+            "num_nodes": 1,
+            "component_placement": {},
+            "nsight": {
+                "flags": ["python-backtrace"],
+                "options": {"python-backtrace": "cuda"},
+            },
+        }
     )
-    assert f"-o {expected_prefix}" in py_executable
-    assert py_executable.endswith(sys.executable)
+
+    with pytest.raises(
+        AssertionError, match="Nsight flags and options must not specify the same names"
+    ):
+        ClusterConfig.from_dict_cfg(config)
+
+
+def test_nsight_default_preset_enables_cpu_sampling_and_cuda_backtrace():
+    preset_path = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "embodiment"
+        / "config"
+        / "nsight"
+        / "default.yaml"
+    )
+    preset_cfg = OmegaConf.load(preset_path)
+    nsight_cfg = NsightConfig(**OmegaConf.to_container(preset_cfg, resolve=True))
+
+    assert nsight_cfg.options is not None
+    assert nsight_cfg.options["sample"] == "process-tree"
+    assert nsight_cfg.options["cudabacktrace"] == "all"
+    assert nsight_cfg.flags == []
+
+
+def test_nsight_to_cli_tokens_supports_flags():
+    nsight_cfg = NsightConfig(flags=["python-backtrace"])
+
+    assert nsight_cfg.to_cli_tokens() == ["--python-backtrace"]
 
 
 def test_build_worker_py_executable_skips_non_matching_group():
     py_executable = Cluster.build_worker_py_executable(
         python_interpreter_path=sys.executable,
         worker_name="actor:0",
-        worker_rank=0,
         nsight_cfg=NsightConfig(
             worker_groups=["rollout"],
             options={"t": "cuda,cudnn,cublas,nvtx"},
@@ -575,7 +611,6 @@ def test_build_worker_py_executable_skips_disabled_nsight():
     py_executable = Cluster.build_worker_py_executable(
         python_interpreter_path=sys.executable,
         worker_name="actor:0",
-        worker_rank=0,
         nsight_cfg=NsightConfig(
             enabled=False,
             worker_groups=["actor"],
@@ -584,39 +619,6 @@ def test_build_worker_py_executable_skips_disabled_nsight():
     )
 
     assert py_executable == sys.executable
-
-
-def test_build_worker_py_executable_preserves_custom_output(tmp_path):
-    custom_output = tmp_path / "custom-profile-output"
-    py_executable = Cluster.build_worker_py_executable(
-        python_interpreter_path=sys.executable,
-        worker_name="actor:0",
-        worker_rank=0,
-        nsight_cfg=NsightConfig(
-            worker_groups="all",
-            options={"o": str(custom_output), "sample": "none"},
-        ),
-    )
-
-    assert f"-o {custom_output}" in py_executable
-    assert "rlinf_nsight_actor_0_rank0_%p" not in py_executable
-
-
-def test_build_worker_py_executable_uses_custom_nsight_output_dir(tmp_path):
-    output_dir = tmp_path / "nsights"
-    py_executable = Cluster.build_worker_py_executable(
-        python_interpreter_path=sys.executable,
-        worker_name="actor:0",
-        worker_rank=0,
-        nsight_cfg=NsightConfig(
-            worker_groups=["actor"],
-            options={"sample": "none"},
-        ),
-        nsight_output_dir=str(output_dir),
-    )
-
-    assert f"-o {output_dir}/rlinf_nsight_actor_0_rank0_%p" in py_executable
-    assert output_dir.is_dir()
 
 
 def test_path_env_merge_mode_default_is_append():

--- a/tests/unit_tests/test_cluster_config.py
+++ b/tests/unit_tests/test_cluster_config.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -23,7 +24,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from rlinf.scheduler import Cluster, ComponentPlacement, NodePlacementStrategy, Worker
 from rlinf.scheduler.cluster.cluster import ClusterEnvVar, PathEnvMergeMode
-from rlinf.scheduler.cluster.config import ClusterConfig
+from rlinf.scheduler.cluster.config import ClusterConfig, NsightConfig
 from rlinf.scheduler.hardware.robots.franka import FrankaConfig
 
 
@@ -448,6 +449,174 @@ def test_cluster_config_num_nodes_must_be_positive():
 
     with pytest.raises(AssertionError, match="'num_nodes' must be a positive integer"):
         ClusterConfig.from_dict_cfg(config)
+
+
+def test_cluster_config_parses_nsight_settings():
+    config = DictConfig(
+        {
+            "num_nodes": 1,
+            "component_placement": {},
+            "nsight": {
+                "worker_groups": ["actor", "rollout"],
+                "options": {
+                    "t": "cuda,cudnn,cublas,nvtx",
+                    "capture-range": "nvtx",
+                    "stop-on-range-end": True,
+                },
+            },
+        }
+    )
+
+    cluster_cfg = ClusterConfig.from_dict_cfg(config)
+
+    assert cluster_cfg.nsight is not None
+    assert cluster_cfg.nsight.enabled is True
+    assert cluster_cfg.nsight.worker_groups == ["actor", "rollout"]
+    assert cluster_cfg.nsight.options == {
+        "t": "cuda,cudnn,cublas,nvtx",
+        "capture-range": "nvtx",
+        "capture-range-end": "stop",
+    }
+
+
+def test_cluster_config_parses_disabled_nsight_settings():
+    config = DictConfig(
+        {
+            "num_nodes": 1,
+            "component_placement": {},
+            "nsight": {
+                "enabled": False,
+                "worker_groups": ["actor"],
+                "options": {"t": "cuda,cudnn,cublas,nvtx"},
+            },
+        }
+    )
+
+    cluster_cfg = ClusterConfig.from_dict_cfg(config)
+
+    assert cluster_cfg.nsight is not None
+    assert cluster_cfg.nsight.enabled is False
+    assert cluster_cfg.nsight.worker_groups == ["actor"]
+    assert cluster_cfg.nsight.options == {"t": "cuda,cudnn,cublas,nvtx"}
+
+
+def test_cluster_config_nsight_rejects_duplicate_range_end_options():
+    config = DictConfig(
+        {
+            "num_nodes": 1,
+            "component_placement": {},
+            "nsight": {
+                "options": {
+                    "stop-on-range-end": True,
+                    "capture-range-end": "stop",
+                },
+            },
+        }
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match="must not specify both 'stop-on-range-end' and 'capture-range-end'",
+    ):
+        ClusterConfig.from_dict_cfg(config)
+
+
+def test_cluster_config_nsight_options_must_be_mapping():
+    config = DictConfig(
+        {
+            "num_nodes": 1,
+            "component_placement": {},
+            "nsight": {
+                "options": ["BAD"],
+            },
+        }
+    )
+
+    with pytest.raises(AssertionError, match="Nsight options must be a dictionary"):
+        ClusterConfig.from_dict_cfg(config)
+
+
+def test_build_worker_py_executable_wraps_nsight_for_matching_group():
+    py_executable = Cluster.build_worker_py_executable(
+        python_interpreter_path=sys.executable,
+        worker_name="actor:0",
+        worker_rank=0,
+        nsight_cfg=NsightConfig(
+            worker_groups=["actor"],
+            options={"t": "cuda,cudnn,cublas,nvtx", "sample": "none"},
+        ),
+    )
+
+    assert py_executable.startswith("nsys profile ")
+    assert "-t cuda,cudnn,cublas,nvtx" in py_executable
+    assert "--sample=none" in py_executable
+    expected_prefix = os.path.join(
+        tempfile.gettempdir(), "rlinf_nsight_actor_0_rank0_%p"
+    )
+    assert f"-o {expected_prefix}" in py_executable
+    assert py_executable.endswith(sys.executable)
+
+
+def test_build_worker_py_executable_skips_non_matching_group():
+    py_executable = Cluster.build_worker_py_executable(
+        python_interpreter_path=sys.executable,
+        worker_name="actor:0",
+        worker_rank=0,
+        nsight_cfg=NsightConfig(
+            worker_groups=["rollout"],
+            options={"t": "cuda,cudnn,cublas,nvtx"},
+        ),
+    )
+
+    assert py_executable == sys.executable
+
+
+def test_build_worker_py_executable_skips_disabled_nsight():
+    py_executable = Cluster.build_worker_py_executable(
+        python_interpreter_path=sys.executable,
+        worker_name="actor:0",
+        worker_rank=0,
+        nsight_cfg=NsightConfig(
+            enabled=False,
+            worker_groups=["actor"],
+            options={"t": "cuda,cudnn,cublas,nvtx"},
+        ),
+    )
+
+    assert py_executable == sys.executable
+
+
+def test_build_worker_py_executable_preserves_custom_output(tmp_path):
+    custom_output = tmp_path / "custom-profile-output"
+    py_executable = Cluster.build_worker_py_executable(
+        python_interpreter_path=sys.executable,
+        worker_name="actor:0",
+        worker_rank=0,
+        nsight_cfg=NsightConfig(
+            worker_groups="all",
+            options={"o": str(custom_output), "sample": "none"},
+        ),
+    )
+
+    assert f"-o {custom_output}" in py_executable
+    assert "rlinf_nsight_actor_0_rank0_%p" not in py_executable
+
+
+def test_build_worker_py_executable_uses_custom_nsight_output_dir(tmp_path):
+    output_dir = tmp_path / "nsights"
+    py_executable = Cluster.build_worker_py_executable(
+        python_interpreter_path=sys.executable,
+        worker_name="actor:0",
+        worker_rank=0,
+        nsight_cfg=NsightConfig(
+            worker_groups=["actor"],
+            options={"sample": "none"},
+        ),
+        nsight_output_dir=str(output_dir),
+    )
+
+    assert f"-o {output_dir}/rlinf_nsight_actor_0_rank0_%p" in py_executable
+    assert output_dir.is_dir()
 
 
 def test_path_env_merge_mode_default_is_append():

--- a/tests/unit_tests/test_cluster_config.py
+++ b/tests/unit_tests/test_cluster_config.py
@@ -594,8 +594,8 @@ def test_nsight_to_cli_tokens_supports_flags():
     assert nsight_cfg.to_cli_tokens() == ["--python-backtrace"]
 
 
-def test_build_worker_py_executable_skips_non_matching_group():
-    py_executable = Cluster.build_worker_py_executable(
+def test_maybe_prepend_nsight_to_py_executable_skips_non_matching_group():
+    py_executable = Cluster.maybe_prepend_nsight_to_py_executable(
         python_interpreter_path=sys.executable,
         worker_name="actor:0",
         nsight_cfg=NsightConfig(
@@ -607,8 +607,8 @@ def test_build_worker_py_executable_skips_non_matching_group():
     assert py_executable == sys.executable
 
 
-def test_build_worker_py_executable_skips_disabled_nsight():
-    py_executable = Cluster.build_worker_py_executable(
+def test_maybe_prepend_nsight_to_py_executable_skips_disabled_nsight():
+    py_executable = Cluster.maybe_prepend_nsight_to_py_executable(
         python_interpreter_path=sys.executable,
         worker_name="actor:0",
         nsight_cfg=NsightConfig(


### PR DESCRIPTION

### Description

Support nsys trace for worker groups.

### Motivation and Context
use a single nsys trace command for the whole RL training process is hard and not easy to fine-grained trace components we want to see, use ray natively-support nsys is much better.

### How has this been tested?
Test 1 yaml with nsight opened, each trace file is okay.

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.