### PR TITLE
fix: robotwin done dtype

### DIFF
--- a/rlinf/envs/robotwin/robotwin_env.py
+++ b/rlinf/envs/robotwin/robotwin_env.py
@@ -375,10 +375,10 @@ class RoboTwinEnv(gym.Env):
                 past_dones, obs_list[-1], infos_list[-1]
             )
 
-        chunk_terminations = torch.zeros((num_envs, chunk_step))
+        chunk_terminations = torch.zeros((num_envs, chunk_step), dtype=bool)
         chunk_terminations[:, -1] = terminations
 
-        chunk_truncations = torch.zeros((num_envs, chunk_step))
+        chunk_truncations = torch.zeros((num_envs, chunk_step), dtype=bool)
         chunk_truncations[:, -1] = truncations
 
         return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Fix the termination and truncation dtype of robotwin. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, RoboTwin with auto_reset=True will run into error.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.