### PR TITLE
feat(dream0): enable grad ckpt with use_reentrant support

### DIFF
--- a/examples/sft/config/droid_sft_dreamzero.yaml
+++ b/examples/sft/config/droid_sft_dreamzero.yaml
@@ -74,7 +74,6 @@ actor:
     embodiment_tag: "oxe_droid"
     relative_action: True
     relative_action_per_horizon: False
-    gradient_checkpointing: False
     load_to_device: False
 
   optim:
@@ -94,7 +93,8 @@ actor:
     strategy: "fsdp2"
     sharding_strategy: "full_shard"
     use_orig_params: True
-    gradient_checkpointing: False
+    gradient_checkpointing: True
+    gradient_checkpointing_use_reentrant: True
     limit_all_gathers: True
     reshard_after_forward: True
     save_full_model_weights: False

--- a/examples/sft/config/libero_sft_dreamzero_5b.yaml
+++ b/examples/sft/config/libero_sft_dreamzero_5b.yaml
@@ -1,0 +1,109 @@
+defaults:
+  - training_backend/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: all
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_sft_dreamzero"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: -1
+  max_steps: 50000
+  val_check_interval: -1
+  save_interval: 3000
+  log_interval: 100
+  resume_dir: path/to/checkpoint
+
+data:
+  train_data_paths: path/to/datasets/DreamZero-DROID-Data
+  lazy_load: True
+  num_workers: 8
+  prefetch_factor: 8
+  video_tolerance_s: 0.1
+  parquet_cache_size: 512
+
+algorithm:
+  adv_type: gae
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 32
+  global_batch_size: 256
+  seed: 42
+  dataloader_num_workers: 1
+  enable_offload: False
+  model:
+    model_type: "dreamzero"
+    precision: fp32
+    model_path: path/to/models/DreamZero-Libero
+    tokenizer_path: path/to/models/umt5-xxl
+    max_seq_len: 512
+    # Shared DreamZero dims (also match DreamZero-Libero checkpoint config).
+    dreamzero_max_action_dim: 32
+    dreamzero_max_state_dim: 64
+    # Unified temporal knobs (branching by embodiment_tag below):
+    dreamzero_action_horizon: 16
+    dreamzero_num_chunks: 4
+    dreamzero_num_video_frames: 33
+
+    cfg_mode: False
+    unconditional_prob: 0.3
+    action_loss_scale: 1.0
+    pretrained_model_path: null
+    add_value_head: False
+    is_lora: False
+    embodiment_tag: "libero_sim"
+    relative_action: False
+    relative_action_per_horizon: False
+
+  optim:
+    lr: 1.0e-5
+    value_lr: 1.55e-4
+    adam_beta1: 0.95
+    adam_beta2: 0.999
+    adam_eps: 1.0e-08
+    weight_decay: 1.0e-5
+    clip_grad: 1.0
+    lr_scheduler: "cosine"
+    lr_warmup_steps: -1
+    lr_warmup_steps_ratio: 0.05
+    total_training_steps: 50000
+  fsdp_config:
+    strategy: "fsdp2"
+    use_orig_params: True
+    gradient_checkpointing: True
+    gradient_checkpointing_use_reentrant: True
+    limit_all_gathers: False
+    forward_prefetch: True
+    backward_prefetch: "pre"
+    reshard_after_forward: False
+    save_full_model_weights: False
+    grad_scaler:
+      enabled: False
+    mixed_precision:
+      param_dtype: bf16
+      reduce_dtype: bf16
+      buffer_dtype: bf16
+    amp_autocast:
+      enabled: False
+      precision: "bf16"
+reward:
+  use_reward_model: False
+critic:
+  use_critic_model: False

--- a/examples/sft/config/libero_sft_dreamzero_5b.yaml
+++ b/examples/sft/config/libero_sft_dreamzero_5b.yaml
@@ -30,7 +30,7 @@ runner:
   resume_dir: path/to/checkpoint
 
 data:
-  train_data_paths: path/to/datasets/DreamZero-DROID-Data
+  train_data_paths: path/to/datasets/DreamZero-Libero-Data
   lazy_load: True
   num_workers: 8
   prefetch_factor: 8

--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -255,9 +255,15 @@ class FSDPModelManager:
             self._logger.info(
                 f"[FSDP] Enabling gradient checkpointing with use_reentrant={use_reentrant}"
             )
-            module.gradient_checkpointing_enable(
-                gradient_checkpointing_kwargs={"use_reentrant": use_reentrant}
-            )
+            if use_reentrant:
+                # use_reentrant=True is the default for HuggingFace models.
+                # We pass no arguments to stay compatible with openpi's
+                # PI0Pytorch.gradient_checkpointing_enable, which takes none.
+                module.gradient_checkpointing_enable()
+            else:
+                module.gradient_checkpointing_enable(
+                    gradient_checkpointing_kwargs={"use_reentrant": use_reentrant}
+                )
         else:
             self._logger.info("[FSDP] Gradient checkpointing is disabled")
 

--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -249,8 +249,9 @@ class FSDPModelManager:
 
         # Enable gradient checkpointing if configured
         if self._cfg.fsdp_config.get("gradient_checkpointing", False):
-            self._logger.info("[FSDP] Enabling gradient checkpointing")
-            module.gradient_checkpointing_enable()
+            use_reentrant = self._cfg.fsdp_config.get("gradient_checkpointing_use_reentrant", True)
+            self._logger.info(f"[FSDP] Enabling gradient checkpointing with use_reentrant={use_reentrant}")
+            module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": use_reentrant})
         else:
             self._logger.info("[FSDP] Gradient checkpointing is disabled")
 

--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -249,9 +249,15 @@ class FSDPModelManager:
 
         # Enable gradient checkpointing if configured
         if self._cfg.fsdp_config.get("gradient_checkpointing", False):
-            use_reentrant = self._cfg.fsdp_config.get("gradient_checkpointing_use_reentrant", True)
-            self._logger.info(f"[FSDP] Enabling gradient checkpointing with use_reentrant={use_reentrant}")
-            module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": use_reentrant})
+            use_reentrant = self._cfg.fsdp_config.get(
+                "gradient_checkpointing_use_reentrant", True
+            )
+            self._logger.info(
+                f"[FSDP] Enabling gradient checkpointing with use_reentrant={use_reentrant}"
+            )
+            module.gradient_checkpointing_enable(
+                gradient_checkpointing_kwargs={"use_reentrant": use_reentrant}
+            )
         else:
             self._logger.info("[FSDP] Gradient checkpointing is disabled")
 

--- a/rlinf/hybrid_engines/fsdp/utils.py
+++ b/rlinf/hybrid_engines/fsdp/utils.py
@@ -438,7 +438,10 @@ def apply_fsdp2_to_model(
         ):
             modules_to_shard.append((name, submodule, "transformer_or_embedding"))
 
-    for name, submodule, module_type in modules_to_shard:
+    # named_modules() returns submodules outermost-first, but fully_shard should
+    # be applied inside-out. Reversing ensures child modules are wrapped first,
+    # so the parent only shards the remaining (non-wrapped) parameters.
+    for name, submodule, module_type in reversed(modules_to_shard):
         fully_shard(
             submodule,
             mesh=device_mesh,

--- a/rlinf/models/embodiment/dreamzero/dreamzero_policy.py
+++ b/rlinf/models/embodiment/dreamzero/dreamzero_policy.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -80,7 +81,7 @@ class DreamZeroPolicy(VLA, BasePolicy):
     _no_split_modules = [
         "T5SelfAttention",  # text encoder
         "AttentionBlock",  # vae
-        "CausalWanModel", # action head
+        "CausalWanModel",  # action head
         "CausalWanAttentionBlock",  # action head layer
     ]
 
@@ -98,15 +99,17 @@ class DreamZeroPolicy(VLA, BasePolicy):
             enabled = True
             use_reentrant = gradient_checkpointing_kwargs.get("use_reentrant", True)
 
-            if diffusion_model is not None:
-                if hasattr(diffusion_model, "_set_gradient_checkpointing"):
-                    diffusion_model._set_gradient_checkpointing(
-                        diffusion_model, enabled
-                    )
-                elif hasattr(diffusion_model, "gradient_checkpointing"):
-                    diffusion_model.gradient_checkpointing = enabled
+            if diffusion_model is None:
+                raise ValueError("DreamZero policy must have action_head.")
 
-            setattr(diffusion_model, 'gradient_checkpointing_use_reentrant', use_reentrant)
+            if hasattr(diffusion_model, "_set_gradient_checkpointing"):
+                diffusion_model._set_gradient_checkpointing(diffusion_model, enabled)
+            elif hasattr(diffusion_model, "gradient_checkpointing"):
+                diffusion_model.gradient_checkpointing = enabled
+
+            setattr(
+                diffusion_model, "gradient_checkpointing_use_reentrant", use_reentrant
+            )
 
             logging.warning(
                 "DreamZero gradient checkpointing is enabled. If you encounter errors "
@@ -340,7 +343,6 @@ class DreamZeroPolicy(VLA, BasePolicy):
             raise NotImplementedError
 
     def sft_forward(self, data=None, **kwargs):
-
         # Mark the start of each training iteration so PyTorch knows when
         # to reclaim memory held by CUDA graphs from the previous iteration.
         torch.compiler.cudagraph_mark_step_begin()

--- a/rlinf/models/embodiment/dreamzero/dreamzero_policy.py
+++ b/rlinf/models/embodiment/dreamzero/dreamzero_policy.py
@@ -75,10 +75,13 @@ class DreamZeroConfig(VLAConfig):
 class DreamZeroPolicy(VLA, BasePolicy):
     """Lightweight DreamZero action model: IdentityBackbone + WANPolicyHead."""
 
+    # CausalWanModel has to be wrapped to avoid a FSDP2 bug
+    # when using with gradient checkpointing
     _no_split_modules = [
         "T5SelfAttention",  # text encoder
         "AttentionBlock",  # vae
-        "CausalWanAttentionBlock",  # action head
+        "CausalWanModel", # action head
+        "CausalWanAttentionBlock",  # action head layer
     ]
 
     def __init__(
@@ -87,9 +90,14 @@ class DreamZeroPolicy(VLA, BasePolicy):
     ):
         super().__init__(config)
         self.config = config
+
+    # This method is called in FSDPModelManager.setup_model_and_optimizer
+    def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs={}):
         try:
             diffusion_model = getattr(getattr(self, "action_head", None), "model", None)
-            enabled = self.config.gradient_checkpointing
+            enabled = True
+            use_reentrant = gradient_checkpointing_kwargs.get("use_reentrant", True)
+
             if diffusion_model is not None:
                 if hasattr(diffusion_model, "_set_gradient_checkpointing"):
                     diffusion_model._set_gradient_checkpointing(
@@ -97,6 +105,16 @@ class DreamZeroPolicy(VLA, BasePolicy):
                     )
                 elif hasattr(diffusion_model, "gradient_checkpointing"):
                     diffusion_model.gradient_checkpointing = enabled
+
+            setattr(diffusion_model, 'gradient_checkpointing_use_reentrant', use_reentrant)
+
+            logging.warning(
+                "DreamZero gradient checkpointing is enabled. If you encounter errors "
+                "or memory leaks, consider: (1) upgrading to PyTorch 2.10 or later; "
+                "(2) using use_reentrant=True to avoid issues when CUDA graphs and "
+                "gradient checkpointing are used together."
+            )
+
         except Exception:
             pass
 
@@ -322,6 +340,11 @@ class DreamZeroPolicy(VLA, BasePolicy):
             raise NotImplementedError
 
     def sft_forward(self, data=None, **kwargs):
+
+        # Mark the start of each training iteration so PyTorch knows when
+        # to reclaim memory held by CUDA graphs from the previous iteration.
+        torch.compiler.cudagraph_mark_step_begin()
+
         if data is None:
             data = kwargs.get("data")
         if data is None:

--- a/rlinf/models/embodiment/dreamzero/patch/wan_causal_model_forward_train.py
+++ b/rlinf/models/embodiment/dreamzero/patch/wan_causal_model_forward_train.py
@@ -133,24 +133,17 @@ def _forward_train(
         return custom_forward
 
     for block in self.blocks:
-        use_ckpt = (
-            torch.is_grad_enabled()
-            and self.gradient_checkpointing
-        )
+        use_ckpt = torch.is_grad_enabled() and self.gradient_checkpointing
 
         if use_ckpt:
+            ckpt_use_reentrant = getattr(
+                self, "gradient_checkpointing_use_reentrant", True
+            )
 
-            ckpt_use_reentrant = getattr(self, 'gradient_checkpointing_use_reentrant', True)
-
-            if not ckpt_use_reentrant:
-                x = torch.utils.checkpoint.checkpoint(
-                    create_custom_forward(block),
-                    x,
-                    **kwargs,
-                    use_reentrant=False,
-                )
-            else:
-                # When use_reentrant=True, the checkpoint interface only allows positional arguments
+            if ckpt_use_reentrant:
+                # When gradient_checkpointing_use_reentrant=True,
+                # torch.utils.checkpoint.checkpoint only accepts
+                # positional arguments, not keyword arguments.
                 x, _ = torch.utils.checkpoint.checkpoint(
                     block,
                     x,
@@ -165,6 +158,13 @@ def _forward_train(
                     0,  # current_start_frame
                     clean_x is not None,  # is_tf
                     use_reentrant=True,
+                )
+            else:
+                x = torch.utils.checkpoint.checkpoint(
+                    create_custom_forward(block),
+                    x,
+                    **kwargs,
+                    use_reentrant=False,
                 )
         else:
             x, _ = block(x, **kwargs)

--- a/rlinf/models/embodiment/dreamzero/patch/wan_causal_model_forward_train.py
+++ b/rlinf/models/embodiment/dreamzero/patch/wan_causal_model_forward_train.py
@@ -136,16 +136,36 @@ def _forward_train(
         use_ckpt = (
             torch.is_grad_enabled()
             and self.gradient_checkpointing
-            and not (action_register_length is not None and x.shape[0] > 1)
         )
 
         if use_ckpt:
-            x = torch.utils.checkpoint.checkpoint(
-                create_custom_forward(block),
-                x,
-                **kwargs,
-                use_reentrant=False,
-            )
+
+            ckpt_use_reentrant = getattr(self, 'gradient_checkpointing_use_reentrant', True)
+
+            if not ckpt_use_reentrant:
+                x = torch.utils.checkpoint.checkpoint(
+                    create_custom_forward(block),
+                    x,
+                    **kwargs,
+                    use_reentrant=False,
+                )
+            else:
+                # When use_reentrant=True, the checkpoint interface only allows positional arguments
+                x, _ = torch.utils.checkpoint.checkpoint(
+                    block,
+                    x,
+                    e0,
+                    freqs,
+                    self.freqs_action,
+                    self.freqs_state,
+                    action_register_length,
+                    context,
+                    None,  # kv_cache
+                    None,  # crossattn_cache
+                    0,  # current_start_frame
+                    clean_x is not None,  # is_tf
+                    use_reentrant=True,
+                )
         else:
             x, _ = block(x, **kwargs)
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This PR is a Doppelgänger of PR1138 which is closed because of wrong branch name
1. Add use_reentrant=True path for gradient checkpointing in CausalWanModel to work around CUDA graph compatibility issues. 
2. Wire gradient_checkpointing and gradient_checkpointing_use_reentrant config through FSDP model manager. 
3. Also fix FSDP2 fully_shard wrapping order (inside-out via reversed) and add CUDA graph step marking in sft_forward.

### Motivation and Context
1. Training 5B model without gradient checkpointing limits micro batch size, which harms throughput.
2. `use_reentrant=False` (the DreamZero default) conflicts with CUDA Graph capture, causing a known PyTorch issue (https://github.com/pytorch/pytorch/issues/154306). So we supported the use_reentrant=True code path.
3. There is also a subtle FSDP2 bug that requires wrapping CausalWanModel.
4. Using checkpoint(use_reentrant=False) with FSDP2 causes gpu memory leak in backward passes if PyTorch version is under 2.10 (https://github.com/pytorch/pytorch/issues/169349). So if gradient checkpoint is needed, please use **PyTorch >= 2.10**.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
1. Now we can enable gradient checkpointing under the conditions of micro batch size per gpu > 1 and cuda graph enabled, with no error reported,  using PyTorch == 2.10
2. With mbs == 8, 3.6 samples/sec/gpu is achieved, compared to 1.7 samples/sec/gpu under mbs=2
3. However, the current bottleneck in training speed has become data processing. The next PR will fix this.

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.