### PR TITLE
docs(recap): clarify LIBERO baseline scope

### DIFF
--- a/docs/source-en/rst_source/examples/embodied/recap.rst
+++ b/docs/source-en/rst_source/examples/embodied/recap.rst
@@ -666,6 +666,14 @@ We provide a reproduced experiment on the `LIBERO-10 <https://github.com/Lifelon
 - **Rollout data**: 4,096 trajectories collected by a few-shot π\ :sub:`0.5` policy on Task 0, containing both successful and failed episodes
 - **Eval data**: A held-out set collected by the same few-shot π\ :sub:`0.5` policy, used in Step 2 to monitor value model overfitting
 
+.. note::
+
+   This tutorial intentionally uses a few-shot π\ :sub:`0.5` policy with a moderate
+   initial success rate so that RECAP's offline improvement can be observed in a
+   compact Task 0 example. The baseline below is scoped to this reproduced setup;
+   it is not intended to represent the general π\ :sub:`0.5` SFT performance on
+   the full LIBERO benchmark.
+
 The dataset is available `here <https://huggingface.co/datasets/RLinf/RECAP-Libero10-Task0-48succ-Data/tree/main>`_.
 
 
@@ -673,7 +681,7 @@ The dataset is available `here <https://huggingface.co/datasets/RLinf/RECAP-Libe
 RECAP Results
 --------------
 
-After one iteration of the RECAP pipeline on LIBERO-10 Task 0, the success rate improves from **48.8%** (SFT baseline) to **66.5%** (RECAP), an absolute improvement of **17.7%**.
+After one iteration of the RECAP pipeline on LIBERO-10 Task 0, the success rate improves from **48.8%** (the few-shot SFT baseline in this tutorial setup) to **66.5%** (RECAP), an absolute improvement of **17.7%**.
 
 .. raw:: html
 

--- a/docs/source-zh/rst_source/examples/embodied/recap.rst
+++ b/docs/source-zh/rst_source/examples/embodied/recap.rst
@@ -660,6 +660,12 @@ RECAP 流程会在 ``logs/`` 目录下生成两个子目录：
 - **Rollout 数据**：few-shot π\ :sub:`0.5` 策略在 Task 0 上采集的 4,096 条轨迹，包含成功和失败的 episode
 - **Eval 数据**：同样由 few-shot π\ :sub:`0.5` 策略采集的验证集，用于 Step 2 监控价值模型是否过拟合
 
+.. note::
+
+   本教程有意使用初始成功率适中的 few-shot π\ :sub:`0.5` 策略，以便在紧凑的
+   Task 0 示例中观察 RECAP 的离线提升。下方 baseline 仅对应该可复现实验设置，
+   不代表 π\ :sub:`0.5` SFT 在完整 LIBERO benchmark 上的通用表现。
+
 数据集可从 `此处 <https://huggingface.co/datasets/RLinf/RECAP-Libero10-Task0-48succ-Data/tree/main>`_ 下载。
 
 
@@ -667,7 +673,7 @@ RECAP 流程会在 ``logs/`` 目录下生成两个子目录：
 RECAP 实验结果
 -----------------
 
-在 LIBERO-10 Task 0 上执行一轮 RECAP 迭代后，成功率从 **48.8%**\ （SFT 基线）提升至 **66.5%**\ （RECAP），绝对提升 **17.7%**。
+在 LIBERO-10 Task 0 上执行一轮 RECAP 迭代后，成功率从 **48.8%**\ （本教程设置下的 few-shot SFT baseline）提升至 **66.5%**\ （RECAP），绝对提升 **17.7%**。
 
 .. raw:: html
 


### PR DESCRIPTION
### Description
Clarify that the 48.8% LIBERO-10 Task 0 SFT baseline in the RECAP tutorial is scoped to the reproduced tutorial setup, not a general pi0.5 SFT result on the full LIBERO benchmark.

The English and Chinese RECAP pages now explicitly say that this baseline belongs to the compact Task 0 reproduction setup used to demonstrate RECAP's offline improvement.

### Motivation and Context
Closes #1089.

The issue asks why the RECAP page reports a surprisingly low pi0.5 SFT baseline. The previous result sentence could be read as a generic pi0.5 SFT baseline, while the surrounding dataset section describes a tutorial-specific setup.

### How has this been tested?
- requirements/install.sh docs --venv .venv
- pre-commit run --all-files
- pre-commit run --hook-stage commit-msg --commit-msg-filename /tmp/rlinf-commit-msg.txt
- git diff --check
- git diff --cached --check
- sphinx-build -b html docs/source-en /tmp/rlinf-docs-en
- sphinx-build -b html docs/source-zh /tmp/rlinf-docs-zh

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (not applicable: documentation-only wording clarification)
- [x] All new and existing checks listed above passed.