### PR TITLE
fix(maniskill): avoid stale offload video counter state

### DIFF
--- a/rlinf/envs/maniskill/maniskill_offload_env.py
+++ b/rlinf/envs/maniskill/maniskill_offload_env.py
@@ -86,7 +86,6 @@ class _ManiskillEnvCore(ManiskillEnv, EnvOffloadMixin):
             "reset_state_ids": self.reset_state_ids.cpu(),
             "generator_state": self._generator.get_state(),
             "is_start": self.is_start,
-            "video_cnt": self.video_cnt,
             "_init_raw_obs": self.env.unwrapped._init_raw_obs,
             "agent_controller_state": recursive_to_device(
                 self.env.agent.controller.get_state(), "cpu"
@@ -165,9 +164,6 @@ class _ManiskillEnvCore(ManiskillEnv, EnvOffloadMixin):
         )
         for key, value in task_metric_states.items():
             setattr(self.env, key, value)
-
-        # Restore utils state
-        self.video_cnt = state["video_cnt"]
 
         if self.record_metrics and "success_once" in state:
             self.success_once = state["success_once"].to(self.device)

--- a/rlinf/envs/utils.py
+++ b/rlinf/envs/utils.py
@@ -15,7 +15,6 @@
 import os
 from typing import Any, Optional, Union
 
-import imageio
 import numpy as np
 import torch
 from PIL import Image, ImageDraw, ImageFont
@@ -126,6 +125,13 @@ def save_rollout_video(
     """
     os.makedirs(output_dir, exist_ok=True)
     mp4_path = os.path.join(output_dir, f"{video_name}.mp4")
+    try:
+        import imageio
+    except ImportError as exc:
+        raise ImportError(
+            "imageio is required to save rollout videos; install rlinf[embodied]."
+        ) from exc
+
     video_writer = imageio.get_writer(mp4_path, fps=fps)
     for img in rollout_images:
         video_writer.append_data(img)

--- a/tests/unit_tests/test_maniskill_offload_env.py
+++ b/tests/unit_tests/test_maniskill_offload_env.py
@@ -1,0 +1,220 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import io
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+
+class _FakeCudaTensor:
+    def torch(self):
+        return torch.tensor([1.0])
+
+
+class _FakePx:
+    def __init__(self):
+        self.cuda_articulation_link_data = _FakeCudaTensor()
+        self.cuda_articulation_qacc = _FakeCudaTensor()
+        self.cuda_articulation_qf = _FakeCudaTensor()
+        self.cuda_articulation_qpos = _FakeCudaTensor()
+        self.cuda_articulation_qvel = _FakeCudaTensor()
+        self.cuda_articulation_target_qpos = _FakeCudaTensor()
+        self.cuda_articulation_target_qvel = _FakeCudaTensor()
+        self.cuda_rigid_body_data = _FakeCudaTensor()
+        self.cuda_rigid_dynamic_data = _FakeCudaTensor()
+
+    def gpu_update_articulation_kinematics(self):
+        return None
+
+
+class _FakeScene:
+    def __init__(self):
+        self.px = _FakePx()
+        self.timestep = None
+
+    def get_timestep(self):
+        return 0.02
+
+    def set_timestep(self, timestep):
+        self.timestep = timestep
+
+    def _gpu_apply_all(self):
+        return None
+
+    def _gpu_fetch_all(self):
+        return None
+
+
+class _FakeBatchedRng:
+    rngs = ["rng"]
+
+
+class _FakeController:
+    def __init__(self):
+        self.loaded_state = None
+
+    def get_state(self):
+        return {"controller": torch.tensor([1.0])}
+
+    def set_state(self, state):
+        self.loaded_state = state
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.controller = _FakeController()
+
+
+class _FakeEnv:
+    def __init__(self):
+        self.unwrapped = self
+        self.device = "cpu"
+        self.scene = _FakeScene()
+        self._main_rng = "main_rng"
+        self._batched_main_rng = _FakeBatchedRng()
+        self._main_seed = 123
+        self._episode_rng = "episode_rng"
+        self._batched_episode_rng = _FakeBatchedRng()
+        self._episode_seed = 456
+        self.action_space = "action_space"
+        self.single_action_space = "single_action_space"
+        self._orig_single_action_space = "orig_single_action_space"
+        self._elapsed_steps = torch.tensor([3])
+        self._init_raw_obs = {"obs": torch.tensor([1.0])}
+        self.agent = _FakeAgent()
+        self.task_reset_states = {}
+        self.task_metric_states = {}
+        self.reset_seed = None
+        self.reset_options = None
+        self.loaded_state = None
+
+    def get_state(self):
+        return {"sim": torch.tensor([2.0])}
+
+    def reset(self, seed=None, options=None):
+        self.reset_seed = seed
+        self.reset_options = options
+
+    def set_state(self, state):
+        self.loaded_state = state
+
+
+class _FakeManiskillEnv:
+    pass
+
+
+def _load_maniskill_offload_module(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = (
+        repo_root / "rlinf" / "envs" / "maniskill" / "maniskill_offload_env.py"
+    )
+
+    fake_package = types.ModuleType("rlinf.envs.maniskill")
+    fake_package.__path__ = [str(module_path.parent)]
+    fake_env_module = types.ModuleType("rlinf.envs.maniskill.maniskill_env")
+    fake_env_module.ManiskillEnv = _FakeManiskillEnv
+
+    monkeypatch.setitem(sys.modules, "rlinf.envs.maniskill", fake_package)
+    monkeypatch.setitem(
+        sys.modules, "rlinf.envs.maniskill.maniskill_env", fake_env_module
+    )
+    monkeypatch.delitem(
+        sys.modules, "rlinf.envs.maniskill.maniskill_offload_env", raising=False
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "rlinf.envs.maniskill.maniskill_offload_env", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_core(module):
+    core = object.__new__(module._ManiskillEnvCore)
+    core.env = _FakeEnv()
+    core.seed = 10
+    core.device = "cpu"
+    core.prev_step_reward = torch.tensor([0.5])
+    core.reset_state_ids = torch.tensor([1])
+    core._generator = torch.Generator()
+    core._generator.manual_seed(0)
+    core.is_start = True
+    core.record_metrics = False
+    return core
+
+
+def test_maniskill_offload_state_does_not_require_record_video_counter(monkeypatch):
+    module = _load_maniskill_offload_module(monkeypatch)
+    core = _make_core(module)
+
+    state_buffer = core.get_state()
+    state = torch.load(io.BytesIO(state_buffer), map_location="cpu", weights_only=False)
+
+    assert "video_cnt" not in state
+
+
+def test_maniskill_offload_load_state_accepts_state_without_video_counter(
+    monkeypatch,
+):
+    module = _load_maniskill_offload_module(monkeypatch)
+    monkeypatch.setattr(
+        module, "set_batch_rng_state", lambda rng_state: _FakeBatchedRng()
+    )
+    core = _make_core(module)
+
+    source_state = torch.load(
+        io.BytesIO(core.get_state()),
+        map_location="cpu",
+        weights_only=False,
+    )
+    assert "video_cnt" not in source_state
+
+    core.load_state(_serialize_state(source_state))
+
+    assert core.env.reset_seed == core.seed
+    assert core.env.reset_options == {"reconfigure": False}
+    torch.testing.assert_close(core.env.loaded_state["sim"], torch.tensor([2.0]))
+    assert core.env.scene.timestep == 0.02
+    assert not hasattr(core, "video_cnt")
+
+
+def test_maniskill_offload_load_state_ignores_legacy_video_counter(monkeypatch):
+    module = _load_maniskill_offload_module(monkeypatch)
+    monkeypatch.setattr(
+        module, "set_batch_rng_state", lambda rng_state: _FakeBatchedRng()
+    )
+    core = _make_core(module)
+
+    source_state = torch.load(
+        io.BytesIO(core.get_state()),
+        map_location="cpu",
+        weights_only=False,
+    )
+    source_state["video_cnt"] = 7
+
+    core.load_state(_serialize_state(source_state))
+
+    assert not hasattr(core, "video_cnt")
+
+
+def _serialize_state(state):
+    buffer = io.BytesIO()
+    torch.save(state, buffer)
+    return buffer.getvalue()


### PR DESCRIPTION
### Description
This removes stale `video_cnt` state from `_ManiskillEnvCore` offload serialization/deserialization.

`video_cnt` is now owned by the generic `RecordVideo` wrapper, not by the ManiSkill core env. The ManiSkill offload core still tried to save and restore it, so capturing offload state could crash before the state buffer was created.

The regression tests load `maniskill_offload_env.py` with lightweight fakes so the core offload-state contract can be checked without requiring ManiSkill/Sapien.

### Motivation and Context
Found while investigating #114 and the closed unmerged PR #127. This PR is related context only and does not close #114, because the original issue was about video file overwrite behavior and this PR fixes an adjacent stale offload-state bug.

#### Minimal reproduction

I reproduced the failure on the current base commit `3a7c83e` by applying only the new regression test file from this PR to `upstream/main` and running the smallest test that exercises the stale state access:

```bash
python -m pytest tests/unit_tests/test_maniskill_offload_env.py::test_maniskill_offload_state_does_not_require_record_video_counter -q
```

Result on `upstream/main`: the test fails with:

```text
E       AttributeError: '_ManiskillEnvCore' object has no attribute 'video_cnt'
rlinf/envs/maniskill/maniskill_offload_env.py:89
```

The failing line is:

```python
"video_cnt": self.video_cnt,
```

This happens before a state buffer can be produced, so an offloaded ManiSkill core can fail during `get_state()` even when video recording itself is handled outside the core env.

The fakes in the test only replace ManiSkill/Sapien dependencies; the test still executes the real `_ManiskillEnvCore.get_state()` method from the production file.

#### Root-cause trace

The ownership mismatch comes from two earlier changes:

1. `a500e7f feat: remove EnvManager and add RecordVideo wrapper (#659)` moved video recording out of environment classes and into `rlinf/envs/wrappers/record_video.py`.
   - `ManiskillEnv.__init__` stopped defining `self.video_cnt`.
   - `ManiskillEnv` lost its local `render_images`, `add_new_frames()`, and `flush_video()` video state/methods.
   - `RecordVideo.__init__` now defines `self.video_cnt = 0`.
   - `RecordVideo.flush_video()` writes `{self.video_cnt}.mp4` and increments the wrapper-owned counter.
   - `EnvWorker` wraps envs with `RecordVideo(env, video_cfg)` when `video_cfg.save_video` is enabled.

2. `89f71e5 feat(env_offload): support ManiSkillEnv and OpenSoraEnv offload (#727)` later reintroduced `rlinf/envs/maniskill/maniskill_offload_env.py`, but its `_ManiskillEnvCore` state schema still included the old env-owned video counter:
   - `get_state()` serialized `"video_cnt": self.video_cnt`.
   - `load_state()` restored `self.video_cnt = state["video_cnt"]`.

On current `main`, `_ManiskillEnvCore` subclasses `ManiskillEnv`, and `ManiskillEnv` no longer owns `video_cnt`; the wrapper does. The offload core should therefore serialize simulator/core state only, not wrapper video state.

### How has this been tested?
Targeted local checks on this branch:

```bash
python -m pytest tests/unit_tests/test_maniskill_offload_env.py tests/unit_tests/test_overlap_env_bootstrap.py -q
```

Result: `5 passed`.

```bash
python -m ruff check rlinf/envs/maniskill/maniskill_offload_env.py tests/unit_tests/test_maniskill_offload_env.py
python -m ruff format --check rlinf/envs/maniskill/maniskill_offload_env.py tests/unit_tests/test_maniskill_offload_env.py
git diff --check HEAD~1..HEAD
```

Results: ruff check passed, format check passed, diff whitespace check passed.

I did not run a real ManiSkill/Sapien embodied e2e locally. The added regression tests intentionally avoid those optional heavy dependencies and cover the `_ManiskillEnvCore` offload state schema directly.

### Additional information (optional, e.g., figures and logs):
The tests cover three state-schema cases:

- `get_state()` no longer emits `video_cnt`.
- `load_state()` accepts a state buffer without `video_cnt`.
- `load_state()` ignores a legacy buffer that still contains an extra `video_cnt` field.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
