### PR TITLE
fix(robotwin): cover multi-worker seed partition

### DIFF
--- a/rlinf/envs/robotwin/robotwin_env.py
+++ b/rlinf/envs/robotwin/robotwin_env.py
@@ -40,6 +40,7 @@ class RoboTwinEnv(gym.Env):
     ):
         env_seed = cfg.seed
         self.seed = env_seed + seed_offset
+        self.base_seed = env_seed
         self.num_envs = num_envs
         self.seed_offset = seed_offset
         self.total_num_processes = total_num_processes
@@ -421,16 +422,22 @@ class RoboTwinEnv(gym.Env):
             success_seeds = data[self.task_name].get("success_seeds", None)
             if success_seeds is not None:
                 success_seeds = torch.as_tensor(success_seeds, dtype=torch.long)
-                self._generator = torch.Generator()
-                self._generator.manual_seed(self.seed)
+                # All workers use the same global seed so the shuffle order is identical,
+                # then each worker takes a non-overlapping slice keyed by its rank.
+                global_generator = torch.Generator()
+                global_generator.manual_seed(self.base_seed)
                 shuffled_indices = torch.randperm(
-                    success_seeds.numel(), generator=self._generator
+                    success_seeds.numel(), generator=global_generator
                 )
                 shuffled_seeds = success_seeds[shuffled_indices]
-                # Drop last to make total divisible by num_group
                 total_seeds = shuffled_seeds.numel()
-                keep_count = (total_seeds // self.num_group) * self.num_group
-                self.success_seeds = shuffled_seeds[:keep_count]
+                seeds_per_worker = total_seeds // self.total_num_processes
+                start = self.seed_offset * seeds_per_worker
+                end = start + seeds_per_worker
+                worker_seeds = shuffled_seeds[start:end]
+                # Drop last to make this worker's slice divisible by num_group
+                keep_count = (worker_seeds.numel() // self.num_group) * self.num_group
+                self.success_seeds = worker_seeds[:keep_count]
                 self._current_seed_index = 0
             else:
                 self.success_seeds = None

--- a/rlinf/envs/robotwin/robotwin_env.py
+++ b/rlinf/envs/robotwin/robotwin_env.py
@@ -23,6 +23,7 @@ import torch.multiprocessing as mp
 from omegaconf import OmegaConf
 from PIL import Image
 
+from rlinf.envs.robotwin.seed_utils import partition_success_seeds
 from rlinf.envs.utils import center_crop_image, list_of_dict_to_dict_of_list
 
 __all__ = ["RoboTwinEnv"]
@@ -422,22 +423,13 @@ class RoboTwinEnv(gym.Env):
             success_seeds = data[self.task_name].get("success_seeds", None)
             if success_seeds is not None:
                 success_seeds = torch.as_tensor(success_seeds, dtype=torch.long)
-                # All workers use the same global seed so the shuffle order is identical,
-                # then each worker takes a non-overlapping slice keyed by its rank.
-                global_generator = torch.Generator()
-                global_generator.manual_seed(self.base_seed)
-                shuffled_indices = torch.randperm(
-                    success_seeds.numel(), generator=global_generator
+                self.success_seeds = partition_success_seeds(
+                    success_seeds,
+                    base_seed=self.base_seed,
+                    seed_offset=self.seed_offset,
+                    total_num_processes=self.total_num_processes,
+                    num_group=self.num_group,
                 )
-                shuffled_seeds = success_seeds[shuffled_indices]
-                total_seeds = shuffled_seeds.numel()
-                seeds_per_worker = total_seeds // self.total_num_processes
-                start = self.seed_offset * seeds_per_worker
-                end = start + seeds_per_worker
-                worker_seeds = shuffled_seeds[start:end]
-                # Drop last to make this worker's slice divisible by num_group
-                keep_count = (worker_seeds.numel() // self.num_group) * self.num_group
-                self.success_seeds = worker_seeds[:keep_count]
                 self._current_seed_index = 0
             else:
                 self.success_seeds = None

--- a/rlinf/envs/robotwin/seed_utils.py
+++ b/rlinf/envs/robotwin/seed_utils.py
@@ -1,0 +1,38 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def partition_success_seeds(
+    success_seeds: torch.Tensor,
+    *,
+    base_seed: int,
+    seed_offset: int,
+    total_num_processes: int,
+    num_group: int,
+) -> torch.Tensor:
+    """Shuffle success seeds globally and return the non-overlapping worker slice."""
+    global_generator = torch.Generator()
+    global_generator.manual_seed(base_seed)
+    shuffled_indices = torch.randperm(success_seeds.numel(), generator=global_generator)
+    shuffled_seeds = success_seeds[shuffled_indices]
+
+    seeds_per_worker = shuffled_seeds.numel() // total_num_processes
+    start = seed_offset * seeds_per_worker
+    end = start + seeds_per_worker
+    worker_seeds = shuffled_seeds[start:end]
+
+    keep_count = (worker_seeds.numel() // num_group) * num_group
+    return worker_seeds[:keep_count]

--- a/tests/unit_tests/test_robotwin_seed_partition.py
+++ b/tests/unit_tests/test_robotwin_seed_partition.py
@@ -1,0 +1,93 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from rlinf.envs.robotwin.seed_utils import partition_success_seeds
+
+
+def _first_eval_seeds(
+    *,
+    seed_count: int,
+    total_num_envs: int,
+    total_num_processes: int,
+    group_size: int = 1,
+    base_seed: int = 0,
+) -> list[int]:
+    success_seeds = torch.arange(seed_count, dtype=torch.long)
+    selected_seeds = []
+    for seed_offset in range(total_num_processes):
+        num_envs = total_num_envs // total_num_processes
+        num_group = num_envs // group_size
+        worker_seeds = partition_success_seeds(
+            success_seeds,
+            base_seed=base_seed,
+            seed_offset=seed_offset,
+            total_num_processes=total_num_processes,
+            num_group=num_group,
+        )
+        selected_seeds.extend(worker_seeds[:num_group].tolist())
+    return selected_seeds
+
+
+@pytest.mark.parametrize(
+    ("seed_count", "total_num_envs", "total_num_processes"),
+    [
+        (320, 128, 4),
+        (320, 128, 8),
+        (320, 128, 16),
+        (260, 128, 4),
+        (200, 128, 8),
+        (150, 128, 4),
+    ],
+)
+def test_robotwin_eval_success_seeds_do_not_overlap_across_workers(
+    seed_count: int,
+    total_num_envs: int,
+    total_num_processes: int,
+):
+    """Regression test for duplicate RoboTwin eval seeds across EnvWorkers."""
+    selected_seeds = _first_eval_seeds(
+        seed_count=seed_count,
+        total_num_envs=total_num_envs,
+        total_num_processes=total_num_processes,
+    )
+
+    assert len(selected_seeds) == total_num_envs
+    assert len(set(selected_seeds)) == total_num_envs
+
+
+def test_robotwin_eval_success_seed_order_is_controlled_by_base_seed():
+    selected_seed_0 = _first_eval_seeds(
+        seed_count=320,
+        total_num_envs=128,
+        total_num_processes=4,
+        base_seed=0,
+    )
+    selected_seed_0_again = _first_eval_seeds(
+        seed_count=320,
+        total_num_envs=128,
+        total_num_processes=4,
+        base_seed=0,
+    )
+    selected_seed_1 = _first_eval_seeds(
+        seed_count=320,
+        total_num_envs=128,
+        total_num_processes=4,
+        base_seed=1,
+    )
+
+    assert selected_seed_0 == selected_seed_0_again
+    assert selected_seed_0 != selected_seed_1


### PR DESCRIPTION
## Summary

- Adds a lightweight regression test for the RoboTwin multi-worker success seed partition logic introduced in #1196.
- Extracts the partition logic into a small helper so the behavior can be tested without launching RoboTwin/SAPIEN or any GPU environment.
- Verifies that 128 eval episodes remain unique across 4/8/16 workers and several representative RoboTwin success-seed counts.

## Notes

This PR is intended as a follow-up to #1196 / #1175. It is currently based on #1196's fix commit, so the diff includes that change until #1196 is merged. After #1196 lands, this PR should reduce to the helper extraction plus regression test.

## Test

```bash
PYTHONPATH=$(pwd):$(pwd)/tests/unit_tests pytest tests/unit_tests/test_robotwin_seed_partition.py -q
ruff check rlinf/envs/robotwin/seed_utils.py rlinf/envs/robotwin/robotwin_env.py tests/unit_tests/test_robotwin_seed_partition.py
```

Local result: 7 passed; ruff passed when run inside the RoboTwin/OpenVLA-OFT environment used for local validation.
