### PR TITLE
refactor(sft): unify SFT loss/metrics API

### DIFF
--- a/rlinf/models/embodiment/dreamzero/dreamzero_policy.py
+++ b/rlinf/models/embodiment/dreamzero/dreamzero_policy.py
@@ -322,9 +322,11 @@ class DreamZeroPolicy(VLA, BasePolicy):
         if data is None:
             raise ValueError("sft_forward requires `data` from the SFT dataloader.")
         outputs = super().forward(data)
+        if hasattr(outputs, "data"):
+            outputs = outputs.data
         if "loss" not in outputs:
             raise ValueError("sft_forward requires `loss` in the outputs.")
-        return outputs
+        return dict(outputs)
 
     def default_forward(
         self,

--- a/rlinf/models/embodiment/openpi/openpi_action_model.py
+++ b/rlinf/models/embodiment/openpi/openpi_action_model.py
@@ -325,12 +325,37 @@ class OpenPi0ForRLActionPrediction(PI0Pytorch, BasePolicy):
         else:
             raise NotImplementedError
 
-    def sft_forward(self, data, **kwargs):
+    def sft_forward(self, data, use_action_chunk_loss: bool = False, **kwargs):
         if hasattr(self, "gradient_checkpointing_disable"):
             self.gradient_checkpointing_disable()
-        observation = data["observation"]
-        actions = data["actions"]
-        return super().forward(observation, actions)
+
+        if isinstance(data, tuple):
+            observation, actions = data
+        else:
+            observation = data["observation"]
+            actions = data["actions"]
+
+        device = next(self.parameters()).device
+        register_pytree_dataclasses(observation)
+        observation = tree_map(
+            lambda x: (
+                torch.as_tensor(x, device=device).contiguous().clone()
+                if x is not None
+                else x
+            ),
+            observation,
+        )
+        if not isinstance(actions, torch.Tensor):
+            actions = torch.as_tensor(actions, device=device)
+        else:
+            actions = actions.to(device=device)
+        actions = actions.to(dtype=torch.float32)
+
+        # PI0Pytorch.forward returns per-element MSE (reduction="none").
+        loss = super().forward(observation, actions)
+        if use_action_chunk_loss:
+            loss = loss[:, : self.config.action_chunk, : self.config.action_env_dim]
+        return loss.mean()
 
     def prepare_dagger_sft_batch(self, batch):
         """Prepare replay-buffer samples for DAgger SFT updates."""

--- a/rlinf/workers/actor/fsdp_actor_worker.py
+++ b/rlinf/workers/actor/fsdp_actor_worker.py
@@ -1266,28 +1266,11 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
             self.sft_iterator = iter(self.data_loader)
             observation, actions = next(self.sft_iterator)
 
-        register_pytree_dataclasses(observation)
-        observation = tree_map(
-            lambda x: x.to(self.device) if x is not None else x,
-            observation,
-        )
-        actions = actions.to(torch.float32)
-        actions = actions.to(self.device)
-
-        sft_losses = self.model(
-            data={"observation": observation, "actions": actions},
+        sft_loss = self.model(
+            data=(observation, actions),
             forward_type=ForwardType.SFT,
         )
-        # Ensure losses is a tensor and handle different return types
-        if isinstance(sft_losses, list | tuple):
-            sft_losses = torch.stack(sft_losses)
-        elif not isinstance(sft_losses, torch.Tensor):
-            sft_losses = torch.tensor(
-                sft_losses, device=self.device, dtype=torch.float32
-            )
-
-        sft_loss = sft_losses.mean()
-        metrics_data["sft_loss"] = sft_loss.clone().detach().item()
+        metrics_data["sft_loss"] = sft_loss.detach().item()
         total_loss = loss + self.sft_loss_weight * sft_loss
         loss = total_loss
 

--- a/rlinf/workers/actor/fsdp_actor_worker.py
+++ b/rlinf/workers/actor/fsdp_actor_worker.py
@@ -23,7 +23,6 @@ from omegaconf import DictConfig, OmegaConf
 from torch import nn
 from torch.distributed.tensor import DTensor
 from torch.multiprocessing.reductions import reduce_tensor
-from torch.utils._pytree import tree_map
 
 import rlinf.algorithms  # noqa: F401
 from rlinf.algorithms.registry import calculate_adv_and_returns, policy_loss
@@ -75,7 +74,6 @@ from rlinf.utils.placement import (
     HybridComponentPlacement,
     ModelParallelComponentPlacement,
 )
-from rlinf.utils.pytree import register_pytree_dataclasses
 from rlinf.utils.utils import (
     clear_memory,
     compute_entropy_from_logits,

--- a/rlinf/workers/actor/fsdp_dagger_policy_worker.py
+++ b/rlinf/workers/actor/fsdp_dagger_policy_worker.py
@@ -94,24 +94,18 @@ class EmbodiedDAGGERFSDPPolicy(EmbodiedFSDPActor):
         """Prepare model-specific DAgger training inputs."""
         return self.model.prepare_dagger_sft_batch(batch)
 
-    def _reduce_sft_loss(self, loss):
-        """Reduce model-specific SFT loss to a scalar."""
-        if not isinstance(loss, torch.Tensor):
-            loss = torch.as_tensor(loss, device=self.device)
-
-        if SupportedModel(self.cfg.actor.model.model_type) == SupportedModel.OPENPI:
-            action_chunk = self.model.config.action_chunk
-            action_dim = self.model.config.action_env_dim
-            loss = loss[:, :action_chunk, :action_dim]
-
-        return loss.mean()
-
     @Worker.timer("forward_actor")
     def forward_actor(self, batch):
         """Run one supervised forward pass for DAgger."""
         data = self._prepare_sft_batch(batch)
-        actor_loss = self.model(forward_type=ForwardType.SFT, data=data)
-        return self._reduce_sft_loss(actor_loss)
+        use_action_chunk_loss = (
+            SupportedModel(self.cfg.actor.model.model_type) == SupportedModel.OPENPI
+        )
+        return self.model(
+            forward_type=ForwardType.SFT,
+            data=data,
+            use_action_chunk_loss=use_action_chunk_loss,
+        )
 
     @Worker.timer("update_one_epoch")
     def update_one_epoch(self):

--- a/rlinf/workers/sft/fsdp_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_sft_worker.py
@@ -15,7 +15,7 @@
 import logging
 import os
 from abc import abstractmethod
-from typing import Any, Tuple
+from typing import Any
 
 import numpy as np
 import torch
@@ -200,7 +200,9 @@ class FSDPSftWorker(FSDPModelManager, Worker):
         raise NotImplementedError
 
     @abstractmethod
-    def get_train_model_output(self, batch: dict[str, Any]) -> Tuple[torch.Tensor, dict[str, Any]]:
+    def get_train_model_output(
+        self, batch: dict[str, Any]
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         raise NotImplementedError
 
     @abstractmethod

--- a/rlinf/workers/sft/fsdp_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_sft_worker.py
@@ -15,7 +15,7 @@
 import logging
 import os
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Tuple
 
 import numpy as np
 import torch
@@ -137,7 +137,6 @@ class FSDPSftWorker(FSDPModelManager, Worker):
             self.model.train()
 
             metrics = {}
-            avg_loss = 0.0
 
             for idx in range(self.gradient_accumulation):
                 # set the gradient accumulation backward_ctx
@@ -162,18 +161,10 @@ class FSDPSftWorker(FSDPModelManager, Worker):
                     batch = next(self.data_iter)
                     self._data_iter_offset = 1
 
-                losses = self.get_train_model_output(batch)
-
-                if isinstance(losses, (list, tuple)):
-                    losses = torch.stack(losses)
-                elif not isinstance(losses, torch.Tensor):
-                    losses = torch.tensor(
-                        losses, device=self.device, dtype=torch.float32
-                    )
-                loss = losses.mean()
+                loss, step_metrics = self.get_train_model_output(batch)
+                append_to_dict(metrics, step_metrics)
 
                 loss = loss / self.gradient_accumulation
-                avg_loss += loss.item()
                 with backward_ctx:
                     self.grad_scaler.scale(loss).backward()
 
@@ -189,7 +180,6 @@ class FSDPSftWorker(FSDPModelManager, Worker):
             append_to_dict(
                 metrics,
                 {
-                    "loss": avg_loss,
                     "learning_rate": lr_value,
                     "grad_norm": grad_norm_value,
                 },
@@ -210,7 +200,7 @@ class FSDPSftWorker(FSDPModelManager, Worker):
         raise NotImplementedError
 
     @abstractmethod
-    def get_train_model_output(self, batch: dict[str, Any]):
+    def get_train_model_output(self, batch: dict[str, Any]) -> Tuple[torch.Tensor, dict[str, Any]]:
         raise NotImplementedError
 
     @abstractmethod

--- a/rlinf/workers/sft/fsdp_vla_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_vla_sft_worker.py
@@ -106,13 +106,13 @@ class FSDPVlaSftWorker(FSDPSftWorker):
 
             torch.distributed.barrier()
 
-        rng_state = get_rng_state()
-        all_rng_states = [None] * self._world_size
-        torch.distributed.all_gather_object(all_rng_states, rng_state)
-        if self._rank == 0:
-            torch.save(all_rng_states, os.path.join(save_path, "rng.pt"))
+            rng_state = get_rng_state()
+            all_rng_states = [None] * self._world_size
+            torch.distributed.all_gather_object(all_rng_states, rng_state)
+            if self._rank == 0:
+                torch.save(all_rng_states, os.path.join(save_path, "rng.pt"))
 
-        torch.distributed.barrier()
+            torch.distributed.barrier()
 
     def load_checkpoint(self, load_path: str) -> None:
         super().load_checkpoint(load_path)
@@ -125,12 +125,12 @@ class FSDPVlaSftWorker(FSDPSftWorker):
             self.data_loader.load_state_dict(state)
             self.data_iter = iter(self.data_loader)
 
-        rng_path = os.path.join(load_path, "rng.pt")
-        if os.path.exists(rng_path):
-            all_rng_states = torch.load(rng_path, weights_only=False)
-            set_rng_state(all_rng_states[self._rank])
+            rng_path = os.path.join(load_path, "rng.pt")
+            if os.path.exists(rng_path):
+                all_rng_states = torch.load(rng_path, weights_only=False)
+                set_rng_state(all_rng_states[self._rank])
 
-        torch.distributed.barrier()
+            torch.distributed.barrier()
 
     def get_max_steps_per_epoch(self):
         if self.data_loader is None:

--- a/rlinf/workers/sft/fsdp_vla_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_vla_sft_worker.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Any, Tuple
+from typing import Any
 
 import torch
 from omegaconf import DictConfig
@@ -73,9 +73,7 @@ class FSDPVlaSftWorker(FSDPSftWorker):
         # now the eval is not supported for embodied sft
         raise NotImplementedError("eval is not supported for embodied sft right now.")
 
-    def get_train_model_output(
-        self, batch: Any
-    ) -> Tuple[torch.Tensor, dict[str, Any]]:
+    def get_train_model_output(self, batch: Any) -> tuple[torch.Tensor, dict[str, Any]]:
         with self.amp_context:
             output = self.model(forward_type=ForwardType.SFT, data=batch)
 

--- a/rlinf/workers/sft/fsdp_vla_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_vla_sft_worker.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Any
+from typing import Any, Tuple
 
 import torch
 from omegaconf import DictConfig
-from torch.utils._pytree import tree_map
 from torchdata.stateful_dataloader import StatefulDataLoader
 
 from rlinf.config import SupportedModel
 from rlinf.models.embodiment.base_policy import ForwardType
-from rlinf.utils.pytree import register_pytree_dataclasses
 from rlinf.utils.utils import get_rng_state, set_rng_state
 from rlinf.workers.sft.fsdp_sft_worker import FSDPSftWorker
 
@@ -59,7 +57,6 @@ class FSDPVlaSftWorker(FSDPSftWorker):
         elif SupportedModel(self.cfg.actor.model.model_type) in [
             SupportedModel.DREAMZERO
         ]:
-            self._dreamzero_loss = None
             from rlinf.data.datasets.dreamzero import (
                 build_dreamzero_sft_dataloader,
             )
@@ -76,63 +73,26 @@ class FSDPVlaSftWorker(FSDPSftWorker):
         # now the eval is not supported for embodied sft
         raise NotImplementedError("eval is not supported for embodied sft right now.")
 
-    def get_train_model_output(self, batch: dict[str, Any]):
-        if SupportedModel(self.cfg.actor.model.model_type) in [
-            SupportedModel.LINGBOTVLA,
-            SupportedModel.DREAMZERO,
-        ]:
-            with self.amp_context:
-                losses_dict = self.model(forward_type=ForwardType.SFT, data=batch)
-            if losses_dict.get("dynamics_loss", None) is not None:
-                self._dreamzero_loss = {
-                    "dynamics_loss": losses_dict["dynamics_loss"],
-                    "action_loss": losses_dict["action_loss"],
-                }
-            return losses_dict["loss"]
-        observation, actions = batch
-
-        register_pytree_dataclasses(observation)
-        observation = tree_map(
-            lambda x: (
-                torch.as_tensor(x, device=self.device).contiguous().clone()
-                if x is not None
-                else x
-            ),
-            observation,
-        )
-        actions = actions.to(torch.float32)
-        actions = actions.to(self.device)
-
+    def get_train_model_output(
+        self, batch: Any
+    ) -> Tuple[torch.Tensor, dict[str, Any]]:
         with self.amp_context:
-            losses = self.model(
-                forward_type=ForwardType.SFT,
-                data={"observation": observation, "actions": actions},
-            )
+            output = self.model(forward_type=ForwardType.SFT, data=batch)
 
-        # train model return the loss
-        return losses
+        if isinstance(output, torch.Tensor):
+            loss = output
+        else:
+            loss = output["loss"]
 
-    def run_training(self):
-        train_metrics = super().run_training()
-        if (
-            SupportedModel(self.cfg.actor.model.model_type)
-            in [SupportedModel.DREAMZERO]
-            and self._dreamzero_loss is not None
-        ):
-            train_metrics.update(
+        step_metrics = {"loss": loss.detach().item()}
+        if isinstance(output, dict) and output.get("dynamics_loss", None) is not None:
+            step_metrics.update(
                 {
-                    "dynamics_loss": self._dreamzero_loss["dynamics_loss"]
-                    .detach()
-                    .cpu()
-                    .item(),
-                    "action_loss": self._dreamzero_loss["action_loss"]
-                    .detach()
-                    .cpu()
-                    .item(),
+                    "dynamics_loss": output["dynamics_loss"].detach().item(),
+                    "action_loss": output["action_loss"].detach().item(),
                 }
             )
-            self._dreamzero_loss = None
-        return train_metrics
+        return loss, step_metrics
 
     def save_checkpoint(self, save_path: str, step: int = 0) -> None:
         super().save_checkpoint(save_path, step)

--- a/rlinf/workers/sft/fsdp_vlm_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_vlm_sft_worker.py
@@ -15,7 +15,7 @@
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Tuple
 
 import torch
 from omegaconf import DictConfig
@@ -209,7 +209,9 @@ class FSDPVlmSftWorker(FSDPSftWorker):
         # eval model return the correct number of answers
         return correct
 
-    def get_train_model_output(self, batch: dict[str, Any]):
+    def get_train_model_output(
+        self, batch: dict[str, Any]
+    ) -> Tuple[torch.Tensor, dict[str, Any]]:
         # hundle the input batch
         input_ids = batch["prompt"].to(self.device)
         attention_mask = batch["attention_mask"].to(self.device, dtype=torch.bool)
@@ -233,5 +235,5 @@ class FSDPVlmSftWorker(FSDPSftWorker):
                 **multi_modal_inputs,
             )
 
-        # train model return the loss
-        return outputs.loss
+        loss = outputs.loss
+        return loss, {"loss": loss.detach().item()}

--- a/rlinf/workers/sft/fsdp_vlm_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_vlm_sft_worker.py
@@ -15,7 +15,7 @@
 import json
 import logging
 import os
-from typing import Any, Tuple
+from typing import Any
 
 import torch
 from omegaconf import DictConfig
@@ -211,7 +211,7 @@ class FSDPVlmSftWorker(FSDPSftWorker):
 
     def get_train_model_output(
         self, batch: dict[str, Any]
-    ) -> Tuple[torch.Tensor, dict[str, Any]]:
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
         # hundle the input batch
         input_ids = batch["prompt"].to(self.device)
         attention_mask = batch["attention_mask"].to(self.device, dtype=torch.bool)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Refactored FSDP SFT training to use a (loss, step_metrics) return contract from `get_train_model_output`:

1. `FSDPSftWorker`: uses the returned loss directly for backward; aggregates per-micro-batch metrics (including loss) via step_metrics.

2. `FSDPVlmSftWorker` / `FSDPVlaSftWorker`: updated to the new API; VLA worker now uses a single training path for OpenPI, LingBot, and DreamZero.

3. `OpenPi0ForRLActionPrediction.sft_forward`: centralized batch preprocessing, device transfer, and loss reduction; supports both dataloader tuples and dict inputs; added use_action_chunk_loss for DAgger.

4. fsdp_actor_worker / fsdp_dagger_policy_worker: removed duplicate OpenPI preprocessing and loss reduction logic.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, SFT workers mixed backward loss computation, metric logging, and model-specific preprocessing in multiple places (base worker, VLA worker overrides, actor/DAgger workers). This made it harder to add model-specific metrics (e.g. DreamZero dynamics_loss) and led to duplicated OpenPI handling.

This change separates training loss from logging metrics, moves OpenPI-specific logic into the model, and unifies VLA SFT call sites—making the SFT pipeline easier to extend and maintain.

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.