### PR TITLE
feat(embodiment): add LingBot-VA SFT + eval on Libero-Object

### DIFF
--- a/docs/source-en/rst_source/examples/embodied/sft_lingbotva.rst
+++ b/docs/source-en/rst_source/examples/embodied/sft_lingbotva.rst
@@ -1,0 +1,493 @@
+LingBot-VA Supervised Fine-Tuning
+==================================
+
+This document explains how to run LingBot-VA supervised fine-tuning (SFT) in RLinf on the Libero-Object benchmark.
+
+It targets the 5B-parameter LingBot-VA video-diffusion transformer on a single node with **8 × NVIDIA A100-80GB SXM4** GPUs, and replicates the lingbot-va reference ``va_libero_train_cfg`` (FSDP2 full-sharding, plain AdamW, ``flex_attention``) at the same effective batch size (80).
+
+
+Supported setups
+----------------
+
+Recommended config:
+
+- ``examples/sft/config/libero_sft_lingbotva.yaml``: Libero-Object SFT on 8 × A100-80GB (plain AdamW + FSDP2 ``fully_shard`` + flex_attention)
+
+A single-GPU launch path (FSDP1 ``no_shard`` + bitsandbytes ``AdamW8bit`` + flex_attention) is documented inline in the config's header comment and is reached by overriding four fields on the launch CLI — see :ref:`single-gpu-launch` below.
+
+Starting point:
+
+- **Cold-start from the LingBot-VA base checkpoint** (Wan-Video 2.2 backbone). Continuing from a partially trained checkpoint is supported but not the verified path.
+
+Verified result on 8 × A100-80GB (one node):
+
+- ckpt_2000 mean SR on Libero-Object: **70 % (35/50)** over 10 tasks × 5 episodes (single-A100 reference recipe: ~18 %; ``lingbot-va-base`` without SFT scores 0/50)
+- Per-step wall time: ~12.5 s/step at effective batch 80; ~7 h to step 2000; ~10.5 h projected to step 3000
+- Per-GPU memory: ~32 GB at training (FSDP2 sharding active; under half what single-GPU NO_SHARD would use); ~39 GB per process at evaluation (KV-cache replay)
+
+
+Training entrypoint
+-------------------
+
+Use:
+
+- ``examples/sft/run_vla_sft.sh``
+
+The script runs:
+
+.. code:: bash
+
+   python examples/sft/train_vla_sft.py \
+     --config-path examples/sft/config/ \
+     --config-name libero_sft_lingbotva \
+     runner.logger.log_path=<auto_log_dir>
+
+Logs are written to:
+
+- ``<repo>/logs/<timestamp>/run_embodiment.log``
+
+The script also exports ``PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True``. It is not strictly required on 80 GB cards but is harmless and avoids allocator fragmentation during the wrap/first-forward phase.
+
+
+Environment
+-----------
+
+1. **PyTorch 2.9.0+cu126 is required.** Earlier versions hit a ``flex_attention`` + inductor codegen bug (``NameError: name 's10' is not defined``). Install with::
+
+     pip install --no-deps --force-reinstall \
+       torch==2.9.0+cu126 \
+       --index-url https://download.pytorch.org/whl/cu126
+     pip install nvidia-cufile-cu12 nvidia-nvshmem-cu12
+
+   Do **not** force-upgrade NCCL: torch 2.9 hard-pins ``nvidia-nccl-cu12==2.27.5``. Let it install transitively.
+
+2. Install RLinf and the LingBot-VA dependency group::
+
+     pip install -e ${REPO_PATH}
+     pip install -r ${REPO_PATH}/requirements/embodied/models/lingbotva.txt
+
+3. Install the LIBERO simulator and the runtime deps the lingbot-va requirements file does not pull::
+
+     pip install "lerobot==0.3.3" "robosuite==1.4.1" "gym==0.26.2" \
+                 bddl draccus tensorflow_graphics websockets msgpack \
+                 matplotlib Pillow
+     pip install -e <RLINF_LIBERO_REPO_PATH>     # https://github.com/RLinf/LIBERO.git
+
+   ``lerobot==0.3.3`` is mandatory — 0.4.x breaks the ``LatentLeRobotDataset`` imports the loader relies on. The lerobot install can also pull a transitive torch downgrade; re-run step 1 after it to re-pin torch 2.9.0+cu126 and its companions.
+
+4. Clone the lingbot-va peer repository (provides the ``wan_va`` Python package — needed at runtime by both training and the dataset-prep ``extract_latents.py``; the data-prep scripts themselves now live under ``toolkits/data_scripts_lingbotva/`` in this RLinf clone)::
+
+     git clone https://github.com/robbyant/lingbot-va.git <LINGBOT_VA_REPO_PATH>
+
+   Do **not** ``pip install -e`` it: the upstream ``pyproject.toml`` declares the package as ``lingbot_va`` while the source tree is ``wan_va``, and ``flash_attn`` is a hard build dep that fails on torch 2.9. Make ``wan_va`` importable via ``PYTHONPATH`` instead (step 5).
+
+5. Set the path env vars consumed by the launch script (substitute your own absolute paths)::
+
+     export LINGBOT_VA_REPO_PATH=<your-lingbot-va-clone>
+     export LINGBOT_VA_MODEL_PATH=<your-model-dir>
+     export LINGBOT_VA_DATASET_PATH=<your-dataset-dir>
+     export PYTHONPATH=${REPO_PATH}:${LINGBOT_VA_REPO_PATH}:${PYTHONPATH}
+     export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl
+
+6. **lingbot-va flash_attn patch.** ``wan_va/modules/model.py`` imports ``flash_attn`` at module-load time. The prebuilt wheels do not load against the torch 2.9 ABI; patch the import to fall through gracefully:
+
+   .. code:: diff
+
+       try:
+           from flash_attn_interface import flash_attn_func
+      -except:
+      -    from flash_attn import flash_attn_func
+      +except Exception:
+      +    try:
+      +        from flash_attn import flash_attn_func
+      +    except Exception:
+      +        flash_attn_func = None
+
+   This recipe uses ``attn_mode: flex`` and never calls ``flash_attn_func``, so the fallthrough is safe.
+
+7. **Hydra model-default visibility.** The SFT yaml uses ``model/lingbotva@actor.model``, but ``model/lingbotva.yaml`` lives under ``examples/embodiment/config/model/``, not ``examples/sft/config/model/``. ``run_vla_sft.sh`` sets ``EMBODIED_PATH=examples/sft``, so hydra cannot resolve the default and fails with ``Could not load 'model/lingbotva'``. Resolve by symlinking the file into the SFT search path::
+
+     ln -s ${REPO_PATH}/examples/embodiment/config/model/lingbotva.yaml \
+           ${REPO_PATH}/examples/sft/config/model/lingbotva.yaml
+
+
+Data preparation
+----------------
+
+The training dataset is a LeRobot v2.1 conversion of the full Libero-Object set (10 tasks × 50 demos = 500 episodes) with pre-extracted Wan 2.2 VAE latents and a cached UMT5 empty-prompt embedding. The 8-GPU run uses the full 500-demo set; the 100-demo subsample remains useful as a smoke-test path on a single GPU.
+
+1. Download the raw HDF5 demonstrations. **Use** ``yifengzhu-hf/LIBERO-datasets``, **NOT** ``IPEC-COMMUNITY``: the two distributions have different wrist-camera mounts, and the IPEC version trains fine but evaluates at 0 % SR.
+
+   .. code:: bash
+
+      export LIBERO_RAW_DIR=<your-libero-raw-dir>
+      huggingface-cli download yifengzhu-hf/LIBERO-datasets --local-dir ${LIBERO_RAW_DIR}
+
+2. Run the conversion scripts shipped under ``toolkits/data_scripts_lingbotva/``. See that directory's ``README.md`` for inputs / outputs of each step.
+
+   .. code:: bash
+
+      cd ${REPO_PATH}
+
+      # (a) HDF5 -> LeRobot v2.1 format (all 500 demos)
+      python toolkits/data_scripts_lingbotva/convert_libero_object_to_lerobot.py \
+        --src ${LIBERO_RAW_DIR}/libero_object \
+        --dst ${LINGBOT_VA_DATASET_PATH}
+
+      # (b) Extract Wan 2.2 VAE latents + cache the UMT5 empty-prompt embedding
+      python toolkits/data_scripts_lingbotva/extract_latents.py \
+        --dataset ${LINGBOT_VA_DATASET_PATH} \
+        --ckpt-dir ${LINGBOT_VA_MODEL_PATH}
+
+      # (c) MANDATORY: reshape image stats from (3,) to (3, 1, 1)
+      # lerobot>=0.3.3 rejects the dataset on the first batch with
+      # "ValueError: Shape of 'min' must be (3,1,1)" otherwise. Apply
+      # in place to every observation.images.* entry in episodes_stats.jsonl:
+      python - <<'PY'
+      import json, os
+      path = os.path.join(os.environ["LINGBOT_VA_DATASET_PATH"], "meta", "episodes_stats.jsonl")
+      with open(path) as f:
+          rows = [json.loads(line) for line in f]
+      for row in rows:
+          for key, stats in row.get("stats", {}).items():
+              if not key.startswith("observation.images."):
+                  continue
+              for stat_name, vec in stats.items():
+                  if isinstance(vec, list) and len(vec) == 3 and not isinstance(vec[0], list):
+                      stats[stat_name] = [[[v]] for v in vec]   # (3,) -> (3, 1, 1)
+      with open(path, "w") as f:
+          for row in rows:
+              f.write(json.dumps(row) + "\n")
+      PY
+
+   Optional smoke-test path: insert ``select_subset.py --src ... --dst ..._subset --per-task 10 --seed 42`` between (a) and (b), then point (b) and (c) at the ``_subset`` directory. Use it to validate the pipeline end-to-end before committing to a multi-hour 500-demo run.
+
+3. Expected layout under ``${LINGBOT_VA_DATASET_PATH}``::
+
+      meta/{info,episodes,episodes_stats,tasks}.jsonl
+      data/chunk-000/episode_NNNNNN.parquet
+      videos/chunk-000/observation.images.{agentview_rgb,eye_in_hand_rgb}/episode_NNNNNN.mp4
+      latents/chunk-000/observation.images.{agentview_rgb,eye_in_hand_rgb}/episode_NNNNNN_<s>_<e>.pth
+      empty_emb.pt
+
+
+Model and weight preparation
+----------------------------
+
+Download the LingBot-VA base checkpoint (Wan-Video 2.2 backbone, ~30 GB) into ``${LINGBOT_VA_MODEL_PATH}``. Expected layout::
+
+   ${LINGBOT_VA_MODEL_PATH}/
+   ├── transformer/                # 5B-param Wan transformer
+   │   ├── config.json
+   │   └── diffusion_pytorch_model-*.safetensors
+   ├── vae/                        # Wan 2.2 VAE (used by extract_latents.py)
+   └── text_encoder/               # UMT5 (only the empty-prompt embedding is
+                                     used at train time)
+
+Source: as provided in the original lingbot-va release notes.
+
+
+Key LingBot-VA config fields
+----------------------------
+
+The recipe in ``libero_sft_lingbotva.yaml`` mirrors lingbot-va's reference ``va_libero_train_cfg``. Load-bearing values:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Setting
+     - Value
+     - Why
+   * - ``cluster.num_nodes``
+     - ``1``
+     - Single-node, 8-GPU placement.
+   * - ``cluster.component_placement``
+     - ``actor,env,rollout: all``
+     - Co-locate all components across the 8 ranks (the rollout/env workers are unused at SFT time but the placement must still be set).
+   * - ``actor.fsdp_config.strategy``
+     - ``fsdp2``
+     - FSDP2 ``fully_shard`` is the lingbot-va reference. Full sharding gives the ~32 GB/GPU footprint that lets the 5B-param transformer + activations + plain-AdamW state fit on 80 GB.
+   * - ``actor.fsdp_config.reshard_after_forward``
+     - ``True``
+     - Free per-rank shards between forward and backward.
+   * - ``actor.fsdp_config.mixed_precision.param_dtype`` / ``reduce_dtype``
+     - ``bf16`` / ``fp32``
+     - bf16 compute with fp32 grad reduction matches the reference recipe.
+   * - ``actor.optim.optimizer_type``
+     - ``adamw``
+     - Plain ``torch.optim.AdamW``. The single-GPU recipe uses ``adamw_8bit`` (bitsandbytes) to fit on a 45 GB card; that hack is not needed on 80 GB ranks under FSDP2 and was dropped.
+   * - ``actor.optim.lr`` / ``betas`` / ``wd`` / ``lr_warmup_steps``
+     - ``1e-5`` / ``(0.9, 0.95)`` / ``0.1`` / ``10``
+     - Match the reference recipe.
+   * - ``actor.micro_batch_size``
+     - ``1``
+     - Reference recipe.
+   * - ``actor.global_batch_size``
+     - ``80``
+     - Effective batch 80 = micro 1 × world_size 8 × gradient_accumulation 10. Same effective batch as the single-A100 recipe (10 = 1 × 1 × 10).
+   * - ``actor.model.lingbotva.attn_mode``
+     - ``flex``
+     - Reference recipe; requires torch ≥ 2.9. ``attn_mode: torch`` silently drops the BlockMask and collapses eval SR to 0 %.
+   * - ``actor.model.lingbotva.cfg_prob``
+     - ``0.1``
+     - Classifier-free guidance dropout; reference recipe.
+   * - ``actor.model.precision``
+     - ``bf16``
+     - Transformer is loaded bf16 + force-cast (avoids fp32 leakage from ``scale_shift_table``).
+   * - ``data.num_workers``
+     - ``16``
+     - Reference recipe; data loading is only ~7 % of step time, so the dataloader is not the bottleneck.
+   * - ``runner.max_steps``
+     - ``3000``
+     - Reference run length.
+   * - ``runner.save_interval``
+     - ``500``
+     - Each save writes ``full_weights.pt`` (~9.5 GB) and a ``dcp_checkpoint/`` directory of sharded optimizer state (~28 GB), so a saved step costs ~38 GB on disk. If you only need eval-able weights, delete ``dcp_checkpoint/`` after each save and keep only ``full_weights.pt``.
+
+
+Launch training
+---------------
+
+Run from repository root:
+
+.. code:: bash
+
+   bash examples/sft/run_vla_sft.sh libero_sft_lingbotva
+
+.. _single-gpu-launch:
+
+Running on a single GPU
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The defaults assume 8 ranks. To run the same recipe on one GPU (L40-class, ≥45 GB), override four load-bearing fields on the launch CLI. Plain AdamW state for the 5B-param transformer is ~37 GB on its own — too large for a 45 GB card — so the single-GPU path swaps in bitsandbytes ``AdamW8bit`` and falls back to FSDP1 ``NO_SHARD`` (FSDP2 wraps params as DTensors that bnb's CUDA kernels reject):
+
+.. code:: bash
+
+   bash examples/sft/run_vla_sft.sh libero_sft_lingbotva \
+     actor.fsdp_config.strategy=fsdp \
+     actor.fsdp_config.sharding_strategy=no_shard \
+     actor.fsdp_config.use_orig_params=True \
+     actor.fsdp_config.reshard_after_forward=False \
+     actor.optim.optimizer_type=adamw_8bit \
+     actor.global_batch_size=10 \
+     data.num_workers=4 \
+     actor.dataloader_num_workers=4
+
+The ``global_batch_size=10`` override preserves the reference effective batch (world_size 1 × micro 1 × grad_accum 10). Verified steady-state throughput on an L40: ~17 s/step.
+
+
+Monitoring and sanity checks
+----------------------------
+
+1. Check ``run_embodiment.log``:
+
+   - stable ``time/step`` (~12.5 s/step on 8 × A100-80GB at effective batch 80)
+   - per-GPU memory ~32 GB; all 8 GPUs at 96–100 % util
+   - reasonable ``train/latent_loss`` and ``train/action_loss``
+
+2. Expected loss trajectory (5-step mean window around each saved step):
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 15 25 25 35
+
+      * - Step
+        - latent_loss
+        - action_loss
+        - grad_norm
+      * - 500
+        - ~0.120
+        - ~0.097
+        - ~0.077
+      * - 1000
+        - ~0.113
+        - ~0.087
+        - ~0.091
+      * - 1500
+        - ~0.103
+        - ~0.082
+        - ~0.111
+      * - 2000
+        - ~0.103
+        - ~0.082
+        - ~0.121
+
+   These are below the single-A100 reference at every step where the reference reports a number. The plateau between step 1500 and 2000 (``action_loss`` static at ~0.082) suggests near-convergence on training data. Values within ±25 % are within typical RNG noise (CFG dropout + flow-matching timestep sampling diverge across torch versions even at the same seed). Values >2× off the reference at the same step count indicate something is wrong with training; the most common cause is ``attn_mode: torch`` slipping back in via a stale config or YAML merge — verify the active config logs show ``attn_mode: flex``. (Low training loss with bad eval SR is usually an *evaluation*-side problem — see :ref:`Common issues <common-issues>`.)
+
+3. TensorBoard:
+
+   .. code:: bash
+
+      tensorboard --logdir ./logs --port 6006
+
+
+Evaluation
+----------
+
+Once ``checkpoints/global_step_2000/actor/model_state_dict/full_weights.pt`` exists, evaluate with the standard RLinf entry point using the ``libero_object_eval_lingbotva`` config. The SFT checkpoint is selected via ``LINGBOT_VA_TRANSFORMER_STATE_DICT_PATH``, and the 10 Libero-Object task ids are looped over via the Hydra CLI override ``env.eval.task_id_filter``.
+
+``examples/embodiment/eval_embodiment.sh`` dispatches the eval driver from the ``model_type`` key in the eval YAML: for LingBot-VA it runs ``examples/embodiment/eval_lingbotva.py``, a dedicated single-process driver. Do **not** invoke the generic ``eval_embodied_agent.py`` directly — it drops the per-step raw observations the model needs for KV-cache replay and silently collapses SR to ~0 %.
+
+Sequential form (one task at a time on a single GPU):
+
+.. code:: bash
+
+   CKPT_DIR=${REPO_PATH}/runtime/lingbotva_sft/libero_sft_lingbotva/checkpoints
+   export LINGBOT_VA_TRANSFORMER_STATE_DICT_PATH=\
+   ${CKPT_DIR}/global_step_2000/actor/model_state_dict/full_weights.pt
+   OUT_ROOT=${REPO_PATH}/runtime/lingbotva_libero_eval/ckpt_2000
+
+   for tid in 0 1 2 3 4 5 6 7 8 9; do
+     bash examples/embodiment/eval_embodiment.sh libero_object_eval_lingbotva LIBERO \
+       runner.logger.log_path=${OUT_ROOT}/task_${tid} \
+       env.eval.total_num_envs=1 \
+       env.eval.task_id_filter=[${tid}] \
+       algorithm.eval_rollout_epoch=5
+   done
+
+Do **not** just set ``total_num_envs=50`` — the env's reset-state cursor cycles reset states within a task, not tasks.
+
+Parallel form (one task per GPU, all 8 ranks at once):
+
+The eval driver is a plain single-process script (no Ray / no Cluster), so each task can be pinned to its own GPU. Peak per-process memory is ~39 GB (KV-cache replay accumulates per-chunk observations), so two tasks do **not** fit on one 80 GB card — co-locating OOMs mid-episode. For the 10 Libero-Object tasks, run tasks 0–7 in parallel across GPUs 0–7, then tasks 8–9 on any two free GPUs:
+
+.. code:: bash
+
+   for tid in 0 1 2 3 4 5 6 7; do
+     CUDA_VISIBLE_DEVICES=${tid} MUJOCO_EGL_DEVICE_ID=${tid} \
+       bash examples/embodiment/eval_embodiment.sh libero_object_eval_lingbotva LIBERO \
+         runner.logger.log_path=${OUT_ROOT}/task_${tid} \
+         env.eval.total_num_envs=1 \
+         env.eval.task_id_filter=[${tid}] \
+         algorithm.eval_rollout_epoch=5 &
+   done
+   wait
+
+   for tid in 8 9; do
+     gpu=$((tid - 8))
+     CUDA_VISIBLE_DEVICES=${gpu} MUJOCO_EGL_DEVICE_ID=${gpu} \
+       bash examples/embodiment/eval_embodiment.sh libero_object_eval_lingbotva LIBERO \
+         runner.logger.log_path=${OUT_ROOT}/task_${tid} \
+         env.eval.total_num_envs=1 \
+         env.eval.task_id_filter=[${tid}] \
+         algorithm.eval_rollout_epoch=5 &
+   done
+   wait
+
+``MUJOCO_EGL_DEVICE_ID`` must match ``CUDA_VISIBLE_DEVICES`` so the MuJoCo EGL renderer binds to the same physical GPU as the model.
+
+Baseline (sanity check):
+
+To confirm SFT is doing the work, evaluate the base LingBot-VA backbone (no Libero fine-tuning) by overriding the transformer state dict to null so the model uses the pretrained weights under ``LINGBOT_VA_MODEL_PATH``:
+
+.. code:: bash
+
+   unset LINGBOT_VA_TRANSFORMER_STATE_DICT_PATH
+   OUT_ROOT=${REPO_PATH}/runtime/lingbotva_libero_eval/base
+
+   for tid in 0 1 2 3 4 5 6 7 8 9; do
+     # Same per-task launcher as above, with one extra override:
+     #   actor.model.lingbotva.transformer_state_dict_path=null
+     ...
+   done
+
+The base model is expected to score 0/50 — its backbone has not seen the Libero action distribution and every episode runs to the 240-step cap.
+
+Verified results (per task, 5 episodes each):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - Task
+     - Base (no SFT)
+     - SFT ckpt_2000
+   * - 0
+     - 0/5
+     - 3/5
+   * - 1
+     - 0/5
+     - 4/5
+   * - 2
+     - 0/5
+     - 5/5
+   * - 3
+     - 0/5
+     - 1/5
+   * - 4
+     - 0/5
+     - 4/5
+   * - 5
+     - 0/5
+     - 3/5
+   * - 6
+     - 0/5
+     - 5/5
+   * - 7
+     - 0/5
+     - 3/5
+   * - 8
+     - 0/5
+     - 4/5
+   * - 9
+     - 0/5
+     - 3/5
+   * - **Mean**
+     - **0/50 (0 %)**
+     - **35/50 (70 %)**
+
+Per-task SR is read from ``<out_dir>/task_<tid>/eval_results.json`` (each file records ``success_rate``, ``successes``, ``failures``). Reproducing within ±1 episode per task at the same seed is normal; >2 episodes off at any task usually means a stale checkpoint, the wrong eval driver, or a CPU/EGL device-id mismatch under the parallel form.
+
+
+.. _common-issues:
+
+Common issues
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 30 35
+
+   * - Symptom
+     - Likely cause
+     - Fix
+   * - ``Could not load 'model/lingbotva'`` at launch
+     - ``model/lingbotva.yaml`` not in the SFT hydra search path
+     - Symlink ``examples/embodiment/config/model/lingbotva.yaml`` into ``examples/sft/config/model/`` (Environment step 7).
+   * - Ray claims more GPUs than ``CUDA_VISIBLE_DEVICES`` exposes
+     - ``component_placement: actor,env,rollout: all`` scans every visible GPU and ignores ``CUDA_VISIBLE_DEVICES``
+     - Pin the placement (e.g. ``actor,env,rollout: '0-7'``) or launch in a cgroup/container that masks the unwanted GPUs.
+   * - ``NameError: name 's10' is not defined`` during forward
+     - torch < 2.9 ``flex_attention`` codegen bug
+     - Upgrade to torch 2.9. Do **not** fall back to ``attn_mode: torch``.
+   * - 0 % SR at every task despite low training loss
+     - Wrong eval driver — the generic ``eval_embodied_agent.py`` drops per-step raw observations, so the model's ``record_chunk_observations`` / KV-cache replay path never sees the post-action frames it needs
+     - Launch with ``bash examples/embodiment/eval_embodiment.sh ...``; the dispatcher reads ``model_type`` from the eval YAML and routes LingBot-VA to ``eval_lingbotva.py``. Do not invoke the generic driver directly. (Eval-time ``attn_mode: torch`` is fine — overriding it on the eval CLI is not necessary.)
+   * - 0 % SR even with ``eval_lingbotva.py``
+     - SDPA mask leak at *training* time — the SFT run used ``attn_mode: torch`` and the BlockMask was silently dropped
+     - Confirm the active *training* config logs show ``attn_mode: flex``; if not, retrain. (The eval-time attn_mode is independent and does not need to be flex.)
+   * - ``ImportError: cannot import name 'flash_attn_func'``
+     - torch 2.9 ABI breaks the flash_attn wheel
+     - Apply the patch under "Environment" step 6.
+   * - FSDP "flatten tensors with uniform dtype" error
+     - ``scale_shift_table`` initialised fp32
+     - Confirm ``precision: bf16`` is set and the transformer is force-cast to bf16 (already wired in the action model).
+   * - Out-of-disk while training
+     - ~38 GB per saved step (``full_weights.pt`` + ``dcp_checkpoint/``)
+     - Either raise ``save_interval`` (500 → 1000) or delete ``dcp_checkpoint/`` after each save if you only need eval-able weights.
+   * - ``lerobot`` rejects dataset on first batch
+     - ``episodes_stats.jsonl`` has per-channel image stats as ``(3,)`` instead of ``(3, 1, 1)``
+     - Run the reshape step (Data preparation step 2c).
+   * - Mysterious torch / nccl / cudnn downgrade after dependency installs
+     - ``lerobot==0.3.3`` pulls a transitive torch downgrade
+     - Re-run the torch 2.9.0+cu126 install (Environment step 1) after lerobot.
+
+
+Practical recommendations
+-------------------------
+
+- Run a short trial (e.g. 50–100 steps) after each config change to verify shapes, loss values, and throughput before committing to a multi-hour run. The optional 100-demo subset (Data preparation step 2, smoke-test path) makes this cheap.
+- The 8-GPU recipe is the verified-good path. The single-GPU launch (:ref:`single-gpu-launch`) drops to FSDP1 + bnb ``AdamW8bit`` to fit on a 45 GB card and is otherwise equivalent; use it for L40-class smoke tests only.
+- The forward/backward is compute-bound and scales close to linearly across the 8 ranks, since data loading is only ~7 % of step time.
+- Disk pressure is the most likely surprise: budget ~38 GB per saved step at the reference ``save_interval``, or wire a background cleaner that strips ``dcp_checkpoint/`` immediately after each save if you do not need to resume training.

--- a/examples/embodiment/config/libero_object_eval_lingbotva.yaml
+++ b/examples/embodiment/config/libero_object_eval_lingbotva.yaml
@@ -1,0 +1,187 @@
+defaults:
+  - env/libero_object@env.train
+  - env/libero_object@env.eval
+  - model/lingbotva@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - weight_syncer/patch_syncer@weight_syncer
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: all
+
+runner:
+  task_type: embodied
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_object_eval_lingbotva"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 1
+  max_steps: -1
+
+  only_eval: True
+  val_check_interval: -1
+  save_interval: -1
+
+  resume_dir: null
+  ckpt_path: null
+
+algorithm:
+  normalize_advantages: True
+  kl_penalty: kl
+  group_size: 1
+  rollout_epoch: 1
+  eval_rollout_epoch: 1
+
+  reward_type: action_level
+  logprob_type: token_level
+  entropy_type: token_level
+
+  adv_type: grpo
+  loss_type: actor
+  loss_agg_func: "token-mean"
+  kl_beta: 0.0
+  entropy_bonus: 0
+  clip_ratio_high: 0.28
+  clip_ratio_low: 0.2
+  clip_ratio_c: 3.0
+  value_clip: 0.2
+  huber_delta: 10.0
+
+  gamma: 0.99
+  gae_lambda: 0.95
+
+  reward_coef: 1.0
+  filter_rewards: False
+  rewards_lower_bound: 0.5
+  rewards_upper_bound: 4.5
+
+  sampling_params:
+    do_sample: False
+    temperature_train: 1.0
+    temperature_eval: -1
+    top_k: -1
+    top_p: 1.0
+    repetition_penalty: 1.0
+
+  length_params:
+    max_new_token: null
+    max_length: 512
+    min_length: 1
+
+env:
+  group_name: "EnvGroup"
+
+  train:
+    total_num_envs: 1
+    group_size: 1
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 240
+    reset_gripper_open: True
+    use_fixed_reset_state_ids: True
+    use_ordered_reset_state_ids: False
+
+  eval:
+    total_num_envs: 4
+    auto_reset: True
+    # Keep terminations live so success-on-task immediately ends the episode;
+    # the LingBot-VA Libero policy can drop the object if it keeps moving past
+    # the success boundary, which would otherwise produce false negatives.
+    ignore_terminations: False
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 240
+    group_size: 1
+    use_fixed_reset_state_ids: True
+    use_ordered_reset_state_ids: True
+    reset_gripper_open: True
+    is_eval: True
+    # Restrict eval to a subset of libero_object task ids (0..9). null = all
+    # ten tasks. Override per-task from the CLI, e.g.
+    #   bash examples/embodiment/eval_embodiment.sh libero_object_eval_lingbotva \
+    #       LIBERO env.eval.task_id_filter=[3]
+    task_id_filter: null
+    init_params:
+      camera_heights: 128
+      camera_widths: 128
+    video_cfg:
+      save_video: True
+      info_on_video: True
+      video_base_dir: ${runner.logger.log_path}/video/eval
+
+rollout:
+  group_name: "RolloutGroup"
+  generation_backend: "huggingface"
+  enable_offload: False
+  pipeline_stage_num: 1
+
+  model:
+    model_type: lingbotva
+    model_path: ${actor.model.model_path}
+    precision: ${actor.model.precision}
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 1
+  global_batch_size: 1
+  seed: 1234
+  enable_offload: False
+
+  model:
+    model_type: lingbotva
+    model_path: ${oc.env:LINGBOT_VA_MODEL_PATH}
+    precision: bf16
+    # SFT trains with num_action_chunks=12; eval uses 16 to match the
+    # verified per-task SR baseline. The model can predict an arbitrary
+    # number of chunks per inference call.
+    num_action_chunks: 16
+    action_dim: 7
+    lingbotva:
+      repo_path: ${oc.env:LINGBOT_VA_REPO_PATH}
+      config_name: libero
+      enable_offload: false
+      action_per_frame: 4
+      # Optional override for the transformer weights — e.g. an SFT checkpoint
+      # at .../checkpoints/global_step_N/actor/model_state_dict/full_weights.pt.
+      # Set via env var LINGBOT_VA_TRANSFORMER_STATE_DICT_PATH (default: null
+      # = use the transformer shipped under ${actor.model.model_path}).
+      transformer_state_dict_path: ${oc.env:LINGBOT_VA_TRANSFORMER_STATE_DICT_PATH,null}
+      save_root: ./runtime/lingbotva
+      # Cross-chunk KV-cache replay. Eval relies on the per-chunk
+      # record_chunk_observations / reset_episode hooks driven by
+      # eval_lingbotva.py; without this the model loses its inter-chunk
+      # memory and SR collapses to ~0%.
+      enable_kv_cache_replay: True
+
+  optim:
+    lr: 5.0e-05
+    value_lr: 1.0e-05
+    adam_beta1: 0.9
+    adam_beta2: 0.999
+    adam_eps: 1.0e-05
+    weight_decay: 0.01
+    clip_grad: 1.0
+
+  fsdp_config:
+    strategy: "fsdp"
+    gradient_checkpointing: False
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+
+reward:
+  use_reward_model: False
+
+critic:
+  use_critic_model: False

--- a/examples/embodiment/config/model/lingbotva.yaml
+++ b/examples/embodiment/config/model/lingbotva.yaml
@@ -1,0 +1,25 @@
+model_type: lingbotva
+model_path: ${oc.env:LINGBOT_VA_MODEL_PATH}
+precision: bf16
+num_action_chunks: 12
+action_dim: 7
+is_lora: false
+lora_rank: 4
+lora_path: null
+lingbotva:
+  repo_path: ${oc.env:LINGBOT_VA_REPO_PATH}
+  config_name: libero
+  enable_offload: false
+  action_per_frame: 4
+  transformer_state_dict_path: ${oc.env:LINGBOT_VA_TRANSFORMER_STATE_DICT_PATH,null}
+  save_root: ./runtime/lingbotva
+  # SFT-only knobs (ignored by the eval path).
+  training_mode: false
+  cfg_prob: 0.1
+  empty_emb_path: null
+  # Attention backend for the transformer at load time. Eval uses "torch"
+  # (SDPA) — the per-step inference loop is not compatible with
+  # flex_attention's block-mask layout. SFT can use "flex" on torch>=2.9
+  # to match the reference recipe; on older torch the SFT YAML overrides
+  # to "torch" to dodge the flex_attention+inductor codegen bug.
+  attn_mode: torch

--- a/examples/embodiment/eval_embodiment.sh
+++ b/examples/embodiment/eval_embodiment.sh
@@ -2,10 +2,14 @@
 
 export EMBODIED_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export REPO_PATH=$(dirname $(dirname "$EMBODIED_PATH"))
+# Default driver. Overridden below per actor.model.model_type so that
+# policies which maintain inter-chunk state (e.g. LingBot-VA's KV-cache
+# replay) can use their dedicated single-process driver. See
+# eval_lingbotva.py for the reasoning.
 export SRC_FILE="${EMBODIED_PATH}/eval_embodied_agent.py"
 
-export MUJOCO_GL="osmesa"
-export PYOPENGL_PLATFORM="osmesa"
+export MUJOCO_GL="${MUJOCO_GL:-osmesa}"
+export PYOPENGL_PLATFORM="${PYOPENGL_PLATFORM:-osmesa}"
 export PYTHONPATH=${REPO_PATH}:$PYTHONPATH
 
 # Base path to the BEHAVIOR dataset, which is the BEHAVIOR-1k repo's dataset folder
@@ -34,6 +38,27 @@ else
     CONFIG_NAME=$1
 fi
 
+# Select eval driver based on actor.model.model_type in the config YAML.
+# Most policies use the generic, multi-worker eval_embodied_agent.py.
+# Policies that need inter-chunk model state (KV-cache replay, episode
+# buffers) need a dedicated driver that captures per-step raw obs and
+# calls their record_chunk_observations / reset_episode hooks. To opt in,
+# add a top-level "model_type:" key matching the policy name and provide
+# a per-policy driver file (eval_<model_type>.py).
+CONFIG_FILE="${EMBODIED_PATH}/config/${CONFIG_NAME}.yaml"
+if [ -f "${CONFIG_FILE}" ]; then
+    MODEL_TYPE=$(awk -F':' '/^[[:space:]]*model_type:/ {gsub(/[[:space:]"'\'',]/,"",$2); print $2; exit}' "${CONFIG_FILE}")
+fi
+case "${MODEL_TYPE}" in
+    lingbotva)
+        CANDIDATE="${EMBODIED_PATH}/eval_lingbotva.py"
+        if [ -f "${CANDIDATE}" ]; then
+            SRC_FILE="${CANDIDATE}"
+        fi
+        ;;
+esac
+echo "Eval driver: ${SRC_FILE} (model_type=${MODEL_TYPE:-unknown})"
+
 # NOTE: Set the active robot platform (required for correct action dimension and normalization), supported platforms are LIBERO, ALOHA, BRIDGE, default is LIBERO
 ROBOT_PLATFORM=${2:-${ROBOT_PLATFORM:-"LIBERO"}}
 
@@ -56,6 +81,12 @@ echo "Using ROBOT_PLATFORM=$ROBOT_PLATFORM"
 LOG_DIR="${REPO_PATH}/logs/$(date +'%Y%m%d-%H:%M:%S')-${CONFIG_NAME}" #/$(date +'%Y%m%d-%H:%M:%S')"
 MEGA_LOG_FILE="${LOG_DIR}/eval_embodiment.log"
 mkdir -p "${LOG_DIR}"
-CMD="python ${SRC_FILE} --config-path ${EMBODIED_PATH}/config/ --config-name ${CONFIG_NAME} runner.logger.log_path=${LOG_DIR}"
-echo ${CMD}
-${CMD} 2>&1 | tee ${MEGA_LOG_FILE}
+# Forward any extra positional args ($3..$N) as Hydra overrides so callers
+# can do e.g. `bash eval_embodiment.sh <cfg> <platform> env.eval.task_id_filter=[3]`.
+shift $(( $# >= 2 ? 2 : $# ))
+echo "python ${SRC_FILE} --config-path ${EMBODIED_PATH}/config/ --config-name ${CONFIG_NAME} runner.logger.log_path=${LOG_DIR} $*"
+python "${SRC_FILE}" \
+    --config-path "${EMBODIED_PATH}/config/" \
+    --config-name "${CONFIG_NAME}" \
+    runner.logger.log_path="${LOG_DIR}" \
+    "$@" 2>&1 | tee "${MEGA_LOG_FILE}"

--- a/examples/embodiment/eval_lingbotva.py
+++ b/examples/embodiment/eval_lingbotva.py
@@ -1,0 +1,229 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hydra-driven evaluation driver for LingBot-VA on Libero-Object.
+
+A separate driver exists because LingBot-VA's action model maintains
+inter-chunk state (KV-cache replay on per-step raw observations). The
+generic eval path in ``eval_embodied_agent.py`` routes obs through
+``MultiStepRolloutWorker``, which keeps only the last step's wrapped obs
+from each chunk and drops the per-step raw obs the model needs to call
+``record_chunk_observations``. Running LingBot-VA through that path
+silently collapses success rate to ~0%.
+
+``eval_embodiment.sh`` dispatches here whenever
+``actor.model.model_type == "lingbotva"``; every other policy continues
+to go through ``eval_embodied_agent.py``.
+
+Model hooks consumed (defined on ``LingbotVALiberoActionModel``):
+  - ``model.enable_kv_cache_replay`` — gates the recorder loop
+  - ``model.record_chunk_observations(env_idx, chunk_obs_list, prev_model_action)``
+  - ``model.reset_episode(env_idx)`` on termination
+  - ``model._episode_states[env_idx].prev_model_action`` carried across chunks
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import hydra
+import numpy as np
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+from rlinf.envs.libero.libero_env import LiberoEnv
+from rlinf.models import get_model
+
+
+def _build_libero_env(cfg: DictConfig) -> LiberoEnv:
+    eval_cfg = cfg.env.eval
+    return LiberoEnv(
+        cfg=eval_cfg,
+        num_envs=int(eval_cfg.total_num_envs),
+        seed_offset=0,
+        total_num_processes=1,
+        worker_info=None,
+    )
+
+
+def _chunk_step_with_obs(env: LiberoEnv, chunk_actions: np.ndarray):
+    """Step the env chunk_size actions and capture per-step raw obs per env.
+
+    LiberoEnv.chunk_step does the same internally but only exposes the last
+    step's obs to callers; the model needs the full per-step history to
+    rebuild its KV cache. Duplicating the inner loop here is the cost of
+    keeping LiberoEnv.chunk_step generic.
+    """
+    num_envs, chunk_size, _ = chunk_actions.shape
+    raw_obs_history: list[list[dict]] = [[] for _ in range(num_envs)]
+    obs_list = []
+    rewards = []
+    terms = []
+    truncs = []
+    for i in range(chunk_size):
+        action = chunk_actions[:, i]
+        wrapped, r, t, tr, _ = env.step(action, auto_reset=False)
+        for env_idx in range(num_envs):
+            raw_obs_history[env_idx].append(env.current_raw_obs[env_idx])
+        obs_list.append(wrapped)
+        rewards.append(r)
+        terms.append(t)
+        truncs.append(tr)
+    rewards = torch.stack(rewards, dim=1)
+    terms = torch.stack(terms, dim=1)
+    truncs = torch.stack(truncs, dim=1)
+    past_dones = (terms | truncs).any(dim=1)
+    if past_dones.any() and env.auto_reset:
+        obs_list[-1], _ = env._handle_auto_reset(
+            past_dones.cpu().numpy(), obs_list[-1], {}
+        )
+    return obs_list[-1], rewards, terms, truncs, raw_obs_history, past_dones
+
+
+def _evaluate(
+    model: torch.nn.Module,
+    env: LiberoEnv,
+    num_episodes: int,
+) -> dict:
+    print("[eval_lingbotva] resetting env...", flush=True)
+    obs, _ = env.reset()
+    print("[eval_lingbotva] env reset complete", flush=True)
+    total_steps = 0
+    total_episodes_done = 0
+    successes = 0
+    failures = 0
+    task_stats: dict[int, dict[str, int]] = {}
+    cur_episode_task_ids = list(env.task_ids.copy())
+
+    target_total_episodes = num_episodes
+    max_steps_safety = num_episodes * 260
+
+    chunk_idx = 0
+    enable_kv_replay = getattr(model, "enable_kv_cache_replay", False)
+    while (
+        total_episodes_done < target_total_episodes
+        and total_steps < max_steps_safety
+    ):
+        t0 = time.time()
+        action_tensor, _ = model.predict_action_batch(obs, mode="eval")
+        infer_sec = time.time() - t0
+
+        t1 = time.time()
+        chunk_actions = action_tensor.detach().cpu().numpy()
+        (
+            final_obs,
+            rewards,
+            chunk_terminations,
+            chunk_truncations,
+            raw_obs_history,
+            past_dones,
+        ) = _chunk_step_with_obs(env, chunk_actions)
+        step_sec = time.time() - t1
+
+        successes_this_chunk = chunk_terminations.any(dim=1)
+        for env_idx in range(past_dones.shape[0]):
+            if past_dones[env_idx].item():
+                task_id = int(cur_episode_task_ids[env_idx])
+                stats = task_stats.setdefault(
+                    task_id, {"success": 0, "total": 0}
+                )
+                stats["total"] += 1
+                if successes_this_chunk[env_idx].item():
+                    stats["success"] += 1
+                    successes += 1
+                else:
+                    failures += 1
+                total_episodes_done += 1
+                cur_episode_task_ids[env_idx] = int(env.task_ids[env_idx])
+                if hasattr(model, "reset_episode"):
+                    model.reset_episode(env_idx)
+            elif enable_kv_replay:
+                state = model._episode_states.get(env_idx)
+                if state is not None and state.prev_model_action is not None:
+                    model.record_chunk_observations(
+                        env_idx=env_idx,
+                        chunk_obs_list=raw_obs_history[env_idx],
+                        prev_model_action=state.prev_model_action,
+                    )
+        obs = final_obs
+        total_steps += chunk_actions.shape[1]
+        chunk_idx += 1
+        print(
+            f"  chunk={chunk_idx:3d} step={total_steps:4d} "
+            f"infer={infer_sec:6.2f}s env={step_sec:5.2f}s "
+            f"episodes={total_episodes_done} succ={successes} fail={failures}",
+            flush=True,
+        )
+
+    total = successes + failures
+    success_rate = successes / total if total > 0 else 0.0
+    return {
+        "success_rate": success_rate,
+        "successes": successes,
+        "failures": failures,
+        "task_stats": {
+            tid: {
+                **stats,
+                "rate": stats["success"] / stats["total"]
+                if stats["total"]
+                else 0.0,
+            }
+            for tid, stats in task_stats.items()
+        },
+    }
+
+
+@hydra.main(
+    version_base="1.1",
+    config_path="config",
+    config_name="libero_object_eval_lingbotva",
+)
+def main(cfg: DictConfig) -> None:
+    if str(cfg.actor.model.model_type) != "lingbotva":
+        raise ValueError(
+            f"eval_lingbotva.py expects actor.model.model_type=lingbotva, "
+            f"got {cfg.actor.model.model_type!r}. Use eval_embodied_agent.py "
+            "for other policies."
+        )
+
+    cfg.runner.only_eval = True
+    print(json.dumps(OmegaConf.to_container(cfg, resolve=True), indent=2))
+
+    num_envs = int(cfg.env.eval.total_num_envs)
+    rollout_epoch = int(cfg.algorithm.eval_rollout_epoch)
+    num_episodes = num_envs * rollout_epoch
+
+    env = _build_libero_env(cfg)
+    model = get_model(cfg.actor.model)
+    if model is None:
+        raise RuntimeError(
+            f"Failed to build model of type {cfg.actor.model.model_type}"
+        )
+
+    t0 = time.time()
+    metrics = _evaluate(model, env, num_episodes=num_episodes)
+    metrics["elapsed_sec"] = time.time() - t0
+    metrics["num_envs"] = num_envs
+    metrics["num_episodes"] = num_episodes
+
+    out_dir = Path(cfg.runner.logger.log_path)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "eval_results.json").write_text(json.dumps(metrics, indent=2))
+    print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sft/config/libero_sft_lingbotva.yaml
+++ b/examples/sft/config/libero_sft_lingbotva.yaml
@@ -1,0 +1,181 @@
+# SFT training of LingBot-VA on Libero-Object.
+#
+# Verified setup: single node, 8 x NVIDIA A100-80GB. Matches the lingbot-va
+# reference `va_libero_train_cfg`:
+#   lr=1e-5, betas=(0.9, 0.95), wd=1e-1, micro=1 x grad_accum=10 x ws=8
+#   (effective batch 80), plain torch.optim.AdamW, FSDP2 full-shard,
+#   activation checkpointing, bf16 params + fp32 grad reduction,
+#   attn_mode=flex, cfg_prob=0.1, 3000 steps.
+# Steady-state throughput ~12.5 s/step, ~32 GB/GPU.
+#
+# Prerequisites (run before launching this config):
+#   1. Download yifengzhu-hf/LIBERO-datasets (NOT IPEC-COMMUNITY) HDF5 files.
+#   2. Convert HDF5 -> LeRobot v2.1 via
+#      toolkits/data_scripts_lingbotva/convert_libero_object_to_lerobot.py.
+#   3. Extract Wan2.2 VAE latents + UMT5 empty embedding via
+#      toolkits/data_scripts_lingbotva/extract_latents.py.
+#   4. Reshape episodes_stats.jsonl image stats from (3,) to (3, 1, 1).
+# The resulting directory becomes ${LINGBOT_VA_DATASET_PATH}. See
+# docs/source-en/rst_source/examples/embodied/sft_lingbotva.rst for the full
+# walkthrough.
+#
+# Load-bearing knobs:
+#   * fsdp_config.strategy: fsdp2 + sharding_strategy: full_shard
+#       Each rank holds 1/8 of the params/grads/opt-state, which is what
+#       lets the 5B-param transformer + activations + plain-AdamW optimizer
+#       state fit at ~32 GB/GPU on 80 GB ranks.
+#   * optim.optimizer_type: adamw
+#       Plain torch.optim.AdamW. (Only the single-GPU override below uses
+#       bitsandbytes adamw_8bit, and only because 45 GB cards cannot hold
+#       fp32 optimizer state for a 5B-param transformer.)
+#   * global_batch_size: 80
+#       global_batch_size / (micro_batch_size * world_size) = grad_accum,
+#       so 80 / (1 * 8) = 10. Adjust together with world_size to keep
+#       grad_accum = 10 and the same effective batch as the reference.
+#   * lingbotva.attn_mode: flex
+#       Reference recipe (flex_attention with BlockMask enforcing the
+#       chunk/window/noise-typed attention pattern). Requires torch >= 2.9 —
+#       earlier versions hit a flex_attention + inductor codegen bug
+#       ("NameError: name 's10' is not defined"). attn_mode: torch (SDPA) is
+#       NOT a valid fallback: SDPA silently drops the BlockMask, leaking
+#       clean ground-truth tokens to noisy queries at training time, which
+#       collapses eval SR to 0%.
+#   * precision: bf16 + mixed_precision.reduce_dtype: fp32
+#       Reference recipe. The transformer is loaded bf16 + force-cast to
+#       avoid fp32 leakage from scale_shift_table (would trip FSDP's
+#       mixed-dtype check).
+#
+# ---------------------------------------------------------------------------
+# Running on a single GPU (L40-class, >=45 GB)
+# ---------------------------------------------------------------------------
+# The 8-GPU recipe above does not fit on one 45-80 GB rank because plain
+# AdamW state alone is ~37 GB for the 5B-param transformer. To run the
+# same recipe on a single GPU, override the four load-bearing knobs at
+# launch via Hydra CLI overrides:
+#
+#   bash examples/sft/run_vla_sft.sh libero_sft_lingbotva \
+#     actor.fsdp_config.strategy=fsdp \
+#     actor.fsdp_config.sharding_strategy=no_shard \
+#     actor.fsdp_config.use_orig_params=True \
+#     actor.fsdp_config.reshard_after_forward=False \
+#     actor.optim.optimizer_type=adamw_8bit \
+#     actor.global_batch_size=10 \
+#     data.num_workers=4 \
+#     actor.dataloader_num_workers=4
+#
+# Why these overrides:
+#   * FSDP1 + no_shard + use_orig_params: FSDP2's `fully_shard` wraps
+#     parameters as DTensors even at world_size=1, which crashes
+#     bitsandbytes.AdamW8bit. FSDP1 + NO_SHARD + use_orig_params keeps
+#     parameters as plain Tensors that bnb's CUDA kernels accept.
+#   * adamw_8bit: required to fit optimizer state on a 45 GB card.
+#   * global_batch_size=10: world_size=1, micro=1 -> grad_accum=10,
+#     preserving the reference effective batch.
+#
+# Single-GPU verified throughput: ~17 s/step on an L40 (45 GB). Also set
+# PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True in the launch shell
+# (run_vla_sft.sh already exports this) — without it the allocator
+# fragments and OOMs during model wrap or first forward.
+defaults:
+  - model/lingbotva@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: all
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_sft_lingbotva"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: -1
+  max_steps: 3000
+  val_check_interval: -1
+  # Each save writes full_weights.pt (~9.5 GB) and a dcp_checkpoint/ dir of
+  # sharded optimizer state (~28 GB), so a saved step costs ~38 GB on disk.
+  # If you only need eval-able weights, strip dcp_checkpoint/ after each save.
+  save_interval: 500
+  log_interval: 1
+
+data:
+  train_data_paths: ${oc.env:LINGBOT_VA_DATASET_PATH}
+  num_workers: 16
+  prefetch_factor: 2
+
+algorithm:
+  adv_type: gae
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 1
+  # global_batch_size / (micro_batch_size * world_size) = grad_accum.
+  # ws=8, micro=1 -> global=80 gives grad_accum=10, matching the
+  # reference effective batch. Override to 10 for single-GPU launches
+  # (see the "Running on a single GPU" section in the header).
+  global_batch_size: 80
+  seed: 42
+  dataloader_num_workers: 16
+  enable_offload: False
+
+  model:
+    model_type: "lingbotva"
+    precision: bf16
+    model_path: ${oc.env:LINGBOT_VA_MODEL_PATH}
+    num_action_chunks: 12
+    action_dim: 7
+    is_lora: False
+    add_value_head: False
+    lingbotva:
+      repo_path: ${oc.env:LINGBOT_VA_REPO_PATH}
+      config_name: libero
+      training_mode: true
+      enable_offload: false
+      action_per_frame: 4
+      transformer_state_dict_path: ${oc.env:LINGBOT_VA_TRANSFORMER_STATE_DICT_PATH,null}
+      empty_emb_path: ${oc.env:LINGBOT_VA_EMPTY_EMB_PATH,null}
+      cfg_prob: 0.1
+      attn_mode: flex
+      save_root: ./runtime/lingbotva_sft
+
+  optim:
+    lr: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 1.0e-1
+    clip_grad: 2.0
+    optimizer_type: adamw
+    lr_scheduler: constant
+    lr_warmup_steps: 10
+    total_training_steps: 3000
+
+  fsdp_config:
+    strategy: "fsdp2"
+    sharding_strategy: "full_shard"
+    use_orig_params: False
+    gradient_checkpointing: True
+    limit_all_gathers: True
+    reshard_after_forward: True
+    grad_scaler:
+      enabled: False
+    mixed_precision:
+      param_dtype: bf16
+      reduce_dtype: fp32
+      buffer_dtype: bf16
+    amp_autocast:
+      enabled: false
+      precision: "bf16"

--- a/examples/sft/run_vla_sft.sh
+++ b/examples/sft/run_vla_sft.sh
@@ -12,6 +12,16 @@ export PYTHONPATH=${REPO_PATH}:${LIBERO_REPO_PATH}:$PYTHONPATH
 export DREAMZERO_PATH=${DREAMZERO_PATH:-"/path/to/DreamZero"}
 export PYTHONPATH=${DREAMZERO_PATH}:$PYTHONPATH
 
+export LINGBOT_VA_REPO_PATH=${LINGBOT_VA_REPO_PATH:-"/path/to/lingbot-va"}
+export LINGBOT_VA_MODEL_PATH=${LINGBOT_VA_MODEL_PATH:-"/path/to/lingbot-va-base"}
+export LINGBOT_VA_DATASET_PATH=${LINGBOT_VA_DATASET_PATH:-"/path/to/libero-data"}
+export PYTHONPATH=${LINGBOT_VA_REPO_PATH}:$PYTHONPATH
+
+# Required by the 5B-param transformer to fit alongside activations on a
+# single GPU; without this the allocator fragments and OOMs during model
+# wrap or first forward.
+export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-"expandable_segments:True"}
+
 if [ -z "$1" ]; then
     CONFIG_NAME="maniskill_ppo_openvlaoft"
 else

--- a/requirements/embodied/models/lingbotva.txt
+++ b/requirements/embodied/models/lingbotva.txt
@@ -1,0 +1,9 @@
+# Extra Python dependencies for the LingBot-VA (Wan-Video VLA) integration.
+#
+# The model code itself lives in the lingbot-va peer repo and must be
+# installed separately via:
+#   pip install -e ${LINGBOT_VA_REPO_PATH}
+#
+bitsandbytes>=0.43,<0.46
+einops
+safetensors

--- a/requirements/install.sh
+++ b/requirements/install.sh
@@ -74,7 +74,7 @@ GITHUB_PREFIX=""
 NO_ROOT=0
 NO_INSTALL_RLINF_CMD="--no-install-project"
 SUPPORTED_TARGETS=("embodied" "agentic" "docs")
-SUPPORTED_MODELS=("openvla" "openvla-oft" "openpi" "gr00t" "dexbotic" "starvla" "lingbotvla" "dreamzero" "qwen3_vl")
+SUPPORTED_MODELS=("openvla" "openvla-oft" "openpi" "gr00t" "dexbotic" "starvla" "lingbotvla" "lingbotva" "dreamzero" "qwen3_vl")
 SUPPORTED_ENVS=("behavior" "maniskill_libero" "libero" "metaworld" "calvin" "isaaclab" "robocasa" "franka" "franka-dexhand" "frankasim" "robotwin" "habitat" "opensora" "wan" "xsquare_turtle2" "liberopro" "liberoplus" "roboverse" "embodichain" "d4rl" "dosw1" "gim_arm" "dummy")
 
 #=======================Utility Functions=======================
@@ -1264,6 +1264,28 @@ install_dreamzero_model() {
     esac
 }
 
+install_lingbot_va_model() {
+    create_and_sync_venv
+    install_common_embodied_deps
+    local lingbotva_dir
+    lingbotva_dir=$(clone_or_reuse_repo LINGBOT_VA_REPO_PATH "$VENV_DIR/lingbot-va" ${GITHUB_PREFIX}https://github.com/robbyant/lingbot-va.git)
+    uv pip install -e "$lingbotva_dir"
+    uv pip install -r $SCRIPT_DIR/embodied/models/lingbotva.txt
+    case "$ENV_NAME" in
+        libero|maniskill_libero)
+            install_${ENV_NAME}_env
+            install_flash_attn
+            ;;
+        "")
+            install_flash_attn
+            ;;
+        *)
+            echo "Environment '$ENV_NAME' is not supported for LingBot-VA model." >&2
+            exit 1
+            ;;
+    esac
+}
+
 install_qwen3_vl_model() {
     create_and_sync_venv
     install_common_embodied_deps
@@ -1812,8 +1834,11 @@ main() {
                 dexbotic)
                     install_dexbotic_model
                     ;;
-                lingbotvla)                  
-                    install_lingbot_vla_model 
+                lingbotvla)
+                    install_lingbot_vla_model
+                    ;;
+                lingbotva)
+                    install_lingbot_va_model
                     ;;
                 dreamzero)
                     install_dreamzero_model

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -96,6 +96,7 @@ SupportedModel.CNN_POLICY = SupportedModel.register("cnn_policy", force=True)
 SupportedModel.FLOW_POLICY = SupportedModel.register("flow_policy", force=True)
 SupportedModel.CMA_POLICY = SupportedModel.register("cma", force=True)
 SupportedModel.LINGBOTVLA = SupportedModel.register("lingbotvla", force=True)
+SupportedModel.LINGBOTVA = SupportedModel.register("lingbotva", force=True)
 SupportedModel.RESNET_REWARD = SupportedModel.register("resnet", force=True)
 SupportedModel.CFG_MODEL = SupportedModel.register("cfg_model", force=True)
 SupportedModel.VALUE_MODEL = SupportedModel.register("value_model", force=True)
@@ -119,6 +120,7 @@ EMBODIED_MODEL = set(
         SupportedModel.FLOW_POLICY,
         SupportedModel.CMA_POLICY,
         SupportedModel.LINGBOTVLA,
+        SupportedModel.LINGBOTVA,
         SupportedModel.RESNET_REWARD,
         SupportedModel.CFG_MODEL,
         SupportedModel.VALUE_MODEL,

--- a/rlinf/data/datasets/lingbotva.py
+++ b/rlinf/data/datasets/lingbotva.py
@@ -1,0 +1,193 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LingBot-VA SFT dataloader builder for the Libero suite.
+
+Wraps lingbot-va's ``MultiLatentLeRobotDataset`` (which reads pre-extracted
+video latents + cached UMT5 text embeddings) and feeds it through a standard
+PyTorch ``DataLoader`` so that RLinf's ``FSDPVlaSftWorker`` can consume it
+the same way it consumes the DreamZero dataset.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+from typing import Any
+
+import torch
+import torch.utils.data
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from rlinf.models.embodiment.lingbotva._utils import extend_import_path
+from rlinf.utils.logging import get_logger
+
+logger = get_logger()
+
+
+class _SynchronousMultiLatentLeRobotDataset(torch.utils.data.Dataset):
+    """Drop-in replacement for ``MultiLatentLeRobotDataset`` without ``Pool``.
+
+    The upstream class spawns a ``multiprocessing.Pool`` of workers to load
+    each per-task ``LatentLeRobotDataset`` in parallel. That forks the current
+    process after CUDA has already been initialized (RLinf calls
+    ``torch.cuda.set_device`` early in the worker), which deadlocks. We
+    construct the underlying datasets sequentially instead — at most ~10
+    sub-datasets for Libero-Object, each ~1s to load.
+    """
+
+    def __init__(self, config: Any):
+        from wan_va.dataset.lerobot_latent_dataset import (
+            LatentLeRobotDataset,
+            recursive_find_file,
+        )
+
+        info_paths = recursive_find_file(config.dataset_path, "info.json")
+        if not info_paths:
+            raise FileNotFoundError(
+                "No LingBot-VA LeRobot dataset found under "
+                f"{config.dataset_path}. Expected at least one "
+                "meta/info.json."
+            )
+        repo_ids = [p.split("/meta/info.json")[0] for p in info_paths]
+        logger.info(
+            "LingBot-VA SFT dataset: loading %d LeRobot sub-dataset(s) from %s.",
+            len(repo_ids),
+            config.dataset_path,
+        )
+
+        self._datasets = [
+            LatentLeRobotDataset(repo_id=repo_id, config=config)
+            for repo_id in repo_ids
+        ]
+        self._item_to_dataset, self._acc = self._build_index()
+
+    def _build_index(self):
+        item_to_dataset: dict[int, int] = {}
+        acc: dict[int, int] = {}
+        acc_nums = [0]
+        idx = 0
+        for dset_id, dset in enumerate(self._datasets):
+            acc_nums.append(acc_nums[-1] + len(dset))
+            for _ in range(len(dset)):
+                item_to_dataset[idx] = dset_id
+                idx += 1
+        for did in range(len(self._datasets)):
+            acc[did] = acc_nums[did]
+        return item_to_dataset, acc
+
+    def __len__(self) -> int:
+        return sum(len(d) for d in self._datasets)
+
+    def __getitem__(self, idx: int) -> dict:
+        assert idx < len(self), f"idx {idx} out of range for dataset len {len(self)}"
+        dset_id = self._item_to_dataset[idx]
+        local_idx = idx - self._acc[dset_id]
+        return self._datasets[dset_id][local_idx]
+
+
+def _build_job_config(cfg) -> Any:
+    """Clone the lingbot-va Libero training config and patch dataset paths."""
+    from wan_va.configs import VA_CONFIGS
+
+    model_cfg = cfg.actor.model
+    repo_path = model_cfg.lingbotva.repo_path
+    extend_import_path(repo_path)
+
+    config_name = getattr(model_cfg.lingbotva, "config_name", "libero")
+    # The lingbot-va training script uses the ``libero_train`` variant which
+    # extends the eval config with optimizer + data fields. Fall back to the
+    # eval-side ``libero`` config if the train variant is missing.
+    base_name = (
+        f"{config_name}_train" if f"{config_name}_train" in VA_CONFIGS else config_name
+    )
+    job_config = copy.deepcopy(VA_CONFIGS[base_name])
+
+    dataset_path = cfg.data.train_data_paths
+    if not os.path.isdir(dataset_path):
+        raise FileNotFoundError(
+            f"LingBot-VA SFT dataset_path does not exist: {dataset_path}. "
+            "Run the lingbot-va data-prep scripts (HDF5 → LeRobot → subset → "
+            "latent extract) before launching SFT."
+        )
+    job_config.dataset_path = dataset_path
+
+    empty_emb_path = model_cfg.lingbotva.get(
+        "empty_emb_path", None
+    ) or os.path.join(dataset_path, "empty_emb.pt")
+    if not os.path.isfile(empty_emb_path):
+        raise FileNotFoundError(
+            f"LingBot-VA empty UMT5 embedding not found: {empty_emb_path}. "
+            "Re-run scripts/extract_latents.py to regenerate it."
+        )
+    job_config.empty_emb_path = empty_emb_path
+
+    job_config.cfg_prob = float(model_cfg.lingbotva.get("cfg_prob", 0.1))
+    return job_config
+
+
+def build_lingbotva_sft_dataloader(
+    cfg,
+    world_size: int,
+    rank: int,
+    data_paths: str,
+    eval_dataset: bool = False,
+):
+    """Build the LingBot-VA SFT dataloader.
+
+    Args:
+        cfg: full RLinf DictConfig.
+        world_size: distributed world size.
+        rank: distributed rank.
+        data_paths: unused (kept for signature parity with DreamZero); we read
+            ``cfg.data.train_data_paths`` instead so the prepared LeRobot
+            directory comes from the SFT YAML.
+        eval_dataset: when True, disables shuffling and ``drop_last``.
+
+    Returns:
+        ``(StatefulDataLoader, metadata_dict)``.
+    """
+    del data_paths  # we pull from cfg.data.train_data_paths
+
+    job_config = _build_job_config(cfg)
+    dataset = _SynchronousMultiLatentLeRobotDataset(job_config)
+    assert len(dataset) > 0, (
+        "LingBot-VA SFT dataset is empty after construction. Verify that "
+        f"latents/*.pth exist under {job_config.dataset_path}/latents."
+    )
+    logger.info("LingBot-VA SFT dataset built with %d samples.", len(dataset))
+
+    sampler = torch.utils.data.distributed.DistributedSampler(
+        dataset,
+        num_replicas=world_size,
+        rank=rank,
+        shuffle=not eval_dataset,
+        drop_last=not eval_dataset,
+        seed=int(cfg.actor.get("seed", 42)),
+    )
+
+    num_workers = int(cfg.data.get("num_workers", 4))
+    prefetch_factor = cfg.data.get("prefetch_factor", 4) if num_workers > 0 else None
+
+    loader = StatefulDataLoader(
+        dataset,
+        batch_size=cfg.actor.micro_batch_size,
+        sampler=sampler,
+        drop_last=not eval_dataset,
+        num_workers=num_workers,
+        pin_memory=True,
+        persistent_workers=num_workers > 0,
+        prefetch_factor=prefetch_factor,
+    )
+    return loader, {"num_samples": len(dataset)}

--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -521,11 +521,26 @@ class FSDPModelManager:
                     "betas": betas,
                 }
             )
-        optimizer = torch.optim.AdamW(
-            param_groups,
-            eps=adam_eps,
-            weight_decay=weight_decay,
-        )
+        optimizer_type = self._cfg.optim.get("optimizer_type", "adamw")
+        if optimizer_type == "adamw":
+            optimizer = torch.optim.AdamW(
+                param_groups,
+                eps=adam_eps,
+                weight_decay=weight_decay,
+            )
+        elif optimizer_type == "adamw_8bit":
+            from bitsandbytes.optim import AdamW8bit
+
+            optimizer = AdamW8bit(
+                param_groups,
+                eps=adam_eps,
+                weight_decay=weight_decay,
+            )
+        else:
+            raise ValueError(
+                f"Unknown optimizer_type {optimizer_type!r}; "
+                "expected 'adamw' or 'adamw_8bit'."
+            )
 
         # run optimizer empty step to initialize optimizer.state
         # to avoid KeyError during get_state_dict/set_state_dict

--- a/rlinf/models/__init__.py
+++ b/rlinf/models/__init__.py
@@ -96,6 +96,11 @@ def _register_builtin_models():
 
         return get_model(cfg, torch_dtype)
 
+    def _build_lingbotva(cfg: DictConfig, torch_dtype):
+        from rlinf.models.embodiment.lingbotva import get_model
+
+        return get_model(cfg, torch_dtype)
+
     def _build_starvla(cfg: DictConfig, torch_dtype):
         from rlinf.models.embodiment.starvla import get_model
 
@@ -173,6 +178,12 @@ def _register_builtin_models():
     register_model(
         SupportedModel.LINGBOTVLA.value,
         _build_lingbotvla,
+        category="embodied",
+        force=True,
+    )
+    register_model(
+        SupportedModel.LINGBOTVA.value,
+        _build_lingbotva,
         category="embodied",
         force=True,
     )

--- a/rlinf/models/embodiment/lingbotva/__init__.py
+++ b/rlinf/models/embodiment/lingbotva/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LingBot-VA embodied model integration for RLinf (Libero evaluation)."""
+
+from __future__ import annotations
+
+import torch
+from omegaconf import DictConfig
+
+from rlinf.utils.logging import get_logger
+
+
+def get_model(cfg: DictConfig, torch_dtype: torch.dtype | None = None):
+    """Build the LingBot-VA model adapter for Libero evaluation."""
+    from rlinf.models.embodiment.lingbotva.lingbotva_action_model import (
+        LingbotVAActionModel,
+    )
+
+    model = LingbotVAActionModel(cfg=cfg, torch_dtype=torch_dtype or torch.bfloat16)
+    get_logger().info("Initialized LingBot-VA adapter for Libero.")
+    return model

--- a/rlinf/models/embodiment/lingbotva/_utils.py
+++ b/rlinf/models/embodiment/lingbotva/_utils.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for the LingBot-VA eval backend and the SFT training path."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import load_file
+
+from rlinf.utils.logging import get_logger
+
+logger = get_logger()
+
+# State-dict key prefixes used by upstream LingBot-VA checkpoints that we may
+# need to strip before loading the weights into a bare transformer module.
+TRANSFORMER_STATE_PREFIXES: tuple[str, ...] = (
+    "_sft_core.transformer.",
+    "transformer.",
+)
+
+
+def extend_import_path(repo_path: Path | str) -> None:
+    """Make `wan_va.*` importable by prepending the LingBot-VA repo to sys.path."""
+    repo_str = str(repo_path)
+    if repo_str not in sys.path:
+        sys.path.insert(0, repo_str)
+
+
+def extract_transformer_state_dict(state_dict: dict[str, Any]) -> dict[str, Any]:
+    """Strip optional `transformer.` / `_sft_core.transformer.` key prefixes."""
+    for prefix in TRANSFORMER_STATE_PREFIXES:
+        extracted = {
+            key[len(prefix):]: value
+            for key, value in state_dict.items()
+            if key.startswith(prefix)
+        }
+        if extracted:
+            return extracted
+    return state_dict
+
+
+def load_transformer_state_dict(
+    transformer: torch.nn.Module,
+    checkpoint_path: Path | str,
+) -> None:
+    """Load a LingBot-VA transformer checkpoint into `transformer`.
+
+    Accepts either a directory containing a HuggingFace-style
+    `transformer/diffusion_pytorch_model.safetensors` (the LingBot-VA SFT
+    checkpoint layout) or a single `.pt`/`.pth` file with optional
+    `transformer.`-prefixed keys.
+    """
+    checkpoint_path = Path(checkpoint_path)
+    if not checkpoint_path.exists():
+        raise FileNotFoundError(
+            f"LingBot-VA transformer state dict path does not exist: {checkpoint_path}"
+        )
+
+    if checkpoint_path.is_dir():
+        transformer_dir = (
+            checkpoint_path / "transformer"
+            if (checkpoint_path / "transformer" / "config.json").exists()
+            else checkpoint_path
+        )
+        state_path = transformer_dir / "diffusion_pytorch_model.safetensors"
+        if not state_path.exists():
+            raise FileNotFoundError(
+                "LingBot-VA transformer checkpoint directory must contain "
+                f"diffusion_pytorch_model.safetensors: {transformer_dir}"
+            )
+        transformer_state = load_file(str(state_path), device="cpu")
+    else:
+        raw_state = torch.load(
+            checkpoint_path, map_location="cpu", weights_only=False
+        )
+        if not isinstance(raw_state, dict):
+            raise TypeError(
+                "LingBot-VA transformer state dict must deserialize to a dict, got "
+                f"{type(raw_state)!r}."
+            )
+        transformer_state = extract_transformer_state_dict(raw_state)
+
+    missing_keys, unexpected_keys = transformer.load_state_dict(
+        transformer_state, strict=False
+    )
+    if missing_keys or unexpected_keys:
+        preview_missing = ", ".join(missing_keys[:5])
+        preview_unexpected = ", ".join(unexpected_keys[:5])
+        logger.warning(
+            "LingBot-VA transformer checkpoint partial match "
+            "(missing=%d, unexpected=%d). Missing preview: [%s]. "
+            "Unexpected preview: [%s].",
+            len(missing_keys),
+            len(unexpected_keys),
+            preview_missing,
+            preview_unexpected,
+        )
+    logger.info(
+        "Loaded LingBot-VA Libero transformer checkpoint from %s "
+        "(missing=%d, unexpected=%d).",
+        checkpoint_path,
+        len(missing_keys),
+        len(unexpected_keys),
+    )

--- a/rlinf/models/embodiment/lingbotva/eval_adapter/__init__.py
+++ b/rlinf/models/embodiment/lingbotva/eval_adapter/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/rlinf/models/embodiment/lingbotva/eval_adapter/history_buffer.py
+++ b/rlinf/models/embodiment/lingbotva/eval_adapter/history_buffer.py
@@ -1,0 +1,47 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Episode state helpers for LingBot-VA chunked rollout on Libero."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class LingbotVAEpisodeState:
+    """Per-environment state tracked across LingBot-VA inference chunks."""
+
+    prompt: str | None = None
+    first_obs: dict[str, Any] | None = None
+    first_chunk: bool = True
+    action_queue: deque[np.ndarray] = field(default_factory=deque)
+    prev_model_action: np.ndarray | None = None
+    last_action_per_frame: int | None = None
+    kv_cache_history: list[tuple[list[dict[str, Any]], np.ndarray]] = field(
+        default_factory=list
+    )
+
+    def reset(self, prompt: str) -> None:
+        self.prompt = prompt
+        self.first_obs = None
+        self.first_chunk = True
+        self.action_queue.clear()
+        self.prev_model_action = None
+        self.last_action_per_frame = None
+        self.kv_cache_history.clear()

--- a/rlinf/models/embodiment/lingbotva/eval_adapter/native_backend.py
+++ b/rlinf/models/embodiment/lingbotva/eval_adapter/native_backend.py
@@ -1,0 +1,726 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-process LingBot-VA runtime backend for Libero evaluation."""
+
+from __future__ import annotations
+
+import atexit
+import copy
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from rlinf.models.embodiment.lingbotva._utils import (
+    extend_import_path,
+    load_transformer_state_dict,
+)
+from rlinf.utils.logging import get_logger
+
+logger = get_logger()
+
+
+def _resolve_cuda_local_rank() -> int:
+    local_rank = os.environ.get("LOCAL_RANK")
+    if local_rank is not None:
+        try:
+            return int(local_rank)
+        except ValueError as exc:
+            raise ValueError(f"Invalid LOCAL_RANK value: {local_rank!r}") from exc
+    if torch.cuda.is_available():
+        return torch.cuda.current_device()
+    return 0
+
+
+def _resolve_runtime_path(path_value: str | Path) -> Path:
+    path = Path(path_value).expanduser()
+    if path.is_absolute():
+        return path
+    repo_root = os.environ.get("REPO_PATH")
+    if repo_root:
+        return (Path(repo_root) / path).resolve()
+    return path.resolve()
+
+
+class LingbotVALiberoBackend:
+    """Single-process backend using the official LingBot-VA modules for Libero."""
+
+    _BATCH_CACHE_NAME = "rlinf_libero_batch"
+
+    def __init__(self, cfg: Any, torch_dtype: torch.dtype) -> None:
+        self.cfg = cfg
+        self.torch_dtype = torch_dtype
+        self.config_name = getattr(cfg.lingbotva, "config_name", "libero")
+        self.repo_path = Path(getattr(cfg.lingbotva, "repo_path"))
+        self.model_path = Path(cfg.model_path)
+        transformer_state_dict_path = getattr(
+            cfg.lingbotva, "transformer_state_dict_path", None
+        )
+        self.transformer_state_dict_path = (
+            Path(transformer_state_dict_path)
+            if transformer_state_dict_path is not None
+            else None
+        )
+        self.save_root = _resolve_runtime_path(
+            getattr(cfg.lingbotva, "save_root", "./runtime/lingbotva")
+        )
+        self._get_mesh_id = None
+        self._data_seq_to_patch = None
+        self._prompt_cache: dict[str, tuple[torch.Tensor, torch.Tensor | None]] = {}
+        self._validate_runtime_paths()
+        self._server = self._build_server()
+        atexit.register(self.close)
+
+    def _validate_runtime_paths(self) -> None:
+        if not self.repo_path.exists():
+            raise FileNotFoundError(
+                f"LingBot-VA repo path does not exist: {self.repo_path}"
+            )
+        if not self.repo_path.is_dir():
+            raise NotADirectoryError(
+                f"LingBot-VA repo path is not a directory: {self.repo_path}"
+            )
+        if not self.model_path.exists():
+            raise FileNotFoundError(
+                f"LingBot-VA model path does not exist: {self.model_path}"
+            )
+        if not self.model_path.is_dir():
+            raise NotADirectoryError(
+                f"LingBot-VA model path is not a directory: {self.model_path}"
+            )
+
+    def _build_server(self):
+        extend_import_path(self.repo_path)
+
+        from wan_va.configs import VA_CONFIGS
+        from wan_va.utils import data_seq_to_patch, get_mesh_id
+        from wan_va.wan_va_server import VA_Server
+
+        job_config = copy.deepcopy(VA_CONFIGS[self.config_name])
+        job_config.wan22_pretrained_model_name_or_path = str(self.model_path)
+        job_config.param_dtype = self.torch_dtype
+        job_config.enable_offload = bool(
+            getattr(self.cfg.lingbotva, "enable_offload", False)
+        )
+        job_config.save_root = str(self.save_root)
+
+        # Allow callers to override the diffusion step counts so that the
+        # 25-step video / 50-step action defaults can be reduced for faster
+        # evaluation when needed.
+        override_video_steps = getattr(self.cfg.lingbotva, "num_inference_steps", None)
+        if override_video_steps is not None:
+            job_config.num_inference_steps = int(override_video_steps)
+        override_action_steps = getattr(
+            self.cfg.lingbotva, "action_num_inference_steps", None
+        )
+        if override_action_steps is not None:
+            job_config.action_num_inference_steps = int(override_action_steps)
+
+        current_device = _resolve_cuda_local_rank()
+        if torch.cuda.is_available():
+            torch.cuda.set_device(current_device)
+        job_config.rank = 0
+        job_config.local_rank = current_device
+        job_config.world_size = 1
+        server = VA_Server(job_config)
+        self._data_seq_to_patch = data_seq_to_patch
+        self._get_mesh_id = get_mesh_id
+        if self.transformer_state_dict_path is not None:
+            load_transformer_state_dict(
+                server.transformer, self.transformer_state_dict_path
+            )
+        logger.info(
+            "Initialized in-process LingBot-VA Libero runtime on device %s "
+            "(CUDA_VISIBLE_DEVICES=%s).",
+            current_device,
+            os.environ.get("CUDA_VISIBLE_DEVICES"),
+        )
+        return server
+
+    def _cfg_batch_size(self, batch_size: int) -> int:
+        return batch_size * (2 if self._server.use_cfg else 1)
+
+    def _ensure_observation_runtime_shape(self) -> None:
+        server = self._server
+        if all(
+            hasattr(server, attr)
+            for attr in ("height", "width", "latent_height", "latent_width")
+        ):
+            return
+
+        server.action_per_frame = server.job_config.action_per_frame
+        server.height, server.width = server.job_config.height, server.job_config.width
+        server.latent_height, server.latent_width = (
+            server.height // 16,
+            server.width // 16 * len(server.job_config.obs_cam_keys),
+        )
+
+    def _reset_batch_runtime(self, prompts: list[str]) -> None:
+        if not prompts:
+            raise ValueError("LingBot-VA batch runtime requires at least one prompt.")
+
+        server = self._server
+        batch_size = len(prompts)
+        server.cache_name = self._BATCH_CACHE_NAME
+        server.use_cfg = (server.job_config.guidance_scale > 1) or (
+            server.job_config.action_guidance_scale > 1
+        )
+        server.frame_st_id = 0
+        server.init_latent = None
+        server.transformer.clear_cache(server.cache_name)
+        server.streaming_vae.clear_cache()
+
+        self._ensure_observation_runtime_shape()
+
+        patch_size = server.job_config.patch_size
+        latent_token_per_chunk = (
+            server.job_config.frame_chunk_size
+            * server.latent_height
+            * server.latent_width
+        ) // (patch_size[0] * patch_size[1] * patch_size[2])
+        action_token_per_chunk = (
+            server.job_config.frame_chunk_size * server.action_per_frame
+        )
+        server.transformer.create_empty_cache(
+            server.cache_name,
+            server.job_config.attn_window,
+            latent_token_per_chunk,
+            action_token_per_chunk,
+            dtype=server.dtype,
+            device=server.device,
+            batch_size=self._cfg_batch_size(batch_size),
+        )
+
+        server.action_mask = torch.zeros([server.job_config.action_dim]).bool()
+        server.action_mask[server.job_config.used_action_channel_ids] = True
+        server.actions_q01 = torch.tensor(
+            server.job_config.norm_stat["q01"], dtype=torch.float32
+        ).reshape(-1, 1, 1)
+        server.actions_q99 = torch.tensor(
+            server.job_config.norm_stat["q99"], dtype=torch.float32
+        ).reshape(-1, 1, 1)
+        server.action_norm_method = server.job_config.action_norm_method
+        # Cache prompt embeddings by prompt text so we only run the 5.7B-param
+        # UMT5 text encoder when we encounter a new prompt. After encoding we
+        # offload the text encoder back to CPU (or even free it entirely) to
+        # leave room for the transformer's diffusion-inference activations.
+        do_cfg = server.job_config.guidance_scale > 1
+        pos_list: list[torch.Tensor] = []
+        neg_list: list[torch.Tensor | None] = []
+        missing_prompts = [
+            prompt for prompt in prompts if prompt not in self._prompt_cache
+        ]
+        if missing_prompts:
+            text_encoder = server.text_encoder
+            text_encoder_orig_device = next(text_encoder.parameters()).device
+            if text_encoder_orig_device.type != server.device.type:
+                text_encoder.to(server.device)
+            try:
+                with torch.no_grad():
+                    new_pos, new_neg = server.encode_prompt(
+                        prompt=missing_prompts,
+                        negative_prompt=None,
+                        do_classifier_free_guidance=do_cfg,
+                        num_videos_per_prompt=1,
+                        prompt_embeds=None,
+                        negative_prompt_embeds=None,
+                        max_sequence_length=512,
+                        device=server.device,
+                        dtype=server.dtype,
+                    )
+                for idx, prompt in enumerate(missing_prompts):
+                    pos_emb = new_pos[idx : idx + 1].clone()
+                    neg_emb = (
+                        new_neg[idx : idx + 1].clone()
+                        if (do_cfg and new_neg is not None)
+                        else None
+                    )
+                    self._prompt_cache[prompt] = (pos_emb, neg_emb)
+            finally:
+                if text_encoder_orig_device.type != server.device.type:
+                    text_encoder.to(text_encoder_orig_device)
+                torch.cuda.empty_cache()
+        for prompt in prompts:
+            pos_emb, neg_emb = self._prompt_cache[prompt]
+            pos_list.append(pos_emb)
+            neg_list.append(neg_emb)
+        server.prompt_embeds = torch.cat(pos_list, dim=0).to(server.device)
+        if do_cfg and all(neg is not None for neg in neg_list):
+            server.negative_prompt_embeds = torch.cat(neg_list, dim=0).to(server.device)
+        else:
+            server.negative_prompt_embeds = None
+        server.exp_name = "rlinf_libero_batch"
+        server.exp_save_root = str(self.save_root / "real")
+        os.makedirs(server.exp_save_root, exist_ok=True)
+        torch.cuda.empty_cache()
+
+    @staticmethod
+    def _normalize_obs_sequences(
+        obs_batch: list[dict[str, Any]] | list[list[dict[str, Any]]],
+    ) -> list[list[dict[str, Any]]]:
+        if not obs_batch:
+            raise ValueError("LingBot-VA batch infer requires non-empty observations.")
+        if isinstance(obs_batch[0], dict):
+            return [[obs] for obs in obs_batch]
+        return obs_batch  # type: ignore[return-value]
+
+    def _encode_obs_batch(
+        self,
+        obs_batch: list[dict[str, Any]] | list[list[dict[str, Any]]],
+    ) -> torch.Tensor | None:
+        server = self._server
+        self._ensure_observation_runtime_shape()
+        obs_sequences = self._normalize_obs_sequences(obs_batch)
+        if not obs_sequences:
+            return None
+
+        # Validate uniform sequence lengths.
+        lengths = [len(sequence) for sequence in obs_sequences]
+        if len(set(lengths)) != 1:
+            raise ValueError(
+                "LingBot-VA Libero encoding requires uniform sequence lengths "
+                f"across the batch, got {lengths}."
+            )
+
+        videos = []
+        for camera_key in server.job_config.obs_cam_keys:
+            height_i, width_i = server.height, server.width
+            history_video = torch.stack(
+                [
+                    torch.from_numpy(np.stack([frame[camera_key] for frame in seq]))
+                    .float()
+                    .permute(3, 0, 1, 2)
+                    for seq in obs_sequences
+                ],
+                dim=0,
+            )
+            history_video = F.interpolate(
+                history_video.flatten(0, 1),
+                size=(height_i, width_i),
+                mode="bilinear",
+                align_corners=False,
+            ).unflatten(0, (history_video.shape[0], history_video.shape[1]))
+            videos.append(history_video)
+
+        videos_tensor = torch.cat(videos, dim=0) / 255.0 * 2.0 - 1.0
+        vae = server.streaming_vae.vae
+        vae_orig_device = next(vae.parameters()).device
+        if vae_orig_device.type != server.device.type:
+            vae.to(server.device)
+        try:
+            enc_out = server.streaming_vae.encode_chunk(
+                videos_tensor.to(server.device).to(server.dtype)
+            )
+        finally:
+            if vae_orig_device.type != server.device.type:
+                vae.to(vae_orig_device)
+                torch.cuda.empty_cache()
+
+        mu, _logvar = torch.chunk(enc_out, 2, dim=1)
+        latents_mean = torch.tensor(server.vae.config.latents_mean).to(mu.device)
+        latents_std = torch.tensor(server.vae.config.latents_std).to(mu.device)
+        mu_norm = server.normalize_latents(mu, latents_mean, 1.0 / latents_std)
+        # Concatenate cameras along the width dimension.
+        video_latent = torch.cat(mu_norm.split(len(obs_sequences), dim=0), dim=-1).to(
+            server.device
+        )
+        return video_latent
+
+    def _prepare_batch_input(
+        self,
+        *,
+        latent_model_input: torch.Tensor | None,
+        action_model_input: torch.Tensor | None,
+        latent_t: float = 0,
+        action_t: float = 0,
+        latent_cond: torch.Tensor | None = None,
+        action_cond: torch.Tensor | None = None,
+        frame_st_id: int = 0,
+    ) -> dict[str, dict[str, torch.Tensor]]:
+        server = self._server
+        batch_size = (
+            latent_model_input.shape[0]
+            if latent_model_input is not None
+            else action_model_input.shape[0]
+        )
+        input_dict: dict[str, dict[str, torch.Tensor]] = {}
+
+        if latent_model_input is not None:
+            timesteps = (
+                torch.ones(
+                    [latent_model_input.shape[2]],
+                    dtype=torch.float32,
+                    device=server.device,
+                )
+                * latent_t
+            )
+            grid_id = self._get_mesh_id(
+                latent_model_input.shape[-3] // server.job_config.patch_size[0],
+                latent_model_input.shape[-2] // server.job_config.patch_size[1],
+                latent_model_input.shape[-1] // server.job_config.patch_size[2],
+                0,
+                1,
+                frame_st_id,
+            ).to(server.device)
+            noisy_latents = latent_model_input.clone()
+            if latent_cond is not None:
+                noisy_latents[:, :, 0:1] = latent_cond[:, :, 0:1]
+                timesteps[0:1] *= 0
+            input_dict["latent_res_lst"] = {
+                "noisy_latents": noisy_latents,
+                "timesteps": timesteps,
+                "grid_id": grid_id,
+                "text_emb": server.prompt_embeds.to(server.dtype).clone(),
+            }
+
+        if action_model_input is not None:
+            timesteps = (
+                torch.ones(
+                    [action_model_input.shape[2]],
+                    dtype=torch.float32,
+                    device=server.device,
+                )
+                * action_t
+            )
+            grid_id = self._get_mesh_id(
+                action_model_input.shape[-3],
+                action_model_input.shape[-2],
+                action_model_input.shape[-1],
+                1,
+                1,
+                frame_st_id,
+                action=True,
+            ).to(server.device)
+            noisy_actions = action_model_input.clone()
+            if action_cond is not None:
+                noisy_actions[:, :, 0:1] = action_cond[:, :, 0:1]
+                timesteps[0:1] *= 0
+            noisy_actions[:, ~server.action_mask] *= 0
+            input_dict["action_res_lst"] = {
+                "noisy_latents": noisy_actions,
+                "timesteps": timesteps,
+                "grid_id": grid_id,
+                "text_emb": server.prompt_embeds.to(server.dtype).clone(),
+            }
+
+        for input_value in input_dict.values():
+            if server.use_cfg:
+                input_value["noisy_latents"] = input_value["noisy_latents"].repeat(
+                    2, 1, 1, 1, 1
+                )
+                input_value["text_emb"] = torch.cat(
+                    [
+                        server.prompt_embeds.to(server.dtype).clone(),
+                        server.negative_prompt_embeds.to(server.dtype).clone(),
+                    ],
+                    dim=0,
+                )
+                input_value["grid_id"] = input_value["grid_id"][None].repeat(
+                    self._cfg_batch_size(batch_size), 1, 1
+                )
+                input_value["timesteps"] = input_value["timesteps"][None].repeat(
+                    self._cfg_batch_size(batch_size), 1
+                )
+            else:
+                input_value["grid_id"] = input_value["grid_id"][None].repeat(
+                    batch_size, 1, 1
+                )
+                input_value["timesteps"] = input_value["timesteps"][None].repeat(
+                    batch_size, 1
+                )
+        return input_dict
+
+    def _postprocess_action_batch(self, action: torch.Tensor) -> list[np.ndarray]:
+        server = self._server
+        action = action.detach().cpu()[..., 0]
+        if server.action_norm_method == "quantiles":
+            action = (action + 1) / 2 * (
+                server.actions_q99 - server.actions_q01 + 1e-6
+            ) + server.actions_q01
+        else:
+            raise NotImplementedError
+        action_np = action.numpy()
+        used = action_np[:, server.job_config.used_action_channel_ids]
+        return [used[idx].astype(np.float32) for idx in range(used.shape[0])]
+
+    def _preprocess_action_batch(self, state_batch: np.ndarray) -> torch.Tensor:
+        server = self._server
+        tensors = [
+            server.preprocess_action(np.asarray(state, dtype=np.float32))
+            for state in state_batch
+        ]
+        return torch.cat(tensors, dim=0)
+
+    def _infer_batch_impl(
+        self,
+        obs_batch: list[dict[str, Any]] | list[list[dict[str, Any]]],
+        *,
+        frame_st_id: int = 0,
+    ) -> list[np.ndarray]:
+        server = self._server
+        obs_sequences = self._normalize_obs_sequences(obs_batch)
+        batch_size = len(obs_sequences)
+
+        if frame_st_id == 0 and server.init_latent is None:
+            server.init_latent = self._encode_obs_batch(obs_sequences)
+
+        latents = torch.randn(
+            batch_size,
+            48,
+            server.job_config.frame_chunk_size,
+            server.latent_height,
+            server.latent_width,
+            device=server.device,
+            dtype=server.dtype,
+        )
+        actions = torch.randn(
+            batch_size,
+            server.job_config.action_dim,
+            server.job_config.frame_chunk_size,
+            server.action_per_frame,
+            1,
+            device=server.device,
+            dtype=server.dtype,
+        )
+
+        server.scheduler.set_timesteps(server.job_config.num_inference_steps)
+        server.action_scheduler.set_timesteps(
+            server.job_config.action_num_inference_steps
+        )
+        timesteps = torch.nn.functional.pad(
+            server.scheduler.timesteps, (0, 1), mode="constant", value=0
+        )
+        if server.job_config.video_exec_step != -1:
+            timesteps = timesteps[: server.job_config.video_exec_step]
+        action_timesteps = torch.nn.functional.pad(
+            server.action_scheduler.timesteps, (0, 1), mode="constant", value=0
+        )
+
+        with torch.no_grad():
+            for step_idx, timestep in enumerate(timesteps):
+                last_step = step_idx == len(timesteps) - 1
+                latent_cond = (
+                    server.init_latent[:, :, 0:1] if frame_st_id == 0 else None
+                )
+                input_dict = self._prepare_batch_input(
+                    latent_model_input=latents,
+                    action_model_input=None,
+                    latent_t=float(timestep),
+                    action_t=float(timestep),
+                    latent_cond=latent_cond,
+                    action_cond=None,
+                    frame_st_id=frame_st_id,
+                )
+                video_noise_pred = server.transformer(
+                    input_dict["latent_res_lst"],
+                    update_cache=1 if last_step else 0,
+                    cache_name=server.cache_name,
+                    action_mode=False,
+                )
+                if not last_step or server.job_config.video_exec_step != -1:
+                    video_noise_pred = self._data_seq_to_patch(
+                        server.job_config.patch_size,
+                        video_noise_pred,
+                        server.job_config.frame_chunk_size,
+                        server.latent_height,
+                        server.latent_width,
+                        batch_size=self._cfg_batch_size(batch_size),
+                    )
+                    if server.job_config.guidance_scale > 1:
+                        video_noise_pred = video_noise_pred[
+                            batch_size:
+                        ] + server.job_config.guidance_scale * (
+                            video_noise_pred[:batch_size]
+                            - video_noise_pred[batch_size:]
+                        )
+                    else:
+                        video_noise_pred = video_noise_pred[:batch_size]
+                    latents = server.scheduler.step(
+                        video_noise_pred, timestep, latents, return_dict=False
+                    )
+                if latent_cond is not None:
+                    latents[:, :, 0:1] = latent_cond
+
+            for step_idx, timestep in enumerate(action_timesteps):
+                last_step = step_idx == len(action_timesteps) - 1
+                action_cond = (
+                    torch.zeros(
+                        [
+                            batch_size,
+                            server.job_config.action_dim,
+                            1,
+                            server.action_per_frame,
+                            1,
+                        ],
+                        device=server.device,
+                        dtype=server.dtype,
+                    )
+                    if frame_st_id == 0
+                    else None
+                )
+                input_dict = self._prepare_batch_input(
+                    latent_model_input=None,
+                    action_model_input=actions,
+                    latent_t=float(timestep),
+                    action_t=float(timestep),
+                    latent_cond=None,
+                    action_cond=action_cond,
+                    frame_st_id=frame_st_id,
+                )
+                action_noise_pred = server.transformer(
+                    input_dict["action_res_lst"],
+                    update_cache=1 if last_step else 0,
+                    cache_name=server.cache_name,
+                    action_mode=True,
+                )
+                if not last_step:
+                    action_noise_pred = (
+                        action_noise_pred.unflatten(
+                            1,
+                            (
+                                server.job_config.frame_chunk_size,
+                                server.action_per_frame,
+                            ),
+                        )
+                        .permute(0, 3, 1, 2)
+                        .unsqueeze(-1)
+                    )
+                    if server.job_config.action_guidance_scale > 1:
+                        action_noise_pred = action_noise_pred[
+                            batch_size:
+                        ] + server.job_config.action_guidance_scale * (
+                            action_noise_pred[:batch_size]
+                            - action_noise_pred[batch_size:]
+                        )
+                    else:
+                        action_noise_pred = action_noise_pred[:batch_size]
+                    actions = server.action_scheduler.step(
+                        action_noise_pred, timestep, actions, return_dict=False
+                    )
+                if action_cond is not None:
+                    actions[:, :, 0:1] = action_cond
+
+        actions[:, ~server.action_mask] *= 0
+        torch.cuda.empty_cache()
+        return self._postprocess_action_batch(actions)
+
+    def _compute_kv_cache_batch_impl(
+        self,
+        *,
+        obs_batch: list[list[dict[str, Any]]],
+        state_batch: np.ndarray,
+        frame_st_id: int,
+    ) -> int:
+        server = self._server
+        server.transformer.clear_pred_cache(server.cache_name)
+        latent_model_input = self._encode_obs_batch(obs_batch)
+        if frame_st_id == 0:
+            latent_model_input = (
+                torch.cat([server.init_latent, latent_model_input], dim=2)
+                if latent_model_input is not None
+                else server.init_latent
+            )
+
+        action_model_input = self._preprocess_action_batch(state_batch).to(
+            latent_model_input
+        )
+        input_dict = self._prepare_batch_input(
+            latent_model_input=latent_model_input,
+            action_model_input=action_model_input,
+            frame_st_id=frame_st_id,
+        )
+
+        with torch.no_grad():
+            server.transformer(
+                input_dict["latent_res_lst"],
+                update_cache=2,
+                cache_name=server.cache_name,
+                action_mode=False,
+            )
+            server.transformer(
+                input_dict["action_res_lst"],
+                update_cache=2,
+                cache_name=server.cache_name,
+                action_mode=True,
+            )
+        torch.cuda.empty_cache()
+        return frame_st_id + int(latent_model_input.shape[2])
+
+    def infer_batch(
+        self,
+        obs_batch: list[dict[str, Any]],
+        prompts: list[str],
+        *,
+        kv_cache_histories: (
+            list[list[tuple[list[dict[str, Any]], np.ndarray]]] | None
+        ) = None,
+    ) -> list[np.ndarray]:
+        """Run inference, optionally replaying past chunk history.
+
+        If ``kv_cache_histories`` is provided, we encode the cached
+        ``first_obs`` to populate ``init_latent`` then sequentially feed the
+        history's key-frame batches through the transformer's KV cache before
+        running the actual inference at the resulting ``frame_st_id``. This
+        matches the official LingBot-VA loop where every chunk benefits from
+        the prior chunks' video/action context.
+        """
+        if len(obs_batch) != len(prompts):
+            raise ValueError(
+                "LingBot-VA batch infer expects equal numbers of obs and prompts, got "
+                f"{len(obs_batch)} and {len(prompts)}."
+            )
+        self._reset_batch_runtime(prompts)
+        frame_st_id = 0
+        if kv_cache_histories and any(len(h) > 0 for h in kv_cache_histories):
+            history_lengths = {len(history) for history in kv_cache_histories}
+            if len(history_lengths) != 1:
+                raise ValueError(
+                    "LingBot-VA batched follow-up infer requires uniform kv history "
+                    f"lengths across the batch, got {history_lengths}."
+                )
+            history_len = history_lengths.pop()
+            self._server.init_latent = self._encode_obs_batch(obs_batch)
+            for history_idx in range(history_len):
+                obs_sequences = [
+                    history[history_idx][0] for history in kv_cache_histories
+                ]
+                state_batch = np.stack(
+                    [history[history_idx][1] for history in kv_cache_histories], axis=0
+                )
+                frame_st_id = self._compute_kv_cache_batch_impl(
+                    obs_batch=obs_sequences,
+                    state_batch=state_batch,
+                    frame_st_id=frame_st_id,
+                )
+        return self._infer_batch_impl(obs_batch, frame_st_id=frame_st_id)
+
+    def close(self) -> None:
+        if getattr(self, "_server", None) is None:
+            return
+        transformer = getattr(self._server, "transformer", None)
+        if transformer is not None:
+            try:
+                transformer.clear_cache(self._BATCH_CACHE_NAME)
+            except Exception:
+                pass
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/rlinf/models/embodiment/lingbotva/eval_adapter/observation_adapter.py
+++ b/rlinf/models/embodiment/lingbotva/eval_adapter/observation_adapter.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Observation conversion utilities for LingBot-VA on Libero."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+
+
+class LingbotVALiberoObservationAdapter:
+    """Convert RLinf LiberoEnv observations into LingBot-VA Libero format.
+
+    LiberoEnv applies ``img[::-1, ::-1]`` (a 180-degree rotation) to the
+    rendered MuJoCo frames. LingBot-VA's Libero evaluation client only flips
+    the vertical axis (``[::-1]``). We therefore restore the horizontal axis
+    so the model sees observations in its training-time orientation.
+    """
+
+    @staticmethod
+    def _select_image(image_tensor: Any, env_idx: int) -> np.ndarray:
+        if image_tensor is None:
+            raise ValueError("LingBot-VA requires image observations, but got None.")
+        if isinstance(image_tensor, torch.Tensor):
+            arr = image_tensor[env_idx].detach().cpu().numpy()
+        else:
+            arr = np.asarray(image_tensor[env_idx])
+        return np.ascontiguousarray(arr[:, ::-1, :])
+
+    @staticmethod
+    def _select_state(state_tensor: Any, env_idx: int) -> np.ndarray:
+        if state_tensor is None:
+            return np.zeros((7,), dtype=np.float32)
+        if isinstance(state_tensor, torch.Tensor):
+            if state_tensor.dtype == torch.bfloat16:
+                state_tensor = state_tensor.to(torch.float32)
+            arr = state_tensor[env_idx].detach().cpu().numpy()
+        else:
+            arr = np.asarray(state_tensor[env_idx])
+        return arr.astype(np.float32)
+
+    @classmethod
+    def format_observation(
+        cls,
+        env_obs: dict[str, Any],
+        env_idx: int,
+        prompt: str,
+    ) -> dict[str, Any]:
+        """Convert one batch element to the official LingBot-VA Libero format."""
+        agentview = cls._select_image(env_obs.get("main_images"), env_idx)
+        eye_in_hand = cls._select_image(env_obs.get("wrist_images"), env_idx)
+        state = cls._select_state(env_obs.get("states"), env_idx)
+        return {
+            "observation.images.agentview_rgb": agentview,
+            "observation.images.eye_in_hand_rgb": eye_in_hand,
+            "observation.state": state,
+            "task": prompt,
+        }
+
+    @classmethod
+    def format_raw_step_observation(
+        cls,
+        raw_obs: dict[str, Any],
+        prompt: str,
+    ) -> dict[str, Any]:
+        """Convert a raw libero per-step obs dict (from chunk_step) to LingBot-VA format.
+
+        ``raw_obs`` is the dict returned by Libero's ``OffScreenRenderEnv.step``
+        before RLinf wraps it. It includes ``agentview_image`` and
+        ``robot0_eye_in_hand_image`` arrays in their raw MuJoCo orientation
+        (upside-down). LingBot-VA expects them vertically flipped.
+        """
+        agentview = raw_obs.get("agentview_image")
+        eye_in_hand = raw_obs.get("robot0_eye_in_hand_image")
+        if agentview is None or eye_in_hand is None:
+            raise ValueError(
+                "LingBot-VA raw libero step observation expects "
+                "'agentview_image' and 'robot0_eye_in_hand_image' keys."
+            )
+        return {
+            "observation.images.agentview_rgb": np.ascontiguousarray(
+                np.asarray(agentview)[::-1]
+            ),
+            "observation.images.eye_in_hand_rgb": np.ascontiguousarray(
+                np.asarray(eye_in_hand)[::-1]
+            ),
+            "task": prompt,
+        }

--- a/rlinf/models/embodiment/lingbotva/lingbotva_action_model.py
+++ b/rlinf/models/embodiment/lingbotva/lingbotva_action_model.py
@@ -1,0 +1,564 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LingBot-VA action model adapter for RLinf Libero eval and SFT training."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from rlinf.models.embodiment.base_policy import BasePolicy, ForwardType
+from rlinf.models.embodiment.lingbotva._utils import (
+    extend_import_path,
+    load_transformer_state_dict,
+)
+from rlinf.models.embodiment.lingbotva.eval_adapter.history_buffer import (
+    LingbotVAEpisodeState,
+)
+from rlinf.models.embodiment.lingbotva.eval_adapter.native_backend import (
+    LingbotVALiberoBackend,
+)
+from rlinf.models.embodiment.lingbotva.eval_adapter.observation_adapter import (
+    LingbotVALiberoObservationAdapter,
+)
+
+
+class LingbotVAActionModel(nn.Module, BasePolicy):
+    """LingBot-VA adapter for the Libero suite.
+
+    Two operating modes:
+
+    * **Eval (default)** — :meth:`predict_action_batch` runs one diffusion-based
+      inference per call, wrapping ``wan_va.wan_va_server.VA_Server`` in-process
+      via :class:`LingbotVALiberoBackend`. The transformer lives inside the
+      backend and is invisible to FSDP.
+
+    * **Training** (``cfg.lingbotva.training_mode=True``) —
+      :meth:`sft_forward` runs one flow-matching diffusion step on the
+      pre-extracted latent + action targets from the dataloader. The
+      transformer is exposed as a direct ``nn.Module`` child so that FSDP can
+      wrap it and the SFT worker can drive the optimizer. VAE and text encoder
+      are not loaded (the dataset provides cached latents and the empty UMT5
+      embedding).
+    """
+
+    # FSDP wrap policy reads `_no_split_modules` from the top-level model.
+    # `WanTransformer3DModel` already declares `["WanTransformerBlock"]`
+    # internally; we re-declare here for the outer wrapper.
+    _no_split_modules = [
+        "WanTransformerBlock",
+        "WanAttention",
+        "WanTransformer3DModel",
+    ]
+
+    def __init__(self, cfg: Any, torch_dtype: torch.dtype = torch.bfloat16):
+        super().__init__()
+        self.config = cfg
+        self.torch_dtype = torch_dtype
+        self.action_dim = int(getattr(cfg, "action_dim", 7))
+        self.action_per_frame = int(getattr(cfg.lingbotva, "action_per_frame", 4))
+        # Number of action steps to actually execute per inference. Defaults to
+        # ``(frame_chunk_size - 1) * action_per_frame`` (12 for Libero), but
+        # callers can lower it to force shorter chunks with more frequent
+        # replanning.
+        self.exec_steps_per_chunk = int(
+            getattr(cfg, "num_action_chunks", 3 * self.action_per_frame)
+        )
+        # When ``False`` we always restart from ``frame_st_id=0`` and treat each
+        # chunk as the model's first chunk. When ``True`` we maintain
+        # per-environment KV-cache history (chunked obs + prior action) and
+        # replay it on each call so the model keeps long-horizon context.
+        self.enable_kv_cache_replay = bool(
+            getattr(cfg.lingbotva, "enable_kv_cache_replay", False)
+        )
+        self.training_mode = bool(
+            getattr(cfg.lingbotva, "training_mode", False)
+        )
+
+        self._backend: LingbotVALiberoBackend | None = None
+        self._episode_states: dict[int, LingbotVAEpisodeState] = {}
+        self._ac_applied = False
+
+        if self.training_mode:
+            self._load_transformer_for_training()
+
+    # ------------------------------------------------------------------
+    # Forward dispatch
+    # ------------------------------------------------------------------
+
+    def forward(self, forward_type=ForwardType.DEFAULT, **kwargs):
+        if forward_type == ForwardType.SFT:
+            return self.sft_forward(**kwargs)
+        if forward_type == ForwardType.DEFAULT:
+            return self.default_forward(**kwargs)
+        raise NotImplementedError(
+            f"LingBot-VA does not support forward_type={forward_type}."
+        )
+
+    def default_forward(self, **kwargs):
+        del kwargs
+        raise NotImplementedError(
+            "LingBot-VA default_forward is not supported. Use predict_action_batch "
+            "for eval or sft_forward for training."
+        )
+
+    # ------------------------------------------------------------------
+    # Training path
+    # ------------------------------------------------------------------
+
+    def _load_transformer_for_training(self) -> None:
+        """Load only the transformer + flow-matching schedulers (no VAE / TE)."""
+        repo_path = Path(self.config.lingbotva.repo_path)
+        extend_import_path(repo_path)
+        from wan_va.modules.utils import load_transformer
+
+        transformer_path = os.path.join(self.config.model_path, "transformer")
+        # The reference recipe loads fp32 then immediately casts to bf16 in
+        # `shard_model` (`model.to(dtype).cuda()`). We collapse that into a
+        # single bf16 load to keep peak host memory low and to avoid a 5 B
+        # fp32 model ever landing on the GPU.
+        # `attn_mode` defaults to "flex" to match the reference run; on
+        # torch < 2.9 the flex_attention + inductor combination hits a
+        # known codegen bug, so callers can override to "torch" (SDPA).
+        attn_mode = getattr(self.config.lingbotva, "attn_mode", "flex")
+        self.transformer = load_transformer(
+            transformer_path,
+            torch_dtype=self.torch_dtype,
+            torch_device="cpu",
+            attn_mode=attn_mode,
+        )
+        # `from_pretrained(torch_dtype=...)` casts checkpoint tensors but
+        # leaves freshly-initialised parameters (e.g. `scale_shift_table`)
+        # in their default fp32. FSDP1's flat-param refuses to flatten a
+        # module with mixed dtypes, so force the whole module to bf16.
+        self.transformer.to(dtype=self.torch_dtype)
+
+        # Optional SFT-checkpoint override (rare for first-stage SFT; useful
+        # when resuming or fine-tuning further).
+        override_path = getattr(
+            self.config.lingbotva, "transformer_state_dict_path", None
+        )
+        if override_path:
+            load_transformer_state_dict(self.transformer, override_path)
+
+        self._build_train_schedulers()
+        # Cache values needed by the loss / noise machinery.
+        self._patch_size = (1, 2, 2)  # va_shared_cfg.patch_size
+        self._snr_shift = 5.0  # va_libero_cfg.snr_shift
+        self._action_snr_shift = 0.05  # va_libero_cfg.action_snr_shift
+
+    def _build_train_schedulers(self) -> None:
+        from wan_va.utils import FlowMatchScheduler
+
+        self._train_scheduler_latent = FlowMatchScheduler(
+            shift=5.0, sigma_min=0.0, extra_one_step=True
+        )
+        self._train_scheduler_latent.set_timesteps(1000, training=True)
+        self._train_scheduler_action = FlowMatchScheduler(
+            shift=0.05, sigma_min=0.0, extra_one_step=True
+        )
+        self._train_scheduler_action.set_timesteps(1000, training=True)
+
+    def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None):
+        del gradient_checkpointing_kwargs
+        if self._ac_applied:
+            return
+        if not self.training_mode:
+            raise RuntimeError(
+                "gradient_checkpointing_enable is only valid in training_mode."
+            )
+        from wan_va.distributed.fsdp import apply_ac
+
+        apply_ac(self.transformer)
+        self._ac_applied = True
+
+    @torch.no_grad()
+    def _add_noise(
+        self,
+        latent: torch.Tensor,
+        train_scheduler,
+        action_mask: torch.Tensor | None = None,
+        action_mode: bool = False,
+        noisy_cond_prob: float = 0.0,
+    ) -> dict[str, torch.Tensor]:
+        """Sample flow-matching noise + timesteps. Mirrored from wan_va/train.py:_add_noise."""
+        from wan_va.utils import get_mesh_id, sample_timestep_id
+
+        B, _C, FrameDim, _H, _W = latent.shape
+        device = latent.device
+
+        timestep_ids = sample_timestep_id(
+            batch_size=FrameDim,
+            num_train_timesteps=train_scheduler.num_train_timesteps,
+        )
+        noise = torch.zeros_like(latent).normal_()
+        timesteps = train_scheduler.timesteps[timestep_ids].to(device=device)
+        noisy_latents = train_scheduler.add_noise(latent, noise, timesteps, t_dim=2)
+        targets = train_scheduler.training_target(latent, noise, timesteps)
+
+        patch_f, patch_h, patch_w = self._patch_size
+        if action_mode:
+            patch_f = patch_h = patch_w = 1
+
+        latent_grid_id = get_mesh_id(
+            latent.shape[-3] // patch_f,
+            latent.shape[-2] // patch_h,
+            latent.shape[-1] // patch_w,
+            t=1 if action_mode else 0,
+            f_w=1,
+            f_shift=0,
+            action=action_mode,
+        ).to(device)
+        latent_grid_id = latent_grid_id[None].repeat(B, 1, 1)
+
+        if torch.rand(1).item() < noisy_cond_prob:
+            cond_timestep_ids = sample_timestep_id(
+                batch_size=FrameDim,
+                min_timestep_bd=0.5,
+                max_timestep_bd=1.0,
+                num_train_timesteps=train_scheduler.num_train_timesteps,
+            )
+            noise = torch.zeros_like(latent).normal_()
+            cond_timesteps = train_scheduler.timesteps[cond_timestep_ids].to(
+                device=device
+            )
+            latent = train_scheduler.add_noise(
+                latent, noise, cond_timesteps, t_dim=2
+            )
+        else:
+            cond_timesteps = torch.zeros_like(timesteps)
+
+        if action_mask is not None:
+            noisy_latents *= action_mask.float()
+            targets *= action_mask.float()
+            latent *= action_mask.float()
+
+        return dict(
+            timesteps=timesteps[None].repeat(B, 1),
+            noisy_latents=noisy_latents,
+            targets=targets,
+            latent=latent,
+            cond_timesteps=cond_timesteps[None].repeat(B, 1),
+            grid_id=latent_grid_id,
+        )
+
+    @torch.no_grad()
+    def _prepare_input_dict(self, batch_dict: dict) -> dict:
+        """Build the transformer input dict. Mirrored from wan_va/train.py:_prepare_input_dict."""
+        latent_dict = self._add_noise(
+            latent=batch_dict["latents"],
+            train_scheduler=self._train_scheduler_latent,
+            action_mask=None,
+            action_mode=False,
+            noisy_cond_prob=0.5,
+        )
+        action_dict = self._add_noise(
+            latent=batch_dict["actions"],
+            train_scheduler=self._train_scheduler_action,
+            action_mask=batch_dict["actions_mask"],
+            action_mode=True,
+            noisy_cond_prob=0.0,
+        )
+
+        latent_dict["text_emb"] = batch_dict["text_emb"]
+        action_dict["text_emb"] = batch_dict["text_emb"]
+        action_dict["actions_mask"] = batch_dict["actions_mask"]
+
+        return {
+            "latent_dict": latent_dict,
+            "action_dict": action_dict,
+            "chunk_size": torch.randint(1, 5, (1,)).item(),
+            "window_size": torch.randint(4, 65, (1,)).item(),
+        }
+
+    def _compute_loss(self, input_dict: dict, pred) -> tuple[torch.Tensor, torch.Tensor]:
+        """Per-frame flow-matching MSE on latent + action streams.
+
+        Mirrored from wan_va/train.py:compute_loss, but without the
+        ``/ gradient_accumulation_steps`` division (RLinf's FSDPSftWorker
+        handles grad-accumulation by dividing the loss internally).
+        """
+        from einops import rearrange
+        from wan_va.utils import data_seq_to_patch
+
+        latent_pred, action_pred = pred
+        action_pred = rearrange(
+            action_pred,
+            "b (f n) c -> b c f n 1",
+            f=input_dict["action_dict"]["targets"].shape[-3],
+        )
+        latent_pred = data_seq_to_patch(
+            self._patch_size,
+            latent_pred,
+            input_dict["latent_dict"]["targets"].shape[-3],
+            input_dict["latent_dict"]["targets"].shape[-2],
+            input_dict["latent_dict"]["targets"].shape[-1],
+            batch_size=latent_pred.shape[0],
+        )
+        Bn, Fn = input_dict["latent_dict"]["timesteps"].shape
+        latent_loss_weight = self._train_scheduler_latent.training_weight(
+            input_dict["latent_dict"]["timesteps"].flatten()
+        ).reshape(Bn, Fn)
+        action_loss_weight = self._train_scheduler_action.training_weight(
+            input_dict["action_dict"]["timesteps"].flatten()
+        ).reshape(Bn, Fn)
+
+        latent_loss = F.mse_loss(
+            latent_pred.float(),
+            input_dict["latent_dict"]["targets"].float().detach(),
+            reduction="none",
+        )
+        latent_loss = latent_loss * latent_loss_weight[:, None, :, None, None]
+        latent_loss = latent_loss.permute(0, 2, 3, 4, 1)
+        latent_loss = latent_loss.flatten(0, 1).flatten(1)
+        latent_loss_per_frame = latent_loss.sum(dim=1)
+        latent_mask_per_frame = torch.ones_like(latent_loss).sum(dim=1)
+        latent_loss = (
+            latent_loss_per_frame / (latent_mask_per_frame + 1e-6)
+        ).mean()
+
+        action_loss = F.mse_loss(
+            action_pred.float(),
+            input_dict["action_dict"]["targets"].float().detach(),
+            reduction="none",
+        )
+        action_loss = action_loss * action_loss_weight[:, None, :, None, None]
+        action_loss = action_loss * input_dict["action_dict"]["actions_mask"].float()
+        action_loss = action_loss.permute(0, 2, 3, 4, 1)
+        action_mask = input_dict["action_dict"]["actions_mask"].float().permute(
+            0, 2, 3, 4, 1
+        )
+        action_loss = action_loss.flatten(0, 1).flatten(1)
+        action_mask = action_mask.flatten(0, 1).flatten(1)
+        action_loss_per_frame = action_loss.sum(dim=1)
+        action_mask_per_frame = action_mask.sum(dim=1)
+        action_loss = (
+            action_loss_per_frame / (action_mask_per_frame + 1e-6)
+        ).mean()
+
+        return latent_loss, action_loss
+
+    def sft_forward(self, data=None, **kwargs):
+        if data is None:
+            data = kwargs.get("data")
+        if data is None:
+            raise ValueError("sft_forward requires `data` from the SFT dataloader.")
+        if not self.training_mode:
+            raise RuntimeError(
+                "sft_forward called but cfg.lingbotva.training_mode is False."
+            )
+
+        device = next(self.transformer.parameters()).device
+        batch = {
+            k: v.to(device) for k, v in data.items() if torch.is_tensor(v)
+        }
+        input_dict = self._prepare_input_dict(batch)
+        output = self.transformer(input_dict, train_mode=True)
+        latent_loss, action_loss = self._compute_loss(input_dict, output)
+        return {
+            "loss": latent_loss + action_loss,
+            "latent_loss": latent_loss.detach(),
+            "action_loss": action_loss.detach(),
+        }
+
+    # ------------------------------------------------------------------
+    # Eval path (unchanged from the milestone-1 integration)
+    # ------------------------------------------------------------------
+
+    def _ensure_backend(self) -> LingbotVALiberoBackend:
+        if self.training_mode:
+            raise RuntimeError(
+                "Eval backend not available in training_mode; call sft_forward instead."
+            )
+        if self._backend is None:
+            self._backend = LingbotVALiberoBackend(self.config, self.torch_dtype)
+        return self._backend
+
+    def _get_state(self, env_idx: int) -> LingbotVAEpisodeState:
+        if env_idx not in self._episode_states:
+            self._episode_states[env_idx] = LingbotVAEpisodeState()
+        return self._episode_states[env_idx]
+
+    @staticmethod
+    def _get_prompt(env_obs: dict[str, Any], env_idx: int) -> str:
+        prompts = env_obs.get("task_descriptions")
+        if prompts is None:
+            raise ValueError(
+                "LingBot-VA requires task_descriptions in env observations."
+            )
+        return str(prompts[env_idx])
+
+    @staticmethod
+    def _select_executable_actions(
+        raw_action: np.ndarray, first_chunk: bool
+    ) -> np.ndarray:
+        """Convert raw model output to a flat sequence of env actions.
+
+        Args:
+            raw_action: array of shape
+                ``(action_dim, frame_chunk_size, action_per_frame)``.
+            first_chunk: if True the leading frame is skipped to match the
+                LingBot-VA Libero client behaviour.
+
+        Returns:
+            Array of shape ``(num_actions, action_dim)``.
+        """
+        start_idx = 1 if first_chunk else 0
+        selected = raw_action[:, start_idx:, :]
+        return np.transpose(selected, (1, 2, 0)).reshape(-1, raw_action.shape[0])
+
+    def reset_episode(self, env_idx: int, prompt: str | None = None) -> None:
+        """Drop cached state for the given env so the next call is a first chunk."""
+        self._get_state(env_idx).reset(prompt or "")
+
+    def record_chunk_observations(
+        self,
+        env_idx: int,
+        chunk_obs_list: list[dict[str, Any]],
+        prev_model_action: np.ndarray,
+    ) -> None:
+        """Push the previous chunk's observations into the KV-cache history.
+
+        ``chunk_obs_list`` is the per-step raw libero observation dicts (with
+        ``agentview_image`` and ``robot0_eye_in_hand_image`` keys). We pick the
+        configured key frames (every ``action_per_frame`` steps) and pair them
+        with the raw model action that produced them so the backend can replay
+        them into the transformer's KV cache on the next inference.
+        """
+        if not self.enable_kv_cache_replay:
+            return
+        state = self._get_state(env_idx)
+        if state.prompt is None:
+            return
+        # The LingBot-VA clients sample key frames every ``action_per_frame // 4``
+        # env steps (so they record 4 key frames per video frame predicted by
+        # the model). For Libero that period is 1 (every step), for RoboTwin
+        # 4. Fall back to 1 if the integer division would round to 0.
+        period = max(1, self.action_per_frame // 4)
+        key_frames: list[dict[str, Any]] = []
+        for step_idx, raw_obs in enumerate(chunk_obs_list):
+            if (step_idx + 1) % period != 0:
+                continue
+            key_frames.append(
+                LingbotVALiberoObservationAdapter.format_raw_step_observation(
+                    raw_obs=raw_obs,
+                    prompt=state.prompt,
+                )
+            )
+        if not key_frames:
+            return
+        state.kv_cache_history.append(
+            (key_frames, np.asarray(prev_model_action, dtype=np.float32).copy())
+        )
+
+    def predict_action_batch(
+        self, env_obs: dict[str, Any], mode: str = "eval", **_: Any
+    ):
+        if mode != "eval":
+            raise NotImplementedError(
+                "LingBot-VA Libero adapter only supports eval mode."
+            )
+        if self.training_mode:
+            raise RuntimeError(
+                "predict_action_batch is unavailable while training_mode=True; "
+                "the eval backend is not initialised."
+            )
+        states_tensor = env_obs.get("states")
+        if states_tensor is None:
+            raise ValueError("LingBot-VA requires batched states in env observations.")
+        batch_size = states_tensor.shape[0]
+
+        backend = self._ensure_backend()
+
+        prompts: list[str] = []
+        obs_batch: list[dict[str, Any]] = []
+        kv_cache_histories: list[list[tuple[list[dict[str, Any]], np.ndarray]]] = []
+        first_chunk_flags: list[bool] = []
+
+        for env_idx in range(batch_size):
+            prompt = self._get_prompt(env_obs, env_idx)
+            state = self._get_state(env_idx)
+            if state.prompt != prompt:
+                state.reset(prompt)
+            obs = LingbotVALiberoObservationAdapter.format_observation(
+                env_obs, env_idx, prompt
+            )
+            if state.first_obs is None:
+                state.first_obs = obs
+            prompts.append(prompt)
+            # When KV-cache replay is enabled we reuse the cached first_obs to
+            # keep the obs grid consistent with the replayed history.
+            obs_batch.append(state.first_obs if self.enable_kv_cache_replay else obs)
+            kv_cache_histories.append(list(state.kv_cache_history))
+            first_chunk_flags.append(state.first_chunk)
+
+        replay_groups_match = all(
+            len(history) == len(kv_cache_histories[0]) for history in kv_cache_histories
+        )
+        if (
+            self.enable_kv_cache_replay
+            and replay_groups_match
+            and any(len(h) > 0 for h in kv_cache_histories)
+        ):
+            raw_actions = backend.infer_batch(
+                obs_batch, prompts, kv_cache_histories=kv_cache_histories
+            )
+            current_first_chunk = False
+        else:
+            raw_actions = backend.infer_batch(obs_batch, prompts)
+            current_first_chunk = any(first_chunk_flags)
+
+        chunks: list[torch.Tensor] = []
+        for env_idx, raw_action in enumerate(raw_actions):
+            state = self._get_state(env_idx)
+            # Without KV-cache replay every call rebuilds context from the
+            # current observation, so the model is effectively starting a
+            # fresh "first chunk" each time and we must drop the leading
+            # placeholder frame. Once we are using KV replay we follow the
+            # LingBot-VA client semantics: skip the frame only on the very
+            # first inference per episode.
+            is_first_chunk_for_selection = (
+                state.first_chunk if self.enable_kv_cache_replay else True
+            )
+            env_actions = self._select_executable_actions(
+                raw_action, first_chunk=is_first_chunk_for_selection
+            )
+            limit = min(self.exec_steps_per_chunk, env_actions.shape[0])
+            chunks.append(torch.from_numpy(env_actions[:limit]))
+            # Track this chunk's raw model action so callers can hand it back
+            # via ``record_chunk_observations`` for KV replay on the next call.
+            state.prev_model_action = raw_action.astype(np.float32)
+            state.last_action_per_frame = raw_action.shape[2]
+            state.first_chunk = False
+
+        # In multi-env mode envs can be in different first-chunk states; we
+        # truncate to the shortest chunk so we can stack into a single tensor.
+        common_len = min(c.shape[0] for c in chunks)
+        chunks = [c[:common_len] for c in chunks]
+
+        action_tensor = torch.stack(chunks, dim=0).to(dtype=torch.float32)
+        zeros = torch.zeros(action_tensor.shape[:2], dtype=torch.float32)
+        result = {
+            "prev_logprobs": zeros,
+            "prev_values": zeros,
+            "forward_inputs": {"action": action_tensor},
+        }
+        return action_tensor, result

--- a/rlinf/workers/sft/fsdp_vla_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_vla_sft_worker.py
@@ -67,6 +67,21 @@ class FSDPVlaSftWorker(FSDPSftWorker):
             return build_dreamzero_sft_dataloader(
                 self.cfg, self._world_size, self._rank, data_paths, eval_dataset
             )
+        elif SupportedModel(self.cfg.actor.model.model_type) in [
+            SupportedModel.LINGBOTVA
+        ]:
+            self._lingbotva_loss = None
+            self._lingbotva_loss_accum: dict[str, list[torch.Tensor]] = {
+                "latent_loss": [],
+                "action_loss": [],
+            }
+            from rlinf.data.datasets.lingbotva import (
+                build_lingbotva_sft_dataloader,
+            )
+
+            return build_lingbotva_sft_dataloader(
+                self.cfg, self._world_size, self._rank, data_paths, eval_dataset
+            )
         else:
             raise KeyError(
                 f"not support such model type {self.cfg.actor.model.model_type} for SFT right now."
@@ -80,6 +95,7 @@ class FSDPVlaSftWorker(FSDPSftWorker):
         if SupportedModel(self.cfg.actor.model.model_type) in [
             SupportedModel.LINGBOTVLA,
             SupportedModel.DREAMZERO,
+            SupportedModel.LINGBOTVA,
         ]:
             with self.amp_context:
                 losses_dict = self.model(forward_type=ForwardType.SFT, data=batch)
@@ -88,6 +104,17 @@ class FSDPVlaSftWorker(FSDPSftWorker):
                     "dynamics_loss": losses_dict["dynamics_loss"],
                     "action_loss": losses_dict["action_loss"],
                 }
+            if losses_dict.get("latent_loss", None) is not None:
+                # Accumulate per-micro-batch latent/action loss so the metric we
+                # report per optimizer step is the mean across grad-accum
+                # micro-batches, matching upstream lingbot-va's reporting (which
+                # logs `sum(loss_i / grad_accum)` over grad_accum micro-batches).
+                self._lingbotva_loss_accum["latent_loss"].append(
+                    losses_dict["latent_loss"]
+                )
+                self._lingbotva_loss_accum["action_loss"].append(
+                    losses_dict["action_loss"]
+                )
             return losses_dict["loss"]
         observation, actions = batch
 
@@ -126,6 +153,27 @@ class FSDPVlaSftWorker(FSDPSftWorker):
                 }
             )
             self._dreamzero_loss = None
+        if (
+            SupportedModel(self.cfg.actor.model.model_type)
+            in [SupportedModel.LINGBOTVA]
+            and getattr(self, "_lingbotva_loss_accum", None) is not None
+            and self._lingbotva_loss_accum["latent_loss"]
+        ):
+            # Report the per-component mean across grad-accum micro-batches,
+            # matching upstream lingbot-va's reporting. Without this we'd log
+            # only the last micro-batch's noisy single-sample value, which is
+            # far below the mean for the heavy-tailed action-timestep weights.
+            latent_mean = torch.stack(
+                self._lingbotva_loss_accum["latent_loss"]
+            ).mean()
+            action_mean = torch.stack(
+                self._lingbotva_loss_accum["action_loss"]
+            ).mean()
+            train_metrics.update(
+                {"latent_loss": latent_mean, "action_loss": action_mean}
+            )
+            self._lingbotva_loss_accum["latent_loss"].clear()
+            self._lingbotva_loss_accum["action_loss"].clear()
         return train_metrics
 
     def save_checkpoint(self, save_path: str, step: int = 0) -> None:

--- a/tests/e2e_tests/sft/libero_sft_lingbotva.yaml
+++ b/tests/e2e_tests/sft/libero_sft_lingbotva.yaml
@@ -1,0 +1,95 @@
+defaults:
+  - model/lingbotva@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/embodiment/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor: 0
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "/workspace/results/"
+    project_name: rlinf
+    experiment_name: "libero_sft_lingbotva_e2e"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: -1
+  max_steps: 3
+  val_check_interval: -1
+  save_interval: -1
+  log_interval: 1
+
+  resume_dir: null
+
+data:
+  train_data_paths: ${oc.env:LINGBOT_VA_DATASET_PATH,/workspace/dataset/data/sft-ci-data/lingbotva-libero}
+  num_workers: 0
+
+algorithm:
+  adv_type: gae
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 1
+  global_batch_size: 1
+  seed: 42
+  dataloader_num_workers: 0
+  enable_offload: False
+
+  model:
+    model_type: "lingbotva"
+    precision: bf16
+    model_path: ${oc.env:LINGBOT_VA_MODEL_PATH,/workspace/dataset/lingbot-va-base}
+    num_action_chunks: 12
+    action_dim: 7
+    is_lora: False
+    add_value_head: False
+    lingbotva:
+      repo_path: ${oc.env:LINGBOT_VA_REPO_PATH,/workspace/lingbot-va}
+      config_name: libero
+      training_mode: true
+      enable_offload: false
+      action_per_frame: 4
+      cfg_prob: 0.1
+      attn_mode: torch
+      save_root: ./runtime/lingbotva_sft_e2e
+
+  optim:
+    lr: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 1.0e-1
+    clip_grad: 2.0
+    optimizer_type: adamw_8bit
+    lr_scheduler: constant
+    lr_warmup_steps: 1
+    total_training_steps: 3
+
+  fsdp_config:
+    strategy: "fsdp"
+    sharding_strategy: "no_shard"
+    use_orig_params: True
+    gradient_checkpointing: True
+    limit_all_gathers: True
+    reshard_after_forward: False
+    grad_scaler:
+      enabled: False
+    mixed_precision:
+      param_dtype: bf16
+      reduce_dtype: fp32
+      buffer_dtype: bf16
+    amp_autocast:
+      enabled: false
+      precision: "bf16"

--- a/toolkits/data_scripts_lingbotva/README.md
+++ b/toolkits/data_scripts_lingbotva/README.md
@@ -1,0 +1,73 @@
+# LingBot-VA Data Preparation Scripts
+
+End-to-end recipe that turns raw LIBERO-Object HDF5 demonstrations into
+the LeRobot v2.1 + pre-extracted Wan 2.2 VAE latents bundle that the
+LingBot-VA SFT loader (`rlinf/data/datasets/lingbotva.py`) expects.
+
+These three scripts must be run in order — each consumes the output of
+the previous one.
+
+| Step | Script | Input | Output |
+|---|---|---|---|
+| (a) | [`convert_libero_object_to_lerobot.py`](convert_libero_object_to_lerobot.py) | `${LIBERO_RAW_DIR}/libero_object/*.hdf5` (10 files, 50 demos each, from `yifengzhu-hf/LIBERO-datasets`) | `${LINGBOT_VA_DATASET_PATH}_full/` — LeRobot v2.1 dataset with LingBot-VA's `action_config` annotation injected into `episodes.jsonl` and both cameras vertically flipped to display orientation. |
+| (b) | [`select_subset.py`](select_subset.py) | `${LINGBOT_VA_DATASET_PATH}_full/` | `${LINGBOT_VA_DATASET_PATH}/` — deterministic per-task subset (default 10 demos × 10 tasks via `--per-task 10 --seed 42`). Symlinks parquet + video files from the parent dataset so the subset doesn't duplicate ~7 GB of mp4s. |
+| (c) | [`extract_latents.py`](extract_latents.py) | `${LINGBOT_VA_DATASET_PATH}/` and the LingBot-VA base checkpoint (`${LINGBOT_VA_MODEL_PATH}`) | Pre-extracted Wan 2.2 VAE latents at `latents/chunk-000/observation.images.*/episode_NNNNNN_<s>_<e>.pth` plus a cached UMT5 empty-prompt embedding at `empty_emb.pt`. |
+
+## Usage
+
+```bash
+# Set paths
+export LIBERO_RAW_DIR=<your-libero-raw-dir>
+export LINGBOT_VA_DATASET_PATH=<your-dataset-dir>
+export LINGBOT_VA_MODEL_PATH=<your-model-dir>
+
+# (a) HDF5 -> LeRobot v2.1
+python toolkits/data_scripts_lingbotva/convert_libero_object_to_lerobot.py \
+  --hdf5-root ${LIBERO_RAW_DIR}/libero_object \
+  --output ${LINGBOT_VA_DATASET_PATH}_full
+
+# (b) Subsample 10 demos x 10 tasks (deterministic via seed 42)
+python toolkits/data_scripts_lingbotva/select_subset.py \
+  --src ${LINGBOT_VA_DATASET_PATH}_full \
+  --dst ${LINGBOT_VA_DATASET_PATH} \
+  --per-task 10 --seed 42
+
+# (c) Pre-extract Wan 2.2 VAE latents + cache UMT5 empty embedding
+python toolkits/data_scripts_lingbotva/extract_latents.py \
+  --dataset ${LINGBOT_VA_DATASET_PATH} \
+  --model-path ${LINGBOT_VA_MODEL_PATH}
+```
+
+## Prerequisites
+
+- `LINGBOT_VA_REPO_PATH` and `PYTHONPATH` set so `wan_va` and its
+  dependencies (`AutoencoderKLWan`, `UMT5EncoderModel`, etc.) import. See
+  `examples/embodiment/config/model/lingbotva.yaml` and
+  `docs/source-en/rst_source/examples/embodied/sft_lingbotva.rst` for the
+  full environment setup.
+- Raw HDF5 demos from **`yifengzhu-hf/LIBERO-datasets`** specifically — the
+  IPEC-COMMUNITY mirror uses a different wrist-camera mount and produces
+  0 % eval SR even though training looks healthy.
+
+## Expected layout under `${LINGBOT_VA_DATASET_PATH}` after step (c)
+
+```
+meta/{info.json,episodes.jsonl,episodes_stats.jsonl,tasks.jsonl}
+data/chunk-000/episode_NNNNNN.parquet                                       (100 episodes)
+videos/chunk-000/observation.images.{agentview_rgb,eye_in_hand_rgb}/episode_NNNNNN.mp4
+latents/chunk-000/observation.images.{agentview_rgb,eye_in_hand_rgb}/episode_NNNNNN_<s>_<e>.pth
+empty_emb.pt
+```
+
+## Notes
+
+- **`(b) → (c)` symlink trick.** `select_subset.py` pre-creates dangling
+  symlinks under the subset's `latents/...` tree pointing at the parent
+  dataset's `latents/...` slot. When `extract_latents.py` then runs on
+  the subset, `torch.save` follows the symlink and writes the actual
+  `.pth` into the parent dataset — so additional subsets that share
+  episodes don't have to re-encode the same frames.
+- If `lerobot>=0.3.3` rejects the dataset because `episodes_stats.jsonl`
+  has image stats stored as `(3,)` instead of `(3, 1, 1)`, reshape the
+  per-channel stats in place (the `_full` copy from step (a) preserves
+  the original).

--- a/toolkits/data_scripts_lingbotva/convert_libero_object_to_lerobot.py
+++ b/toolkits/data_scripts_lingbotva/convert_libero_object_to_lerobot.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Convert raw LIBERO-Object HDF5 demos to a LeRobot v2.1 dataset with
+LingBot-VA's `action_config` annotation injected into episodes.jsonl.
+
+Source (download separately):
+    datasets/libero_object_hdf5/libero_object/*.hdf5   (10 files, 50 demos each)
+
+Output (LeRobot v2.1 layout, ready for select_subset.py + extract_latents.py):
+    datasets/libero_object_hdf5_prepared/
+        meta/{info,tasks,episodes,episodes_stats}.jsonl + info.json
+        data/chunk-000/episode_NNNNNN.parquet
+        videos/chunk-000/observation.images.agentview_rgb/episode_NNNNNN.mp4
+        videos/chunk-000/observation.images.eye_in_hand_rgb/episode_NNNNNN.mp4
+
+Key contracts (must match the eval client + the LingBot-VA loader):
+  * BOTH cameras get a vertical flip (`frames[:, ::-1]`). HDF5 stores
+    OpenGL-orientation frames; the eval client also flips sim output, so
+    training data must be in display orientation to match inference.
+  * Action stays in raw 7-dim LIBERO format with gripper in [-1, +1].
+    Padding to the 30-dim standard layout happens at load time via
+    `inverse_used_action_channel_ids` — DO NOT pre-pad here.
+  * Camera keys must be exactly `observation.images.agentview_rgb` and
+    `observation.images.eye_in_hand_rgb` (see va_libero_cfg.obs_cam_keys).
+  * Task order is the LIBERO benchmark order 0..9 (matches §1's per-task
+    SR table; do not reorder by HDF5 mtime / alphabetical filename).
+  * Video encoding: libx264, yuv420p, CRF 18 at 20 fps (near-lossless
+    for VAE input — extract_latents.py reads these mp4s back).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+
+os.environ.setdefault("MUJOCO_GL", "egl")  # avoid headless GL crash on benchmark import
+from libero.libero import benchmark  # noqa: E402
+
+FPS = 20
+HEIGHT = 128
+WIDTH = 128
+CHUNK_SIZE = 1000  # one chunk holds all 500 episodes
+CRF = 18
+PIX_FMT = "yuv420p"
+CODEC = "libx264"
+CAM_KEYS = [
+    "observation.images.agentview_rgb",
+    "observation.images.eye_in_hand_rgb",
+]
+HDF5_CAM_KEYS = {  # LeRobot-side key -> HDF5-side path under data/demo_N/obs/
+    "observation.images.agentview_rgb": "agentview_rgb",
+    "observation.images.eye_in_hand_rgb": "eye_in_hand_rgb",
+}
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def find_hdf5_for_task(hdf5_dir: Path, task_name: str) -> Path:
+    """LIBERO HDF5 filenames are `<task.name>_demo.hdf5`."""
+    candidate = hdf5_dir / f"{task_name}_demo.hdf5"
+    if candidate.exists():
+        return candidate
+    # Fallback: match by stripping `_demo` suffix and comparing slugs.
+    slug = re.sub(r"\s+", "_", task_name.strip().lower())
+    for p in sorted(hdf5_dir.glob("*_demo.hdf5")):
+        if p.stem.replace("_demo", "") == slug:
+            return p
+    raise FileNotFoundError(
+        f"No HDF5 found for task '{task_name}' under {hdf5_dir}"
+    )
+
+
+def encode_video_ffmpeg(frames: np.ndarray, out_path: Path, fps: int) -> None:
+    """Pipe a (T,H,W,3) uint8 RGB array through ffmpeg at libx264 CRF 18."""
+    assert frames.ndim == 4 and frames.shape[-1] == 3 and frames.dtype == np.uint8
+    T, H, W, _ = frames.shape
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-f", "rawvideo",
+        "-pixel_format", "rgb24",
+        "-video_size", f"{W}x{H}",
+        "-framerate", str(fps),
+        "-i", "-",
+        "-c:v", CODEC,
+        "-pix_fmt", PIX_FMT,
+        "-crf", str(CRF),
+        "-preset", "medium",
+        "-an",
+        str(out_path),
+    ]
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    proc.communicate(input=np.ascontiguousarray(frames).tobytes())
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffmpeg failed for {out_path}")
+
+
+def feature_stats(arr: np.ndarray) -> dict:
+    """Per-dim {min,max,mean,std,count} for a (T, D) action/state array."""
+    arr = arr.astype(np.float64, copy=False)
+    return {
+        "min": arr.min(axis=0).tolist(),
+        "max": arr.max(axis=0).tolist(),
+        "mean": arr.mean(axis=0).tolist(),
+        "std": arr.std(axis=0).tolist(),
+        "count": [int(arr.shape[0])],
+    }
+
+
+def video_stats_placeholder(channels: int = 3) -> dict:
+    """Per-channel placeholder stats. LatentLeRobotDataset doesn't aggregate
+    these at training time (self.episodes is None), so the values are not
+    load-bearing — but the schema slot must be present."""
+    return {
+        "min": [0.0] * channels,
+        "max": [1.0] * channels,
+        "mean": [0.5] * channels,
+        "std": [0.25] * channels,
+        "count": [1],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Conversion
+# --------------------------------------------------------------------------- #
+
+def convert(src: Path, dst: Path, benchmark_name: str = "libero_object") -> None:
+    if dst.exists():
+        raise SystemExit(
+            f"Destination exists: {dst}. Remove it first to avoid mixing runs."
+        )
+    bench_dict = benchmark.get_benchmark_dict()
+    bench = bench_dict[benchmark_name]()
+    n_tasks = bench.get_num_tasks()
+    print(f"[convert] {benchmark_name}: {n_tasks} tasks")
+
+    data_dir = dst / "data" / "chunk-000"
+    meta_dir = dst / "meta"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    for cam in CAM_KEYS:
+        (dst / "videos" / "chunk-000" / cam).mkdir(parents=True, exist_ok=True)
+
+    # tasks.jsonl: one line per unique task language, deterministic order.
+    task_languages: list[str] = []
+    for t_idx in range(n_tasks):
+        task = bench.get_task(t_idx)
+        lang = getattr(task, "language", None) or task.name.replace("_", " ")
+        task_languages.append(lang)
+    tasks_path = meta_dir / "tasks.jsonl"
+    with tasks_path.open("w") as f:
+        for ti, lang in enumerate(task_languages):
+            f.write(json.dumps({"task_index": ti, "task": lang}) + "\n")
+
+    # Sweep: per task, per demo, emit parquet + 2 mp4s, accumulate metadata.
+    episode_lines: list[dict] = []
+    episode_stats_lines: list[dict] = []
+    global_idx = 0      # cumulative frame index across all episodes
+    episode_index = 0   # cumulative episode index
+    total_frames = 0
+
+    for t_idx in range(n_tasks):
+        task = bench.get_task(t_idx)
+        lang = task_languages[t_idx]
+        hdf5_path = find_hdf5_for_task(src, task.name)
+        print(f"[convert] task {t_idx}: {task.name}  ({hdf5_path.name})")
+
+        with h5py.File(hdf5_path, "r") as f:
+            demo_keys = sorted(
+                (k for k in f["data"].keys() if k.startswith("demo_")),
+                key=lambda k: int(k.split("_")[1]),
+            )
+            for demo_key in demo_keys:
+                grp = f["data"][demo_key]
+                actions = np.array(grp["actions"], dtype=np.float32)  # (T, 7)
+                T = actions.shape[0]
+                # observation.state: 8-dim (joint_states 7 + gripper 1) is the
+                # LIBERO convention. Fall back to whatever exists.
+                if "obs/joint_states" in grp and "obs/gripper_states" in grp:
+                    joint = np.array(grp["obs/joint_states"], dtype=np.float32)
+                    gripper = np.array(grp["obs/gripper_states"], dtype=np.float32)
+                    if gripper.ndim == 1:
+                        gripper = gripper[:, None]
+                    state = np.concatenate([joint, gripper], axis=1)
+                elif "obs/ee_states" in grp:
+                    state = np.array(grp["obs/ee_states"], dtype=np.float32)
+                else:
+                    state = np.zeros((T, 8), dtype=np.float32)
+
+                # Cameras: HDF5 -> uint8 (T, H, W, 3) in OpenGL orientation.
+                # Flip vertically so display orientation matches the eval client
+                # (which also flips sim output before sending to the server).
+                cam_frames: dict[str, np.ndarray] = {}
+                for cam_key, hdf5_name in HDF5_CAM_KEYS.items():
+                    arr = np.array(grp[f"obs/{hdf5_name}"])
+                    if arr.dtype != np.uint8:
+                        arr = arr.astype(np.uint8)
+                    arr = np.ascontiguousarray(arr[:, ::-1])  # vertical flip
+                    assert arr.shape == (T, HEIGHT, WIDTH, 3), (
+                        f"unexpected {cam_key} shape {arr.shape} for {demo_key}"
+                    )
+                    cam_frames[cam_key] = arr
+
+                # Write per-episode parquet.
+                timestamps = (np.arange(T) / FPS).astype(np.float32)
+                frame_indices = np.arange(T, dtype=np.int64)
+                ep_df = pd.DataFrame({
+                    "action": list(actions),
+                    "observation.state": list(state),
+                    "timestamp": timestamps,
+                    "frame_index": frame_indices,
+                    "episode_index": np.full(T, episode_index, dtype=np.int64),
+                    "index": np.arange(global_idx, global_idx + T, dtype=np.int64),
+                    "task_index": np.full(T, t_idx, dtype=np.int64),
+                })
+                ep_df.to_parquet(
+                    data_dir / f"episode_{episode_index:06d}.parquet",
+                    index=False,
+                )
+
+                # Write mp4s.
+                for cam_key, frames in cam_frames.items():
+                    out_mp4 = (
+                        dst / "videos" / "chunk-000" / cam_key
+                        / f"episode_{episode_index:06d}.mp4"
+                    )
+                    encode_video_ffmpeg(frames, out_mp4, fps=FPS)
+
+                # episodes.jsonl line — with the LingBot-VA `action_config`
+                # field. Single segment covering the whole episode.
+                episode_lines.append({
+                    "episode_index": episode_index,
+                    "tasks": [lang],
+                    "length": int(T),
+                    "action_config": [{
+                        "start_frame": 0,
+                        "end_frame": int(T),
+                        "action_text": lang,
+                    }],
+                })
+
+                # episodes_stats.jsonl line.
+                episode_stats_lines.append({
+                    "episode_index": episode_index,
+                    "stats": {
+                        "action": feature_stats(actions),
+                        "observation.state": feature_stats(state),
+                        "observation.images.agentview_rgb": video_stats_placeholder(),
+                        "observation.images.eye_in_hand_rgb": video_stats_placeholder(),
+                        "timestamp": feature_stats(timestamps[:, None]),
+                        "frame_index": feature_stats(frame_indices[:, None].astype(np.float32)),
+                        "episode_index": feature_stats(
+                            np.full((T, 1), episode_index, dtype=np.float32)
+                        ),
+                        "index": feature_stats(
+                            np.arange(global_idx, global_idx + T,
+                                      dtype=np.float32)[:, None]
+                        ),
+                        "task_index": feature_stats(
+                            np.full((T, 1), t_idx, dtype=np.float32)
+                        ),
+                    },
+                })
+
+                episode_index += 1
+                global_idx += T
+                total_frames += T
+
+    # Write episodes.jsonl + episodes_stats.jsonl
+    with (meta_dir / "episodes.jsonl").open("w") as f:
+        for line in episode_lines:
+            f.write(json.dumps(line) + "\n")
+    with (meta_dir / "episodes_stats.jsonl").open("w") as f:
+        for line in episode_stats_lines:
+            f.write(json.dumps(line) + "\n")
+
+    # info.json — schema declaration LeRobot reads on dataset open.
+    info = {
+        "codebase_version": "v2.1",
+        "robot_type": "panda",
+        "total_episodes": episode_index,
+        "total_frames": total_frames,
+        "total_tasks": n_tasks,
+        "total_videos": episode_index * len(CAM_KEYS),
+        "total_chunks": 1,
+        "chunks_size": CHUNK_SIZE,
+        "fps": FPS,
+        "splits": {"train": f"0:{episode_index}"},
+        "data_path": "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet",
+        "video_path": "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4",
+        "features": {
+            "action": {
+                "dtype": "float32",
+                "shape": [7],
+                "names": [
+                    "ee_x", "ee_y", "ee_z",
+                    "ee_rx", "ee_ry", "ee_rz",
+                    "gripper",
+                ],
+            },
+            "observation.state": {
+                "dtype": "float32",
+                "shape": [state.shape[1]],
+                "names": [f"s{i}" for i in range(state.shape[1])],
+            },
+            "observation.images.agentview_rgb": {
+                "dtype": "video",
+                "shape": [HEIGHT, WIDTH, 3],
+                "names": ["height", "width", "channel"],
+                "info": {
+                    "video.fps": float(FPS),
+                    "video.codec": "h264",
+                    "video.pix_fmt": PIX_FMT,
+                    "video.is_depth_map": False,
+                    "video.has_audio": False,
+                },
+            },
+            "observation.images.eye_in_hand_rgb": {
+                "dtype": "video",
+                "shape": [HEIGHT, WIDTH, 3],
+                "names": ["height", "width", "channel"],
+                "info": {
+                    "video.fps": float(FPS),
+                    "video.codec": "h264",
+                    "video.pix_fmt": PIX_FMT,
+                    "video.is_depth_map": False,
+                    "video.has_audio": False,
+                },
+            },
+            "timestamp": {"dtype": "float32", "shape": [1], "names": None},
+            "frame_index": {"dtype": "int64", "shape": [1], "names": None},
+            "episode_index": {"dtype": "int64", "shape": [1], "names": None},
+            "index": {"dtype": "int64", "shape": [1], "names": None},
+            "task_index": {"dtype": "int64", "shape": [1], "names": None},
+        },
+    }
+    with (meta_dir / "info.json").open("w") as f:
+        json.dump(info, f, indent=2)
+
+    print(
+        f"[convert] done. episodes={episode_index} frames={total_frames} "
+        f"-> {dst}"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--src",
+        type=Path,
+        default=Path("datasets/libero_object_hdf5/libero_object"),
+        help="Directory of `*_demo.hdf5` files",
+    )
+    p.add_argument(
+        "--dst",
+        type=Path,
+        default=Path("datasets/libero_object_hdf5_prepared"),
+        help="Output LeRobot v2.1 dataset directory",
+    )
+    p.add_argument(
+        "--benchmark",
+        default="libero_object",
+        help="LIBERO benchmark name (default: libero_object)",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    if shutil.which("ffmpeg") is None:
+        sys.exit("ffmpeg not found on PATH; install it or use the imageio binary.")
+    convert(args.src, args.dst, benchmark_name=args.benchmark)

--- a/toolkits/data_scripts_lingbotva/extract_latents.py
+++ b/toolkits/data_scripts_lingbotva/extract_latents.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Pre-extract Wan2.2 VAE latents + UMT5 text embeddings for a LeRobot v2.1
+dataset, in the on-disk format LingBot-VA's `LatentLeRobotDataset` expects.
+
+For each episode E and each camera key K listed in `obs_cam_keys`:
+    <dataset>/latents/chunk-000/<K>/episode_<E:06d>_<start>_<end>.pth
+
+The .pth payload is a dict with these keys (LingBot-VA contract — see
+README §"Custom Dataset Preparation" and `lerobot_latent_dataset.py:209`):
+
+    latent              torch.bfloat16, shape (latent_num_frames * latent_height * latent_width, C)
+                        — flat over (T,H,W), channel-last. The loader does
+                          `rearrange(latent, '(f h w) c -> f h w c', f=..., h=..., w=...)`.
+    latent_num_frames   int   — temporal extent in latent space (Wan VAE: (T-1)//4 + 1)
+    latent_height       int   — H // 8
+    latent_width        int   — W // 8
+    video_num_frames    int   — number of frames actually fed to the VAE (after fps subsampling)
+    video_height        int   — input H after resize
+    video_width         int   — input W after resize
+    text_emb            torch.bfloat16, shape (512, D) — same shape the server produces in `_get_t5_prompt_embeds`
+                          with max_sequence_length=512 (real tokens then zero-padded).
+    text                str   — raw action_text from episodes.jsonl
+    frame_ids           list[int] — source-video frame indices actually sampled
+    start_frame         int   — start_frame from action_config (in original-fps frame indexing)
+    end_frame           int   — end_frame from action_config
+    fps                 int   — target sampling fps
+    ori_fps             int   — original-video fps
+
+Side outputs:
+    <dataset>/empty_emb.pt    Tensor (512, D) bfloat16 — UMT5 embedding of "",
+                              used by the loader for classifier-free guidance dropout.
+
+Replicates the server's exact preprocessing so latents extracted here match
+the streaming-server protocol bit-for-bit:
+    * Pixel norm:  `frames/255.0 * 2.0 - 1.0`            (videos in [-1, +1])
+    * Latent norm: `(mu - latents_mean) * (1/latents_std)` using
+                   vae.config.latents_mean / latents_std
+    * Text:        tokenize with padding='max_length', max_length=512;
+                   encode; truncate to attn-mask length; re-pad with zeros.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import imageio.v3 as iio
+import numpy as np
+import torch
+from diffusers import AutoencoderKLWan
+from einops import rearrange
+from tqdm import tqdm
+from transformers import T5TokenizerFast, UMT5EncoderModel
+
+CHUNK_DIR = "chunk-000"
+DEFAULT_CAM_KEYS = [
+    "observation.images.agentview_rgb",
+    "observation.images.eye_in_hand_rgb",
+]
+MAX_TEXT_LEN = 512  # matches wan_va_server.py:_reset (encode_prompt max_sequence_length=512)
+
+
+# --------------------------------------------------------------------------- #
+# Loaders
+# --------------------------------------------------------------------------- #
+
+def load_vae(ckpt_dir: Path, device: str, dtype: torch.dtype) -> AutoencoderKLWan:
+    vae = AutoencoderKLWan.from_pretrained(ckpt_dir / "vae", torch_dtype=dtype)
+    vae.eval()
+    vae.requires_grad_(False)
+    return vae.to(device)
+
+
+def load_text_stack(
+    ckpt_dir: Path, device: str, dtype: torch.dtype
+) -> tuple[T5TokenizerFast, UMT5EncoderModel]:
+    tokenizer = T5TokenizerFast.from_pretrained(ckpt_dir / "tokenizer")
+    text_encoder = UMT5EncoderModel.from_pretrained(
+        ckpt_dir / "text_encoder", torch_dtype=dtype
+    )
+    text_encoder.eval()
+    text_encoder.requires_grad_(False)
+    return tokenizer, text_encoder.to(device)
+
+
+# --------------------------------------------------------------------------- #
+# Encoding
+# --------------------------------------------------------------------------- #
+
+def prompt_clean(text: str) -> str:
+    """Match diffusers.pipelines.wan.pipeline_wan.prompt_clean — collapse
+    consecutive whitespace and strip."""
+    return " ".join(text.split()).strip()
+
+
+@torch.no_grad()
+def encode_text(
+    text: str,
+    tokenizer: T5TokenizerFast,
+    text_encoder: UMT5EncoderModel,
+    device: str,
+    dtype: torch.dtype,
+    max_len: int = MAX_TEXT_LEN,
+) -> torch.Tensor:
+    """Return a CPU tensor (max_len, D) in `dtype`. Mirrors
+    wan_va_server.py:_get_t5_prompt_embeds (single prompt)."""
+    cleaned = prompt_clean(text)
+    inputs = tokenizer(
+        [cleaned],
+        padding="max_length",
+        max_length=max_len,
+        truncation=True,
+        add_special_tokens=True,
+        return_attention_mask=True,
+        return_tensors="pt",
+    )
+    ids = inputs.input_ids.to(device)
+    mask = inputs.attention_mask.to(device)
+    seq_len = int(mask.gt(0).sum(dim=1).item())
+
+    emb = text_encoder(ids, mask).last_hidden_state[0]  # (max_len, D)
+    emb = emb.to(dtype)
+    truncated = emb[:seq_len]
+    padded = torch.cat(
+        [truncated, truncated.new_zeros(max_len - seq_len, truncated.size(-1))],
+        dim=0,
+    )
+    return padded.detach().cpu()
+
+
+@torch.no_grad()
+def encode_video(
+    frames_uint8: np.ndarray,
+    vae: AutoencoderKLWan,
+    device: str,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int, int, int]:
+    """Return (latent_flat, latent_num_frames, latent_height, latent_width).
+
+    latent_flat is bfloat16 on CPU, shape `(T_lat * H_lat * W_lat, C)`,
+    laid out f-major (matches the loader's `(f h w) c -> f h w c` rearrange).
+    """
+    # (T, H, W, 3) uint8 -> (1, 3, T, H, W) float in [-1, +1]
+    x = torch.from_numpy(frames_uint8).float().permute(3, 0, 1, 2).unsqueeze(0)
+    x = x / 255.0 * 2.0 - 1.0
+    x = x.to(device=device, dtype=dtype)
+
+    mu = vae.encode(x).latent_dist.mode()  # (1, C, T_lat, H_lat, W_lat)
+
+    latents_mean = torch.tensor(
+        vae.config.latents_mean, device=device, dtype=torch.float32
+    ).view(1, -1, 1, 1, 1)
+    latents_std = torch.tensor(
+        vae.config.latents_std, device=device, dtype=torch.float32
+    ).view(1, -1, 1, 1, 1)
+    mu_norm = ((mu.float() - latents_mean) / latents_std).to(dtype)
+
+    _, _, T_lat, H_lat, W_lat = mu_norm.shape
+    flat = rearrange(mu_norm[0], "c f h w -> (f h w) c").detach().cpu()
+    return flat, int(T_lat), int(H_lat), int(W_lat)
+
+
+# --------------------------------------------------------------------------- #
+# Video I/O
+# --------------------------------------------------------------------------- #
+
+def read_video_frames(
+    mp4_path: Path,
+    start_frame: int,
+    end_frame: int,
+    fps: int,
+    ori_fps: int,
+    target_h: int,
+    target_w: int,
+) -> tuple[np.ndarray, list[int]]:
+    """Read [start_frame, end_frame) from mp4 (indexed at ori_fps), subsample to
+    target fps, resize to (target_h, target_w), return (T, H, W, 3) uint8 and
+    the list of source-video frame ids actually sampled."""
+    frames_all = iio.imread(mp4_path, plugin="pyav")  # (T_total, H, W, 3) uint8
+    if frames_all.ndim != 4 or frames_all.shape[-1] != 3:
+        raise ValueError(f"Unexpected video shape {frames_all.shape} for {mp4_path}")
+
+    segment = frames_all[start_frame:end_frame]
+    if fps == ori_fps:
+        frame_ids = list(range(start_frame, end_frame))
+        sampled = segment
+    else:
+        if ori_fps % fps != 0:
+            raise ValueError(
+                f"ori_fps ({ori_fps}) must be a multiple of fps ({fps}) "
+                f"for integer subsampling"
+            )
+        stride = ori_fps // fps
+        local_ids = list(range(0, segment.shape[0], stride))
+        frame_ids = [start_frame + i for i in local_ids]
+        sampled = segment[local_ids]
+
+    if sampled.shape[1] != target_h or sampled.shape[2] != target_w:
+        # Bilinear resize via torch (matches server's F.interpolate path).
+        t = torch.from_numpy(sampled).float().permute(0, 3, 1, 2)  # (T,3,H,W)
+        t = torch.nn.functional.interpolate(
+            t, size=(target_h, target_w), mode="bilinear", align_corners=False
+        )
+        sampled = (
+            t.clamp(0, 255).permute(0, 2, 3, 1).contiguous().byte().numpy()
+        )
+
+    return np.ascontiguousarray(sampled), frame_ids
+
+
+# --------------------------------------------------------------------------- #
+# Main loop
+# --------------------------------------------------------------------------- #
+
+def main() -> None:
+    args = parse_args()
+    device = args.device
+    dtype = torch.bfloat16
+
+    dataset = args.dataset
+    meta = dataset / "meta"
+    if not (meta / "episodes.jsonl").exists():
+        raise SystemExit(f"Not a LeRobot dataset: {dataset}")
+
+    info = json.loads((meta / "info.json").read_text())
+    ori_fps_dataset = int(info.get("fps", args.ori_fps))
+    if ori_fps_dataset != args.ori_fps:
+        print(
+            f"[warn] --ori-fps={args.ori_fps} differs from info.json fps="
+            f"{ori_fps_dataset}; using --ori-fps."
+        )
+
+    episodes = [
+        json.loads(line)
+        for line in (meta / "episodes.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+
+    cam_keys = args.cam_keys or DEFAULT_CAM_KEYS
+
+    print(f"[extract] loading VAE + text encoder from {args.ckpt_dir}")
+    vae = load_vae(args.ckpt_dir, device, dtype)
+    tokenizer, text_encoder = load_text_stack(args.ckpt_dir, device, dtype)
+
+    # empty_emb.pt — written once per dataset, regenerate-on-demand.
+    empty_emb_path = dataset / "empty_emb.pt"
+    if not empty_emb_path.exists() or not args.skip_existing:
+        print(f"[extract] writing {empty_emb_path}")
+        empty = encode_text("", tokenizer, text_encoder, device, dtype)
+        torch.save(empty, empty_emb_path)
+
+    # Cache text embeddings per unique action_text to avoid re-encoding.
+    text_cache: dict[str, torch.Tensor] = {}
+
+    def get_text_emb(text: str) -> torch.Tensor:
+        if text not in text_cache:
+            text_cache[text] = encode_text(
+                text, tokenizer, text_encoder, device, dtype
+            )
+        return text_cache[text]
+
+    total_jobs = sum(
+        len(ep.get("action_config", [])) * len(cam_keys) for ep in episodes
+    )
+    pbar = tqdm(total=total_jobs, desc="extract")
+    n_skipped = 0
+    n_written = 0
+    for ep in episodes:
+        ep_idx = ep["episode_index"]
+        for acfg in ep.get("action_config", []):
+            start_frame = acfg["start_frame"]
+            end_frame = acfg["end_frame"]
+            text = acfg["action_text"]
+            text_emb = get_text_emb(text)
+
+            for cam in cam_keys:
+                mp4 = (
+                    dataset / "videos" / CHUNK_DIR / cam
+                    / f"episode_{ep_idx:06d}.mp4"
+                )
+                if not mp4.exists():
+                    raise FileNotFoundError(mp4)
+
+                out_path = (
+                    dataset / "latents" / CHUNK_DIR / cam
+                    / f"episode_{ep_idx:06d}_{start_frame}_{end_frame}.pth"
+                )
+
+                # `out_path` may be a dangling symlink into the parent dataset
+                # (select_subset.py sets these up). Resolve to the symlink
+                # target for existence checks; torch.save will follow it.
+                target = out_path.resolve()
+                if args.skip_existing and target.exists():
+                    n_skipped += 1
+                    pbar.update(1)
+                    continue
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                target.parent.mkdir(parents=True, exist_ok=True)
+
+                frames, frame_ids = read_video_frames(
+                    mp4,
+                    start_frame=start_frame,
+                    end_frame=end_frame,
+                    fps=args.fps,
+                    ori_fps=args.ori_fps,
+                    target_h=args.height,
+                    target_w=args.width,
+                )
+                latent_flat, T_lat, H_lat, W_lat = encode_video(
+                    frames, vae, device, dtype
+                )
+
+                payload = {
+                    "latent": latent_flat,
+                    "latent_num_frames": T_lat,
+                    "latent_height": H_lat,
+                    "latent_width": W_lat,
+                    "video_num_frames": int(frames.shape[0]),
+                    "video_height": int(frames.shape[1]),
+                    "video_width": int(frames.shape[2]),
+                    "text_emb": text_emb,
+                    "text": text,
+                    "frame_ids": frame_ids,
+                    "start_frame": int(start_frame),
+                    "end_frame": int(end_frame),
+                    "fps": int(args.fps),
+                    "ori_fps": int(args.ori_fps),
+                }
+                torch.save(payload, out_path)
+                n_written += 1
+                pbar.update(1)
+    pbar.close()
+    print(
+        f"[extract] done. written={n_written} skipped={n_skipped} "
+        f"unique_texts={len(text_cache)}"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dataset", type=Path, required=True,
+                   help="LeRobot v2.1 dataset directory (post-conversion / subset)")
+    p.add_argument("--ckpt-dir", type=Path, required=True,
+                   help="Base ckpt dir holding vae/, text_encoder/, tokenizer/")
+    p.add_argument("--height", type=int, default=128,
+                   help="Target frame height fed to the VAE")
+    p.add_argument("--width", type=int, default=128,
+                   help="Target frame width fed to the VAE")
+    p.add_argument("--fps", type=int, default=20,
+                   help="Target sampling fps")
+    p.add_argument("--ori-fps", type=int, default=20,
+                   help="Source video fps (must match the dataset's recording fps)")
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--skip-existing", action="store_true",
+                   help="Skip episodes whose .pth target already exists.")
+    p.add_argument("--cam-keys", nargs="*", default=None,
+                   help=f"Override camera keys (default: {DEFAULT_CAM_KEYS})")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/toolkits/data_scripts_lingbotva/select_subset.py
+++ b/toolkits/data_scripts_lingbotva/select_subset.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Build a deterministic per-task subset of a LeRobot v2.1 dataset, with
+contiguous episode_index renumbering (required by LingBot-VA's loader).
+
+What this does:
+  1. Pick `per_task` episodes from each task (grouped via tasks.jsonl /
+     parquet task_index) using a seeded RNG.
+  2. Renumber the selected episodes 0..N-1 contiguously. This is mandatory:
+     LatentLeRobotDataset indexes `episode_data_index['from']` positionally,
+     so a non-contiguous episode_index field raises IndexError at training.
+  3. Symlink the per-episode parquet + video files from the source dataset
+     so the subset doesn't duplicate ~7 GB of mp4s on disk.
+  4. Pre-create dangling latent symlinks under `<subset>/latents/.../
+     episode_<subset_idx>_0_T.pth` pointing at `<src>/latents/.../
+     episode_<orig_idx>_0_T.pth`. When extract_latents.py later runs on the
+     subset, torch.save follows the symlink and writes the actual .pth into
+     the parent dataset — so multiple subsets can share latents.
+  5. Record `original_episode_index` on every line of the rewritten
+     episodes.jsonl for traceability.
+
+The subset's episodes.jsonl keeps the LingBot-VA `action_config` field that
+was injected at conversion time; nothing in this script touches action_config
+contents (other than re-keying the line by the new episode_index).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+CHUNK_DIR = "chunk-000"
+CAM_KEYS = [
+    "observation.images.agentview_rgb",
+    "observation.images.eye_in_hand_rgb",
+]
+
+
+# --------------------------------------------------------------------------- #
+# I/O helpers
+# --------------------------------------------------------------------------- #
+
+def read_jsonl(path: Path) -> list[dict]:
+    with path.open() as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def write_jsonl(path: Path, lines: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for line in lines:
+            f.write(json.dumps(line) + "\n")
+
+
+def relative_symlink(target: Path, link: Path) -> None:
+    """Symlink with a relative path, so the subset dir is portable
+    alongside the parent."""
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if link.is_symlink() or link.exists():
+        link.unlink()
+    rel = os.path.relpath(target, start=link.parent)
+    link.symlink_to(rel)
+
+
+# --------------------------------------------------------------------------- #
+# Selection
+# --------------------------------------------------------------------------- #
+
+def task_index_for_episode(src: Path, episode_index: int) -> int:
+    """Read a single value out of the parquet — cheap, avoids loading frames."""
+    import pyarrow.parquet as pq
+    pq_path = src / "data" / CHUNK_DIR / f"episode_{episode_index:06d}.parquet"
+    tbl = pq.read_table(pq_path, columns=["task_index"])
+    return int(tbl.column("task_index")[0].as_py())
+
+
+def build_subset(src: Path, dst: Path, per_task: int, seed: int) -> None:
+    if dst.exists():
+        raise SystemExit(
+            f"Destination exists: {dst}. Remove it first to avoid mixing runs."
+        )
+    src_meta = src / "meta"
+    if not (src_meta / "info.json").exists():
+        raise SystemExit(f"Source is not a LeRobot dataset: {src}")
+
+    info = json.loads((src_meta / "info.json").read_text())
+    episodes = read_jsonl(src_meta / "episodes.jsonl")
+    episodes_stats = {
+        e["episode_index"]: e for e in read_jsonl(src_meta / "episodes_stats.jsonl")
+    }
+    tasks = read_jsonl(src_meta / "tasks.jsonl")
+
+    by_task: dict[int, list[int]] = defaultdict(list)
+    for ep in episodes:
+        ti = task_index_for_episode(src, ep["episode_index"])
+        by_task[ti].append(ep["episode_index"])
+
+    rng = np.random.default_rng(seed)
+    selected: list[tuple[int, int]] = []  # (task_index, original_episode_index)
+    for ti in sorted(by_task):
+        pool = sorted(by_task[ti])
+        if len(pool) < per_task:
+            raise SystemExit(
+                f"Task {ti} has only {len(pool)} episodes, asked for {per_task}"
+            )
+        picks = rng.choice(len(pool), size=per_task, replace=False)
+        for idx in sorted(picks.tolist()):
+            selected.append((ti, pool[idx]))
+    print(f"[subset] selected {len(selected)} episodes "
+          f"({len(by_task)} tasks × {per_task})")
+
+    # Renumber.
+    new_episodes: list[dict] = []
+    new_episodes_stats: list[dict] = []
+    new_to_old: dict[int, int] = {}
+    cum = 0
+    for new_idx, (_, old_idx) in enumerate(selected):
+        new_to_old[new_idx] = old_idx
+        ep = next(e for e in episodes if e["episode_index"] == old_idx)
+        new_ep = dict(ep)
+        new_ep["episode_index"] = new_idx
+        new_ep["original_episode_index"] = old_idx
+        new_episodes.append(new_ep)
+
+        st = dict(episodes_stats[old_idx])
+        st["episode_index"] = new_idx
+        new_episodes_stats.append(st)
+        cum += ep["length"]
+
+    # Layout.
+    (dst / "meta").mkdir(parents=True, exist_ok=True)
+    (dst / "data" / CHUNK_DIR).mkdir(parents=True, exist_ok=True)
+    for cam in CAM_KEYS:
+        (dst / "videos" / CHUNK_DIR / cam).mkdir(parents=True, exist_ok=True)
+        (dst / "latents" / CHUNK_DIR / cam).mkdir(parents=True, exist_ok=True)
+
+    # tasks.jsonl: identical to parent (task_index references unchanged).
+    write_jsonl(dst / "meta" / "tasks.jsonl", tasks)
+
+    # info.json: update totals, keep schema.
+    info_out = dict(info)
+    info_out["total_episodes"] = len(new_episodes)
+    info_out["total_frames"] = cum
+    info_out["total_videos"] = len(new_episodes) * len(CAM_KEYS)
+    info_out["splits"] = {"train": f"0:{len(new_episodes)}"}
+    (dst / "meta" / "info.json").write_text(json.dumps(info_out, indent=2))
+
+    write_jsonl(dst / "meta" / "episodes.jsonl", new_episodes)
+    write_jsonl(dst / "meta" / "episodes_stats.jsonl", new_episodes_stats)
+
+    # Symlink parquet + mp4 files (renumbered name -> original path).
+    for new_idx, old_idx in new_to_old.items():
+        old_pq = src / "data" / CHUNK_DIR / f"episode_{old_idx:06d}.parquet"
+        new_pq = dst / "data" / CHUNK_DIR / f"episode_{new_idx:06d}.parquet"
+        relative_symlink(old_pq, new_pq)
+        for cam in CAM_KEYS:
+            old_mp4 = (src / "videos" / CHUNK_DIR / cam
+                       / f"episode_{old_idx:06d}.mp4")
+            new_mp4 = (dst / "videos" / CHUNK_DIR / cam
+                       / f"episode_{new_idx:06d}.mp4")
+            relative_symlink(old_mp4, new_mp4)
+
+        # Pre-create dangling latent symlinks. extract_latents.py will write
+        # through them; the actual bytes land in the parent.
+        ep_length = next(e for e in new_episodes
+                         if e["episode_index"] == new_idx)["length"]
+        for cam in CAM_KEYS:
+            old_latent = (src / "latents" / CHUNK_DIR / cam
+                          / f"episode_{old_idx:06d}_0_{ep_length}.pth")
+            new_latent = (dst / "latents" / CHUNK_DIR / cam
+                          / f"episode_{new_idx:06d}_0_{ep_length}.pth")
+            # Ensure parent's latent dir exists so the dangling target is in
+            # a real directory (Python's open('wb') on a dangling symlink
+            # creates the file at the target only if the target's parent dir
+            # already exists).
+            old_latent.parent.mkdir(parents=True, exist_ok=True)
+            relative_symlink(old_latent, new_latent)
+
+    # Save the selection manifest for auditing.
+    manifest = {
+        "src": str(src.resolve()),
+        "seed": seed,
+        "per_task": per_task,
+        "selected": [
+            {"new": ni, "original": old, "task_index": ti}
+            for ni, (ti, old) in enumerate(selected)
+        ],
+    }
+    (dst / "meta" / "subset_manifest.json").write_text(
+        json.dumps(manifest, indent=2)
+    )
+    print(f"[subset] wrote {dst}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--src", type=Path, required=True,
+                   help="Parent LeRobot dataset (output of convert_*.py)")
+    p.add_argument("--dst", type=Path, required=True,
+                   help="Output subset dataset directory")
+    p.add_argument("--per-task", type=int, default=10)
+    p.add_argument("--seed", type=int, default=42)
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    build_subset(args.src, args.dst, args.per_task, args.seed)


### PR DESCRIPTION
### Description

End-to-end integration of the LingBot-VA video-diffusion VLA into RLinf for supervised fine-tuning and evaluation on Libero-Object.

**SFT recipe (8 × A100-80GB, single node):**
- `examples/sft/config/libero_sft_lingbotva.yaml`: bf16 + FSDP2 full-shard + plain torch AdamW + flex_attention. micro=1, global_batch_size=80 (grad_accum=10 on ws=8), matching the lingbot-va reference `va_libero_train_cfg` effective batch. Steady-state ~12.5 s/step at ~32 GB/GPU.
- Single-GPU launch (L40-class, ≥45 GB) is reached via CLI overrides (FSDP1 + NO_SHARD + bnb AdamW8bit + global_batch_size=10) and is documented inline in the yaml header.

**Evaluation:**
- `examples/embodiment/eval_lingbotva.py`: dedicated Hydra-driven single-process driver. Walks the chunk-step loop manually so it can feed `env.current_raw_obs` per step back through the model's KV-cache replay hooks. Going through the generic `MultiStepRolloutWorker` drops per-step obs and silently collapses SR to ~0 %.
- `examples/embodiment/eval_embodiment.sh` now dispatches the eval driver by `model_type`; other policies keep using `eval_embodied_agent.py`.
- Multi-GPU evaluation is one-task-per-GPU via `CUDA_VISIBLE_DEVICES` + `MUJOCO_EGL_DEVICE_ID` (~39 GB peak per process — two tasks do not fit on one 80 GB card).

**Data preparation:** Three conversion scripts vendored under `toolkits/data_scripts_lingbotva/`: raw HDF5 → LeRobot v2.1, deterministic per-task subset, and Wan VAE + UMT5 latent extraction. The lingbot-va peer repo is still needed at runtime for the `wan_va` Python package.

**Documentation:** `docs/source-en/rst_source/examples/embodied/sft_lingbotva.rst` covers setup, data prep, key config knobs, expected loss curve, the 8-GPU + single-GPU launch paths, parallel evaluation across 8 ranks, per-task verified SR, and common failure modes.

### Motivation and Context

Adds LingBot-VA as a supported embodied SFT model in RLinf, with a verified recipe on Libero-Object. This is the first video-diffusion VLA integration in RLinf — chunk-based action generation and KV-cache replay require a dedicated eval driver, hence the new `eval_lingbotva.py`.

### How has this been tested?

**SFT training (8 × A100-80GB, this branch):** 2000 steps in ~7 h. Loss trajectory matches the lingbot-va single-A100 reference at every step where the reference reports a number:

| Step | latent_loss | action_loss | grad_norm |
|---|---|---|---|
| 500 | ~0.120 | ~0.097 | ~0.077 |
| 1000 | ~0.113 | ~0.087 | ~0.091 |
| 1500 | ~0.103 | ~0.082 | ~0.111 |
| 2000 | ~0.103 | ~0.082 | ~0.121 |

**Evaluation (ckpt_2000, 10 Libero-Object tasks × 5 episodes = 50 episodes):**

| Model | Mean SR |
|---|---|
| `lingbot-va-base` (no SFT) | **0 % (0/50)** |
| SFT ckpt_2000 (this branch) | **70 % (35/50)** |

Per-task SR vector for SFT: `[3, 4, 5, 1, 4, 3, 5, 3, 4, 3] / 5`.

**E2E config:** `tests/e2e_tests/sft/libero_sft_lingbotva.yaml` added.

### Additional information (optional, e.g., figures and logs):

Full reproduction walkthrough (env, data prep, training, evaluation, common failure modes) in the new doc page at `docs/source-en/rst_source/examples/embodied/sft_lingbotva.rst`.

### Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. <!-- 8-GPU SFT + 50-episode eval reproduced locally; awaiting reviewer \`run-ci\` label per CONTRIBUTING.md -->