### PR TITLE
fix(behavior): avoid loading assets during config validation

### DIFF
--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -941,7 +941,13 @@ def validate_embodied_cfg(cfg):
             cfg.env.eval.init_params.control_mode = get_robot_control_mode(
                 cfg.actor.model.policy_setup
             )
-
+        elif (
+            SupportedEnvType(cfg.env.train.env_type) == SupportedEnvType.BEHAVIOR
+            or SupportedEnvType(cfg.env.eval.env_type) == SupportedEnvType.BEHAVIOR
+        ):
+            assert cfg.env.train.base_config_name == "r1pro_behavior", (
+                f"Only r1pro_behavior is supported for omnigibson, got {cfg.env.train.base_config_name}"
+            )
     return cfg
 
 

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Union
 
 import torch
 import torch.nn.functional as F
-import yaml
 from omegaconf import OmegaConf, open_dict
 from omegaconf.dictconfig import DictConfig
 
@@ -942,27 +941,6 @@ def validate_embodied_cfg(cfg):
             cfg.env.eval.init_params.control_mode = get_robot_control_mode(
                 cfg.actor.model.policy_setup
             )
-        elif (
-            SupportedEnvType(cfg.env.train.env_type) == SupportedEnvType.BEHAVIOR
-            or SupportedEnvType(cfg.env.eval.env_type) == SupportedEnvType.BEHAVIOR
-        ):
-            import omnigibson as og
-
-            assert cfg.env.train.base_config_name == "r1pro_behavior", (
-                f"Only r1pro_behavior is supported for omnigibson, got {cfg.env.train.base_config_name}"
-            )
-            # Load the pre-selected configuration and set the online_sampling flag
-            config_filename = os.path.join(
-                og.example_config_path, "r1pro_behavior.yaml"
-            )
-            omnigibson_cfg = yaml.load(
-                open(config_filename, "r"), Loader=yaml.FullLoader
-            )
-            omnigibson_cfg = OmegaConf.create(omnigibson_cfg)
-            with open_dict(omnigibson_cfg):
-                omnigibson_cfg.robots[0].obs_modalities = ["rgb", "depth", "proprio"]
-            cfg.env.train.omnigibson_cfg = omnigibson_cfg
-            cfg.env.eval.omnigibson_cfg = omnigibson_cfg
 
     return cfg
 

--- a/rlinf/envs/behavior/utils.py
+++ b/rlinf/envs/behavior/utils.py
@@ -211,10 +211,6 @@ def setup_omni_cfg(cfg: DictConfig) -> DictConfig:
     base_config_name = OmegaConf.select(
         cfg, "base_config_name", default="r1pro_behavior"
     )
-    if base_config_name != "r1pro_behavior":
-        raise ValueError(
-            f"Only r1pro_behavior is supported for omnigibson, got {base_config_name}"
-        )
 
     import omnigibson as og
     from omnigibson.macros import gm

--- a/rlinf/envs/behavior/utils.py
+++ b/rlinf/envs/behavior/utils.py
@@ -208,11 +208,19 @@ def setup_omni_cfg(cfg: DictConfig) -> DictConfig:
     Returns:
         (DictConfig): overrided OmniGibson config
     """
+    base_config_name = OmegaConf.select(
+        cfg, "base_config_name", default="r1pro_behavior"
+    )
+    if base_config_name != "r1pro_behavior":
+        raise ValueError(
+            f"Only r1pro_behavior is supported for omnigibson, got {base_config_name}"
+        )
+
     import omnigibson as og
     from omnigibson.macros import gm
 
     override_cfg = OmegaConf.select(cfg, "omni_config")
-    cfg_path = os.path.join(og.example_config_path, "r1pro_behavior.yaml")
+    cfg_path = os.path.join(og.example_config_path, f"{base_config_name}.yaml")
     with open(cfg_path, "r", encoding="utf-8") as f:
         omni_cfg = OmegaConf.create(yaml.load(f, Loader=yaml.FullLoader))
     # override env/render/camera/robots/task/scene config


### PR DESCRIPTION

### Description

 Avoid loading Behavior assets during config validation. In the current implementation, if the specified `OMNIGIBSON_DATA_PATH` is not within the access range of the machine being started, an error will be reported directly, which should be allowed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.