### PR TITLE
fix(envs): walk through the env to find the inner RecordVideo so that…

### DIFF
--- a/rlinf/workers/env/env_worker.py
+++ b/rlinf/workers/env/env_worker.py
@@ -15,7 +15,7 @@
 import asyncio
 import gc
 from collections import defaultdict
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 import numpy as np
 import torch
@@ -789,21 +789,36 @@ class EnvWorker(Worker):
         adjusted_rewards[:, -1] += self.cfg.algorithm.gamma * final_values
         return adjusted_rewards
 
+    @staticmethod
+    def _find_record_video(env) -> Optional["RecordVideo"]:
+        """Walk the gym wrapper chain to locate the RecordVideo wrapper.
+
+        When data collection is enabled the env is wrapped as
+        ``CollectEpisode(RecordVideo(base_env))``, so the outermost object is
+        not a RecordVideo and ``isinstance(env, RecordVideo)`` would miss it,
+        leaving recorded frames unflushed to disk.
+        """
+        while env is not None:
+            if isinstance(env, RecordVideo):
+                return env
+            env = getattr(env, "env", None)
+        return None
+
     def finish_rollout(self, mode="train"):
         # reset
         if mode == "train":
             for i in range(self.stage_num):
-                if self.cfg.env.train.video_cfg.save_video and isinstance(
-                    self.env_list[i], RecordVideo
-                ):
-                    self.env_list[i].flush_video()
+                if self.cfg.env.train.video_cfg.save_video:
+                    recorder = self._find_record_video(self.env_list[i])
+                    if recorder is not None:
+                        recorder.flush_video()
                 self.env_list[i].update_reset_state_ids()
         elif mode == "eval":
             for i in range(self.stage_num):
-                if self.cfg.env.eval.video_cfg.save_video and isinstance(
-                    self.eval_env_list[i], RecordVideo
-                ):
-                    self.eval_env_list[i].flush_video()
+                if self.cfg.env.eval.video_cfg.save_video:
+                    recorder = self._find_record_video(self.eval_env_list[i])
+                    if recorder is not None:
+                        recorder.flush_video()
                 if not self.cfg.env.eval.auto_reset:
                     self.eval_env_list[i].update_reset_state_ids()
 


### PR DESCRIPTION
… videos and episodes can both be saved

A short change in `env_worker.py` to enable save both parquets and videos.

### Description
Add a function to walk through the env and find the inner RecordVideo

### Motivation and Context
Previously, if parquets are saved, videos won't be saved even if enabled in config file. That's a result of multiple wrapper of env (i.e. it becomes `CollectEpisode(RecordVideo(base_env))`  so that it won't be detected by `isinstance(..., RecordVideo)`)

### How has this been tested?
Manually tested on LIBERO. Now it can save both parquet and video after the change. 

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.