### PR TITLE
feat(embodied): add FastWAM world-action model (LIBERO eval + SFT)

### DIFF
--- a/evaluations/libero/libero_spatial_fastwam_eval.yaml
+++ b/evaluations/libero/libero_spatial_fastwam_eval.yaml
@@ -1,0 +1,62 @@
+defaults:
+  - env/libero_spatial@env.eval
+  - model/fastwam@rollout.model
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    env,rollout: all
+
+runner:
+  task_type: embodied_eval
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_spatial_eval_fastwam"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 1
+  only_eval: True
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+
+env:
+  group_name: "EnvGroup"
+
+  eval:
+    # Minimal eval: a handful of parallel envs, one rollout epoch. FastWAM runs a
+    # 5B+1B flow-matching inference every `num_action_chunks` sim steps, so keep
+    # the env count / horizon small for a quick real-world sanity number.
+    rollout_epoch: 1
+    total_num_envs: 4
+    auto_reset: True
+    ignore_terminations: True
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 240  # ~1 trajectory per env this epoch
+    group_size: 1
+    use_fixed_reset_state_ids: True
+    use_ordered_reset_state_ids: True
+    is_eval: True
+
+    video_cfg:
+      save_video: True
+      video_base_dir: ${runner.logger.log_path}/video/eval
+
+rollout:
+  group_name: "RolloutGroup"
+  generation_backend: "huggingface"
+  enable_offload: False
+  pipeline_stage_num: 1
+
+  model:
+    model_type: "fastwam"

--- a/evaluations/libero/libero_spatial_fastwam_eval_big.yaml
+++ b/evaluations/libero/libero_spatial_fastwam_eval_big.yaml
@@ -1,0 +1,67 @@
+# Larger FastWAM eval on LIBERO-Spatial: 8 trials per task (10 tasks => 80 envs).
+#
+# Eval reset-state ids are interleaved (task0/trial0, task1/trial0, ...), so with
+# use_ordered_reset_state_ids + total_num_envs=80 and one episode per env, every task
+# gets exactly the first 8 trials. Video saving is OFF to keep memory low.
+defaults:
+  - env/libero_spatial@env.eval
+  - model/fastwam@rollout.model
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    env,rollout: all
+
+runner:
+  task_type: embodied_eval
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_spatial_eval_fastwam_big"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 1
+  only_eval: True
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+
+env:
+  group_name: "EnvGroup"
+
+  eval:
+    # 80 total trajectories (= 8 trials x 10 LIBERO-Spatial tasks). Rather than 80
+    # parallel sims (which crashes MuJoCo/GL at colocated startup with the model),
+    # use 20 parallel envs cycling 4x via auto_reset over the interleaved eval ids.
+    # Total model inference is identical; only env concurrency differs.
+    rollout_epoch: 1
+    total_num_envs: 8                   # each env is a spawned subprocess sharing GPU0
+    auto_reset: True
+    ignore_terminations: True
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 2400   # 10 episodes/env x 8 envs = 80 trajectories
+    group_size: 1
+    use_fixed_reset_state_ids: True
+    use_ordered_reset_state_ids: True
+    is_eval: True
+
+    video_cfg:
+      save_video: False                # disabled to keep memory low
+
+rollout:
+  group_name: "RolloutGroup"
+  generation_backend: "huggingface"
+  enable_offload: False
+  pipeline_stage_num: 1
+
+  model:
+    model_type: "fastwam"

--- a/evaluations/libero/libero_spatial_fastwam_plus_eval.yaml
+++ b/evaluations/libero/libero_spatial_fastwam_plus_eval.yaml
@@ -1,0 +1,74 @@
+# FastWAM minimal evaluation on LIBERO-Plus.
+#
+# LIBERO-Plus is selected via the LIBERO_TYPE=plus environment variable (read by
+# rlinf/envs/libero/utils.py::get_libero_type), which routes the env to the
+# `liberoplus` package. Export it before launching, e.g.:
+#
+#   LIBERO_TYPE=plus LIBERO_SUFFIX=all \
+#     bash evaluations/run_eval.sh libero libero_spatial_fastwam_plus_eval
+#
+# Everything else mirrors the standard LIBERO FastWAM eval; the same task_suite_name
+# (libero_spatial) is resolved against the liberoplus benchmark, and Plus picks a
+# perturbed BDDL variant per init state.
+defaults:
+  - env/libero_spatial@env.eval
+  - model/fastwam@rollout.model
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    env,rollout: all
+
+runner:
+  task_type: embodied_eval
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_spatial_plus_eval_fastwam"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 1
+  only_eval: True
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+
+env:
+  group_name: "EnvGroup"
+
+  eval:
+    rollout_epoch: 1
+    total_num_envs: 4
+    auto_reset: True
+    ignore_terminations: True
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 240
+    group_size: 1
+    use_fixed_reset_state_ids: True
+    use_ordered_reset_state_ids: True
+    is_eval: True
+    # Fallbacks if LIBERO_TYPE / LIBERO_SUFFIX are not exported in the shell.
+    libero_variant: plus
+    perturbation_suffix: all
+
+    video_cfg:
+      save_video: True
+      video_base_dir: ${runner.logger.log_path}/video/eval_plus
+
+rollout:
+  group_name: "RolloutGroup"
+  generation_backend: "huggingface"
+  enable_offload: False
+  pipeline_stage_num: 1
+
+  model:
+    model_type: "fastwam"

--- a/evaluations/libero/libero_spatial_fastwam_plus_language_eval.yaml
+++ b/evaluations/libero/libero_spatial_fastwam_plus_language_eval.yaml
@@ -1,0 +1,68 @@
+# Small-sample FastWAM eval on LIBERO-Plus with the LANGUAGE perturbation only.
+#
+# Selected via LIBERO_TYPE=plus + LIBERO_SUFFIX=language (the env filters the plus
+# bddl candidates to *_language*.bddl). 8 envs x 1 episode = 8 trajectories
+# (trial0 of tasks 0-7), no cross-task auto_reset so no reconfigure. Launch:
+#
+#   LIBERO_TYPE=plus LIBERO_SUFFIX=language MUJOCO_GL=egl \
+#     bash evaluations/run_eval.sh libero libero_spatial_fastwam_plus_language_eval
+defaults:
+  - env/libero_spatial@env.eval
+  - model/fastwam@rollout.model
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    env,rollout: all
+
+runner:
+  task_type: embodied_eval
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_spatial_plus_language_eval_fastwam"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 1
+  only_eval: True
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+
+env:
+  group_name: "EnvGroup"
+
+  eval:
+    rollout_epoch: 1
+    total_num_envs: 8
+    auto_reset: True
+    ignore_terminations: True
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 240    # 1 episode/env -> 8 trajectories, no reconfigure
+    group_size: 1
+    use_fixed_reset_state_ids: True
+    use_ordered_reset_state_ids: True
+    is_eval: True
+    libero_variant: plus
+    perturbation_suffix: language
+
+    video_cfg:
+      save_video: False
+
+rollout:
+  group_name: "RolloutGroup"
+  generation_backend: "huggingface"
+  enable_offload: False
+  pipeline_stage_num: 1
+
+  model:
+    model_type: "fastwam"

--- a/evaluations/libero/libero_spatial_fastwam_video_eval.yaml
+++ b/evaluations/libero/libero_spatial_fastwam_video_eval.yaml
@@ -1,0 +1,60 @@
+# FastWAM eval that ALSO generates the predicted future video (world-model
+# imagination) via infer_joint, dumping clips for env 0. Small + short.
+defaults:
+  - env/libero_spatial@env.eval
+  - model/fastwam@rollout.model
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    env,rollout: all
+
+runner:
+  task_type: embodied_eval
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_spatial_fastwam_video"
+    logger_backends: ["tensorboard"]
+  max_epochs: 1
+  only_eval: True
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+
+env:
+  group_name: "EnvGroup"
+  eval:
+    rollout_epoch: 1
+    total_num_envs: 2
+    auto_reset: True
+    ignore_terminations: True
+    max_episode_steps: 240
+    max_steps_per_rollout_epoch: 240
+    group_size: 1
+    use_fixed_reset_state_ids: True
+    use_ordered_reset_state_ids: True
+    is_eval: True
+    video_cfg:
+      save_video: False
+
+rollout:
+  group_name: "RolloutGroup"
+  generation_backend: "huggingface"
+  enable_offload: False
+  pipeline_stage_num: 1
+  model:
+    model_type: "fastwam"
+    # World-model future-video generation (env 0, capped).
+    visualize_future_video: true
+    future_video_dir: /workspace/future_video_demo
+    max_video_saves: 8

--- a/examples/embodiment/config/model/fastwam.yaml
+++ b/examples/embodiment/config/model/fastwam.yaml
@@ -1,0 +1,42 @@
+# FastWAM (Wan2.2 video-diffusion world-action model) rollout config for RLinf.
+#
+# The heavy model/architecture/processor definitions live in FastWAM's own Hydra
+# configs (composed at build time by rlinf/models/embodiment/fastwam/get_model);
+# here we only set the RLinf-facing knobs and the checkpoint / normalization paths.
+model_type: "fastwam"
+precision: bf16
+# Unused by FastWAM (kept for rollout-worker compatibility, which reads model_path).
+model_path: null
+# Required by rlinf get_model dispatcher; FastWAM is not loaded via LoRA.
+is_lora: false
+
+# Fine-tuned FastWAM checkpoint (contains the trained `mot` + `proprio_encoder`).
+checkpoint_path: /workspace/checkpoints/fastwam/libero_uncond_2cam224.pt
+# Action/state min-max stats shipped next to the checkpoint. If null, get_model
+# looks for `<ckpt_stem>_dataset_stats.json` and `dataset_stats.json` beside it.
+dataset_stats_path: /workspace/checkpoints/fastwam/libero_uncond_2cam224_dataset_stats.json
+
+# Action chunking: FastWAM predicts `action_horizon` steps and we execute the
+# first `num_action_chunks` (== FastWAM replan_steps) before re-planning.
+action_dim: 7
+num_action_chunks: 10
+action_horizon: 32
+
+# Flow-matching action sampling.
+num_inference_steps: 10
+binarize_gripper: true
+text_cfg_scale: 1.0
+negative_prompt: ""
+sigma_shift: null
+seed: null
+rand_device: cpu
+tiled: false
+
+# FastWAM Hydra composition (auto-detects FastWAM/configs unless config_dir set).
+fastwam:
+  config_dir: null
+  config_name: sim_libero
+  # Load Wan VAE + T5 from the original Wan-AI HF repo (.pth) instead of the
+  # ModelScope-only converted-safetensors mirror used by default.
+  overrides:
+    - model.redirect_common_files=false

--- a/examples/sft/config/libero_sft_fastwam.yaml
+++ b/examples/sft/config/libero_sft_fastwam.yaml
@@ -71,6 +71,16 @@ actor:
 
   fsdp_config:
     strategy: "fsdp2"
+    # Whole-model FSDP2 wrap (no per-submodule sharding). The MoT performs manual
+    # cross-expert attention by reaching into the video/action DiT-block internals
+    # rather than calling block.forward, which is incompatible with per-block
+    # FSDP2 auto-wrap (sharded block params would not be all-gathered when the MoT
+    # accesses them). An empty wrap target leaves only the root module sharded, so
+    # all params are resident during the manual attention. Without this, FSDP2
+    # auto-wrap has no target and setup crashes (FastWAMPolicy defines no
+    # `_no_split_modules`).
+    wrap_policy:
+      no_split_names: ["__none__"]
     use_orig_params: True
     gradient_checkpointing: True
     gradient_checkpointing_use_reentrant: True

--- a/examples/sft/config/libero_sft_fastwam.yaml
+++ b/examples/sft/config/libero_sft_fastwam.yaml
@@ -1,0 +1,90 @@
+# FastWAM SFT on LIBERO (LeRobot format) through RLinf's FSDP SFT pipeline.
+#
+# Data + text-embedding prep (one-time):
+#   1) download a LIBERO LeRobot suite (e.g. yuanty/LIBERO-fastwam) to
+#      data.train_data_paths
+#   2) precompute T5 text embeddings into data.text_embedding_cache_dir with
+#      FastWAM's scripts/precompute_text_embeds.py
+#
+# Launch:
+#   bash examples/sft/run_sft.sh libero_sft_fastwam   (or train_vla_sft.py --config-name ...)
+defaults:
+  - training_backend/fsdp@actor.fsdp_config
+  - model/fastwam@actor.model
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor: all
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_sft_fastwam"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: -1
+  max_steps: 20            # smoke run; raise for real training
+  val_check_interval: -1
+  save_interval: -1
+  log_interval: 1
+  resume_dir: null
+
+data:
+  # Local LeRobot LIBERO dataset directory (override on the CLI as needed).
+  train_data_paths: /workspace/data/libero/libero_spatial_no_noops_lerobot
+  # Pre-computed T5 text-embedding cache (built by precompute_text_embeds.py).
+  text_embedding_cache_dir: /workspace/data/text_embeds_cache/libero
+  num_workers: 2
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 1
+  global_batch_size: 1
+  seed: 42
+
+  model:
+    model_type: "fastwam"
+
+  optim:
+    lr: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-08
+    weight_decay: 1.0e-2
+    clip_grad: 1.0
+    lr_scheduler: "cosine"
+    lr_warmup_steps: -1
+    lr_warmup_steps_ratio: 0.05
+    total_training_steps: 20
+
+  fsdp_config:
+    strategy: "fsdp2"
+    use_orig_params: True
+    gradient_checkpointing: True
+    gradient_checkpointing_use_reentrant: True
+    limit_all_gathers: False
+    forward_prefetch: True
+    backward_prefetch: "pre"
+    reshard_after_forward: True
+    save_full_model_weights: False
+    grad_scaler:
+      enabled: False
+    mixed_precision:
+      param_dtype: bf16
+      reduce_dtype: bf16
+      buffer_dtype: bf16
+    amp_autocast:
+      enabled: False
+      precision: "bf16"

--- a/examples/sft/config/model/fastwam.yaml
+++ b/examples/sft/config/model/fastwam.yaml
@@ -1,0 +1,31 @@
+# FastWAM SFT model config.
+#
+# For SFT we initialise the MoT experts from the released FastWAM checkpoint
+# (skip_dit_load_from_pretrain=true in sim_libero), so the 20GB Wan DiT and the
+# ActionDiT backbone preprocessing are *not* required. Only the MoT experts and
+# the proprio encoder are trained (see get_model `freeze_non_dit`).
+model_type: "fastwam"
+precision: bf16
+# Required by rlinf get_model dispatcher; FastWAM is not loaded via LoRA.
+is_lora: false
+model_path: null
+
+# Init weights: the fine-tuned FastWAM checkpoint (contains `mot` + `proprio_encoder`).
+# Set to null to train from base (requires the 20GB Wan DiT + ActionDiT backbone).
+checkpoint_path: /workspace/checkpoints/fastwam/libero_uncond_2cam224.pt
+dataset_stats_path: /workspace/checkpoints/fastwam/libero_uncond_2cam224_dataset_stats.json
+
+# Only MoT experts (+ proprio encoder) are trainable.
+freeze_non_dit: true
+
+fastwam:
+  config_dir: null
+  config_name: sim_libero
+  overrides:
+    # Training reads cached text embeddings, so the model itself need not load T5.
+    - model.load_text_encoder=false
+    # Enable gradient checkpointing inside both DiT experts to save memory.
+    - model.mot_checkpoint_mixed_attn=true
+    # Load Wan VAE from the original Wan-AI HF repo (.pth) instead of the
+    # ModelScope-only converted-safetensors mirror.
+    - model.redirect_common_files=false

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -91,6 +91,7 @@ SupportedModel.GR00T = SupportedModel.register("gr00t", force=True)
 SupportedModel.DEXBOTIC_PI = SupportedModel.register("dexbotic_pi", force=True)
 SupportedModel.DEXBOTIC_DM0 = SupportedModel.register("dexbotic_dm0", force=True)
 SupportedModel.DREAMZERO = SupportedModel.register("dreamzero", force=True)
+SupportedModel.FASTWAM = SupportedModel.register("fastwam", force=True)
 SupportedModel.CNN_POLICY = SupportedModel.register("cnn_policy", force=True)
 SupportedModel.FLOW_POLICY = SupportedModel.register("flow_policy", force=True)
 SupportedModel.CMA_POLICY = SupportedModel.register("cma", force=True)
@@ -117,6 +118,7 @@ EMBODIED_MODEL = set(
         SupportedModel.DEXBOTIC_PI,
         SupportedModel.DEXBOTIC_DM0,
         SupportedModel.DREAMZERO,
+        SupportedModel.FASTWAM,
         SupportedModel.CNN_POLICY,
         SupportedModel.FLOW_POLICY,
         SupportedModel.CMA_POLICY,

--- a/rlinf/data/datasets/fastwam/__init__.py
+++ b/rlinf/data/datasets/fastwam/__init__.py
@@ -1,0 +1,126 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SFT dataloader for FastWAM.
+
+Wraps the upstream ``RobotVideoDataset`` (LeRobot-format LIBERO data) in an RLinf
+:class:`~torchdata.stateful_dataloader.StatefulDataLoader`. Each sample is already
+in the exact dict layout consumed by ``FastWAM.training_loss`` (``video``,
+``action``, ``context``, ``context_mask``, ``proprio`` and ``*_is_pad`` masks), so
+the default tensor collate is sufficient.
+
+Text embeddings must be pre-computed with FastWAM's ``scripts/precompute_text_embeds.py``
+into ``text_embedding_cache_dir`` (the dataset raises if a cache entry is missing).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch.utils.data import default_collate
+from torch.utils.data.distributed import DistributedSampler
+from torchdata.stateful_dataloader import StatefulDataLoader
+
+from rlinf.models.embodiment.fastwam import _compose_fastwam_cfg, _default_fastwam_config_dir
+from rlinf.utils.logging import get_logger
+
+logger = get_logger()
+
+
+def build_fastwam_sft_dataloader(
+    cfg,
+    world_size: int,
+    rank: int,
+    data_paths: Any,
+    eval_dataset: bool = False,
+):
+    """Build a distributed FastWAM SFT dataloader.
+
+    Args:
+        cfg: full RLinf config (uses ``cfg.actor.model.fastwam`` + ``cfg.data`` +
+            ``cfg.actor.micro_batch_size``).
+        world_size / rank: distributed layout.
+        data_paths: local path(s) to the LeRobot LIBERO dataset directory(ies).
+        eval_dataset: build a (non-shuffled) eval split.
+
+    Returns:
+        (StatefulDataLoader, info_dict)
+    """
+    from hydra.utils import instantiate
+
+    model_cfg = cfg.actor.model
+    fw = model_cfg.get("fastwam", {}) or {}
+    config_dir = fw.get("config_dir", None) or _default_fastwam_config_dir()
+    config_name = fw.get("config_name", "sim_libero")
+    overrides = list(fw.get("overrides", None) or [])
+
+    fcfg = _compose_fastwam_cfg(config_dir, config_name, overrides)
+    data_train = fcfg.data.train
+
+    # Normalize dataset dir(s).
+    if isinstance(data_paths, (list, tuple)):
+        dataset_dirs = [str(p) for p in data_paths]
+    else:
+        dataset_dirs = [str(data_paths)]
+
+    text_cache = cfg.data.get("text_embedding_cache_dir", None) or data_train.get(
+        "text_embedding_cache_dir", None
+    )
+    # Use shipped dataset stats so we don't recompute (and don't need the full scan).
+    norm_stats = cfg.data.get("pretrained_norm_stats", None) or model_cfg.get(
+        "dataset_stats_path", None
+    )
+
+    # RobotVideoDataset writes a copy of the stats to misc.get_work_dir()
+    # (default "./runs/", which may not exist). Point it at a real directory.
+    import os as _os
+
+    from fastwam.utils import misc as _fw_misc
+
+    work_dir = str(cfg.runner.logger.get("log_path", "/workspace/runs"))
+    _os.makedirs(work_dir, exist_ok=True)
+    _fw_misc.register_work_dir(work_dir)
+
+    overrides_kw = dict(
+        dataset_dirs=dataset_dirs,
+        is_training_set=not eval_dataset,
+        text_embedding_cache_dir=text_cache,
+    )
+    if norm_stats:
+        overrides_kw["pretrained_norm_stats"] = str(norm_stats)
+
+    dataset = instantiate(data_train, **overrides_kw)
+    logger.info(
+        "FastWAM SFT dataset: %d samples from %s", len(dataset), dataset_dirs
+    )
+
+    sampler = DistributedSampler(
+        dataset,
+        num_replicas=world_size,
+        rank=rank,
+        shuffle=not eval_dataset,
+        drop_last=not eval_dataset,
+    )
+
+    data_loader = StatefulDataLoader(
+        dataset,
+        batch_size=cfg.actor.micro_batch_size,
+        sampler=sampler,
+        num_workers=cfg.data.get("num_workers", 2),
+        collate_fn=default_collate,
+        pin_memory=True,
+        drop_last=not eval_dataset,
+    )
+    return data_loader, {"num_samples": len(dataset)}

--- a/rlinf/models/__init__.py
+++ b/rlinf/models/__init__.py
@@ -111,6 +111,11 @@ def _register_builtin_models():
 
         return get_model(cfg, torch_dtype)
 
+    def _build_fastwam(cfg: DictConfig, torch_dtype):
+        from rlinf.models.embodiment.fastwam import get_model
+
+        return get_model(cfg, torch_dtype)
+
     def _build_gr00t_n1d6(cfg: DictConfig, torch_dtype):
         from rlinf.models.embodiment.gr00t import get_model
 
@@ -206,6 +211,12 @@ def _register_builtin_models():
     register_model(
         SupportedModel.DREAMZERO.value,
         _build_dreamzero,
+        category="embodied",
+        force=True,
+    )
+    register_model(
+        "fastwam",
+        _build_fastwam,
         category="embodied",
         force=True,
     )

--- a/rlinf/models/embodiment/fastwam/README.md
+++ b/rlinf/models/embodiment/fastwam/README.md
@@ -1,0 +1,70 @@
+# FastWAM in RLinf
+
+[FastWAM](https://github.com/yuantianyuan01/FastWAM) (*Fast-WAM: Do World Action
+Models Need Test-time Future Imagination?*) is a Wan2.2 video-diffusion world model
+with a flow-matching action expert. This package adapts FastWAM's own implementation
+to RLinf so it can be **evaluated** (LIBERO / LIBERO-Plus) and **SFT-trained** through
+RLinf's standard workers, by wrapping the upstream package rather than reimplementing it.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| `fastwam_policy.py` | `FastWAMPolicy(BasePolicy)` — `predict_action_batch`→`infer_action`, `sft_forward`→`training_loss` |
+| `__init__.py` | `get_model` — composes FastWAM's Hydra configs, builds model + processor, loads checkpoint |
+| `../../../data/datasets/fastwam/` | SFT dataloader wrapping FastWAM `RobotVideoDataset` |
+
+Registered in `rlinf/config.py` (`SupportedModel.FASTWAM`, `EMBODIED_MODEL`),
+`rlinf/models/__init__.py` (`_build_fastwam`), and dispatched in
+`rlinf/workers/sft/fsdp_vla_sft_worker.py`.
+
+## Prerequisites
+
+- Install FastWAM as a package (`pip install -e /path/to/FastWAM`) so `import fastwam` works.
+- Wan2.2 VAE + T5 are fetched by DiffSynth on first model build. The default converted
+  -safetensors mirror is **ModelScope-only**; configs set `model.redirect_common_files=false`
+  to use the original `Wan-AI/Wan2.2-TI2V-5B` `.pth` files on HuggingFace.
+- Eval uses `skip_dit_load_from_pretrain=true`: the released FastWAM checkpoint's `mot`
+  provides the trained video+action experts, so the 20GB Wan DiT is **not** downloaded.
+
+## Evaluation (LIBERO + LIBERO-Plus)
+
+```bash
+# weights
+huggingface-cli download yuanty/fastwam libero_uncond_2cam224.pt \
+  libero_uncond_2cam224_dataset_stats.json --local-dir /workspace/checkpoints/fastwam
+
+# LIBERO
+MUJOCO_GL=egl bash evaluations/run_eval.sh libero libero_spatial_fastwam_eval
+
+# LIBERO-Plus  (needs the liberoplus package + its assets.zip, and ImageMagick)
+LIBERO_TYPE=plus LIBERO_SUFFIX=all MUJOCO_GL=egl \
+  bash evaluations/run_eval.sh libero libero_spatial_fastwam_plus_eval
+```
+
+Set `rollout.model.checkpoint_path` / `dataset_stats_path` (configs default to
+`/workspace/checkpoints/fastwam/...`). `num_action_chunks` is the executed replan
+length; FastWAM predicts `action_horizon` (=`num_frames-1`) per inference.
+
+## SFT
+
+```bash
+# 1) LeRobot LIBERO data + 2) precomputed T5 text embeddings
+python FastWAM/scripts/precompute_text_embeds.py task=libero_uncond_2cam224_1e-4 \
+  'data.train.dataset_dirs=[/path/to/libero_spatial_no_noops_lerobot]' \
+  data.train.text_embedding_cache_dir=/workspace/data/text_embeds_cache/libero \
+  model.redirect_common_files=false
+
+bash examples/sft/run_vla_sft.sh libero_sft_fastwam
+```
+
+SFT initialises the MoT from the released checkpoint (`skip_dit_load_from_pretrain`),
+so only VAE+T5 + the 12GB checkpoint are needed (no 20GB DiT / ActionDiT backbone).
+Only the MoT experts (+ proprio encoder) are trained (`freeze_non_dit`).
+
+**Multi-GPU note:** the full MoT is ~6B trainable params, and the MoT performs *manual*
+cross-expert attention (accessing DiT-block internals rather than `block.forward`),
+which is incompatible with per-block FSDP2 auto-wrap. Full-MoT SFT therefore needs
+multi-GPU FSDP with a whole-model wrap policy; on a single GPU it OOMs. See
+`smoke_sft.py` for a single-GPU action-expert smoke that exercises the full
+dataloader → `sft_forward` → `training_loss` → backward path.

--- a/rlinf/models/embodiment/fastwam/__init__.py
+++ b/rlinf/models/embodiment/fastwam/__init__.py
@@ -1,0 +1,226 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FastWAM model factory for RLinf.
+
+``get_model`` composes the upstream FastWAM Hydra configs (model + data/processor),
+instantiates the model and processor exactly as the official LIBERO eval does, loads
+the fine-tuned checkpoint, and wraps everything in :class:`FastWAMPolicy`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+import torch.nn as nn
+from omegaconf import DictConfig, OmegaConf
+
+from rlinf.models.embodiment.fastwam.fastwam_policy import FastWAMPolicy
+from rlinf.utils.logging import get_logger
+
+logger = get_logger()
+
+
+@dataclass
+class FastWAMInferConfig:
+    """Resolved rollout-time hyper-parameters (defaults mirror ``configs/sim_libero.yaml``)."""
+
+    action_horizon: int = 32
+    num_action_chunks: int = 8
+    num_inference_steps: int = 10
+    binarize_gripper: bool = True
+    text_cfg_scale: float = 1.0
+    negative_prompt: str = ""
+    sigma_shift: Optional[float] = None
+    seed: Optional[int] = None
+    rand_device: str = "cpu"
+    tiled: bool = False
+    concat_multi_camera: str = "horizontal"
+    # Optional world-model future-video generation during eval (uses infer_joint,
+    # which also decodes pixels -> slower; applied to env 0 only, capped count).
+    visualize_future_video: bool = False
+    future_video_dir: Optional[str] = None
+    num_video_frames: int = 9
+    max_video_saves: int = 12
+
+
+def _default_fastwam_config_dir() -> str:
+    """Locate FastWAM's ``configs`` dir (editable install keeps the repo intact)."""
+    env = os.environ.get("FASTWAM_CONFIG_DIR")
+    if env:
+        return env
+    import fastwam
+
+    repo_root = Path(fastwam.__file__).resolve().parents[2]
+    cfg_dir = repo_root / "configs"
+    if not cfg_dir.is_dir():
+        raise FileNotFoundError(
+            f"FastWAM configs dir not found at {cfg_dir}. Set FASTWAM_CONFIG_DIR or "
+            "model.fastwam.config_dir."
+        )
+    return str(cfg_dir)
+
+
+def _register_fastwam_resolvers() -> None:
+    """Register the OmegaConf resolvers FastWAM configs rely on (idempotent)."""
+    for name, fn in (
+        ("eval", eval),
+        ("max", lambda x: max(x)),
+        ("split", lambda s, idx: s.split("/")[int(idx)]),
+    ):
+        try:
+            OmegaConf.register_new_resolver(name, fn)
+        except ValueError:
+            pass  # already registered
+
+
+def _compose_fastwam_cfg(config_dir: str, config_name: str, overrides) -> DictConfig:
+    """Compose a FastWAM Hydra config without disturbing RLinf's own Hydra state."""
+    from hydra import compose, initialize_config_dir
+    from hydra.core.global_hydra import GlobalHydra
+
+    _register_fastwam_resolvers()
+    already = GlobalHydra.instance().is_initialized()
+    if already:
+        GlobalHydra.instance().clear()
+    try:
+        with initialize_config_dir(config_dir=str(config_dir), version_base=None):
+            cfg = compose(config_name=config_name, overrides=list(overrides or []))
+    finally:
+        GlobalHydra.instance().clear()
+    return cfg
+
+
+def _resolve_dataset_stats_path(cfg: DictConfig, ckpt_path: Optional[str]) -> str:
+    explicit = cfg.get("dataset_stats_path", None)
+    candidates = []
+    if explicit:
+        candidates.append(Path(os.path.expanduser(os.path.expandvars(str(explicit)))))
+    if ckpt_path:
+        ckpt = Path(os.path.expanduser(os.path.expandvars(str(ckpt_path))))
+        # released checkpoint ships ``<name>_dataset_stats.json`` next to ``<name>.pt``
+        candidates.append(ckpt.with_name(ckpt.stem + "_dataset_stats.json"))
+        for parent in list(ckpt.parents)[:4]:
+            candidates.append(parent / "dataset_stats.json")
+    for path in candidates:
+        if path.exists():
+            return str(path)
+    raise FileNotFoundError(
+        "Could not locate FastWAM dataset_stats.json. Set "
+        "model.dataset_stats_path to the *_dataset_stats.json shipped with the checkpoint. "
+        f"Tried: {[str(c) for c in candidates]}"
+    )
+
+
+def get_model(cfg: DictConfig, torch_dtype=None) -> nn.Module:
+    """Build a :class:`FastWAMPolicy` from an RLinf model config.
+
+    Expected ``cfg`` keys (under ``rollout.model`` / ``actor.model``):
+        model_type: "fastwam"
+        precision: "bf16"
+        checkpoint_path: path to ``libero_uncond_2cam224.pt`` (None for SFT-from-base)
+        dataset_stats_path: optional explicit ``*_dataset_stats.json``
+        num_action_chunks / action_horizon / num_inference_steps / binarize_gripper / ...
+        fastwam:
+            config_dir: optional FastWAM configs dir (auto-detected otherwise)
+            config_name: FastWAM Hydra config (default "sim_libero")
+            overrides: optional list[str] of extra Hydra overrides
+    """
+    # Point DiffSynth at HuggingFace + the shared checkpoint dir (idempotent).
+    os.environ.setdefault("DIFFSYNTH_DOWNLOAD_SOURCE", "huggingface")
+    os.environ.setdefault(
+        "DIFFSYNTH_MODEL_BASE_PATH",
+        os.environ.get("DIFFSYNTH_MODEL_BASE_PATH", "/workspace/checkpoints"),
+    )
+
+    fw = cfg.get("fastwam", {}) or {}
+    config_dir = fw.get("config_dir", None) or _default_fastwam_config_dir()
+    config_name = fw.get("config_name", "sim_libero")
+    overrides = fw.get("overrides", None)
+
+    fcfg = _compose_fastwam_cfg(config_dir, config_name, overrides)
+
+    if torch_dtype is None:
+        torch_dtype = torch.bfloat16
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    from hydra.utils import instantiate
+
+    # Instantiate the FastWAM model (resolves ${data...}/${model...} against fcfg root).
+    model = instantiate(fcfg.model, model_dtype=torch_dtype, device=device)
+
+    ckpt_path = cfg.get("checkpoint_path", None) or cfg.get("model_path", None)
+    if ckpt_path:
+        ckpt_path = os.path.expanduser(os.path.expandvars(str(ckpt_path)))
+        if Path(ckpt_path).exists():
+            logger.info("Loading FastWAM checkpoint: %s", ckpt_path)
+            model.load_checkpoint(ckpt_path)
+        else:
+            raise FileNotFoundError(f"FastWAM checkpoint_path not found: {ckpt_path}")
+    else:
+        logger.warning(
+            "FastWAM get_model called without checkpoint_path; using base/random "
+            "weights (only valid for SFT-from-base)."
+        )
+
+    # Train only the MoT experts (+ proprio encoder), matching FastWAM's
+    # ``_apply_dit_only_train_mode``. Frozen modules (VAE / text encoder) are not
+    # updated during SFT; for eval this is a harmless no-op under torch.no_grad.
+    if bool(cfg.get("freeze_non_dit", True)):
+        model.requires_grad_(False)
+        if hasattr(model, "dit"):
+            model.dit.requires_grad_(True)
+        if getattr(model, "proprio_encoder", None) is not None:
+            model.proprio_encoder.requires_grad_(True)
+
+    # Build the processor + normalizer from dataset stats (action/state min-max).
+    processor = instantiate(fcfg.data.train.processor).eval()
+    stats_path = _resolve_dataset_stats_path(cfg, ckpt_path)
+    from fastwam.datasets.lerobot.utils.normalizer import load_dataset_stats_from_json
+
+    processor.set_normalizer_from_stats(load_dataset_stats_from_json(stats_path))
+    logger.info("FastWAM processor using dataset stats: %s", stats_path)
+
+    # Resolve rollout hyper-parameters (RLinf cfg wins over sim_libero defaults).
+    eval_cfg = fcfg.get("EVALUATION", {})
+    num_frames = int(fcfg.data.train.num_frames)
+    infer_cfg = FastWAMInferConfig(
+        action_horizon=int(cfg.get("action_horizon", None) or (num_frames - 1)),
+        num_action_chunks=int(cfg.get("num_action_chunks", eval_cfg.get("replan_steps", 8))),
+        num_inference_steps=int(
+            cfg.get("num_inference_steps", eval_cfg.get("num_inference_steps", 10))
+        ),
+        binarize_gripper=bool(cfg.get("binarize_gripper", eval_cfg.get("binarize_gripper", True))),
+        text_cfg_scale=float(cfg.get("text_cfg_scale", eval_cfg.get("text_cfg_scale", 1.0))),
+        negative_prompt=str(cfg.get("negative_prompt", eval_cfg.get("negative_prompt", ""))),
+        sigma_shift=cfg.get("sigma_shift", None),
+        seed=cfg.get("seed", None),
+        rand_device=str(cfg.get("rand_device", "cpu")),
+        tiled=bool(cfg.get("tiled", False)),
+        concat_multi_camera=str(fcfg.data.train.get("concat_multi_camera", "horizontal")),
+        visualize_future_video=bool(cfg.get("visualize_future_video", False)),
+        future_video_dir=cfg.get("future_video_dir", None),
+        num_video_frames=(num_frames - 1)
+        // int(fcfg.data.train.get("action_video_freq_ratio", 1))
+        + 1,
+        max_video_saves=int(cfg.get("max_video_saves", 12)),
+    )
+
+    policy = FastWAMPolicy(model=model, processor=processor, infer_cfg=infer_cfg)
+    policy = policy.to(dtype=torch_dtype)
+    return policy

--- a/rlinf/models/embodiment/fastwam/fastwam_policy.py
+++ b/rlinf/models/embodiment/fastwam/fastwam_policy.py
@@ -1,0 +1,274 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RLinf policy wrapper around the upstream FastWAM world-action model.
+
+FastWAM (``Fast-WAM: Do World Action Models Need Test-time Future Imagination?``)
+is a Wan2.2 video-diffusion world model with a flow-matching action expert. This
+module adapts its self-contained inference / training API to RLinf's
+:class:`~rlinf.models.embodiment.base_policy.BasePolicy` contract so the model can
+be evaluated (LIBERO / LIBERO-Plus) and SFT-trained through RLinf workers.
+
+The wrapper deliberately *reuses* upstream FastWAM code (``infer_action`` for
+rollout, ``training_loss`` for SFT, ``FastWAMProcessor`` for normalization) rather
+than re-implementing the model, so behaviour matches the official repository.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from rlinf.models.embodiment.base_policy import BasePolicy, ForwardType
+
+# Upstream FastWAM. The prompt template and gripper helper are vendored here as
+# small constants to avoid importing the (non-packaged) ``experiments`` scripts.
+DEFAULT_PROMPT = (
+    "A video recorded from a robot's point of view executing the following "
+    "instruction: {task}"
+)
+
+
+def _invert_gripper_action(action: np.ndarray) -> np.ndarray:
+    """Flip the gripper open/close sign (matches FastWAM ``invert_gripper_action``)."""
+    action = action.copy()
+    action[..., -1] = action[..., -1] * -1.0
+    return action
+
+
+def _center_crop_resize(img: np.ndarray, width: int, height: int) -> np.ndarray:
+    """Aspect-preserving resize + center crop to (height, width).
+
+    Mirrors ``experiments/libero/eval_libero_single.py::_center_crop_resize`` so
+    the pixels handed to the model match the official LIBERO evaluation exactly.
+    """
+    from PIL import Image
+
+    pil = Image.fromarray(np.asarray(img, dtype=np.uint8))
+    src_w, src_h = pil.size
+    scale = max(width / src_w, height / src_h)
+    resized = pil.resize(
+        (round(src_w * scale), round(src_h * scale)), resample=Image.BILINEAR
+    )
+    rw, rh = resized.size
+    left = max((rw - width) // 2, 0)
+    top = max((rh - height) // 2, 0)
+    cropped = resized.crop((left, top, left + width, top + height))
+    return np.asarray(cropped, dtype=np.uint8)
+
+
+class FastWAMPolicy(nn.Module, BasePolicy):
+    """Adapter exposing FastWAM through RLinf's embodied policy interface.
+
+    Args:
+        model: An instantiated upstream ``fastwam.models.wan22.fastwam.FastWAM``.
+        processor: A ``FastWAMProcessor`` whose normalizer is already populated
+            from ``dataset_stats.json`` (action/state min-max stats).
+        infer_cfg: Resolved inference hyper-parameters (see :class:`FastWAMInferConfig`).
+    """
+
+    def __init__(self, model: nn.Module, processor: Any, infer_cfg: "FastWAMInferConfig"):
+        nn.Module.__init__(self)
+        self.model = model
+        self.processor = processor
+        self.infer_cfg = infer_cfg
+
+        # Cache the (single) merged action/state keys used by the processor.
+        self._state_key = processor.shape_meta["state"][0]["key"]
+        self._action_key = processor.shape_meta["action"][0]["key"]
+        # Per-camera target HxW from shape_meta (e.g. [3,224,224] -> 224,224).
+        self._cam_hw = [
+            (int(m["shape"][1]), int(m["shape"][2]))
+            for m in processor.shape_meta["images"]
+        ]
+        self._num_cameras = int(processor.num_output_cameras)
+        self._video_saves = 0  # count of predicted-future clips saved so far
+
+    def _save_future_video(self, frames) -> None:
+        """Save a predicted future-video clip (list of PIL frames) as an MP4."""
+        import os
+
+        from fastwam.utils.video_io import save_mp4
+
+        out_dir = self.infer_cfg.future_video_dir
+        os.makedirs(out_dir, exist_ok=True)
+        path = os.path.join(out_dir, f"future_{self._video_saves:04d}.mp4")
+        save_mp4(frames, path, fps=8)
+        self._video_saves += 1
+
+    # ------------------------------------------------------------------ utils
+    @property
+    def device(self):
+        return getattr(self.model, "device", next(self.model.parameters()).device)
+
+    @property
+    def torch_dtype(self):
+        return getattr(self.model, "torch_dtype", torch.bfloat16)
+
+    def _build_input_image(self, main_img, wrist_img) -> torch.Tensor:
+        """Build the FastWAM input frame: per-cam crop/resize, h-concat, [-1, 1]."""
+        main_np = main_img.detach().cpu().numpy() if torch.is_tensor(main_img) else np.asarray(main_img)
+        if self._num_cameras == 1:
+            h, w = self._cam_hw[0]
+            rgb = _center_crop_resize(main_np, width=w, height=h)
+        else:
+            h0, w0 = self._cam_hw[0]
+            h1, w1 = self._cam_hw[1]
+            primary = _center_crop_resize(main_np, width=w0, height=h0)
+            wrist_np = (
+                wrist_img.detach().cpu().numpy()
+                if torch.is_tensor(wrist_img)
+                else np.asarray(wrist_img)
+            )
+            wrist = _center_crop_resize(wrist_np, width=w1, height=h1)
+            if self.infer_cfg.concat_multi_camera == "vertical":
+                rgb = np.concatenate([primary, wrist], axis=0)
+            else:
+                rgb = np.concatenate([primary, wrist], axis=1)
+        x = torch.tensor(rgb).permute(2, 0, 1).unsqueeze(0)
+        x = x.to(device=self.device, dtype=self.torch_dtype)
+        x = x * (2.0 / 255.0) - 1.0
+        return x
+
+    def _normalize_proprio(self, state_vec) -> torch.Tensor:
+        state = state_vec.detach().cpu() if torch.is_tensor(state_vec) else torch.as_tensor(state_vec)
+        state = state.to(dtype=torch.float32).reshape(-1)
+        batch = {"state": {self._state_key: state.unsqueeze(0)}}
+        batch = self.processor.action_state_transform(batch)
+        batch = self.processor.normalizer.forward(batch)
+        return batch["state"][self._state_key]
+
+    def _denormalize_action(self, action: torch.Tensor) -> np.ndarray:
+        if action.ndim == 2:
+            action = action.unsqueeze(0)
+        normalizer = self.processor.normalizer.normalizers["action"][self._action_key]
+        action = action.to(dtype=torch.float32, device="cpu")
+        return normalizer.backward(action).numpy()
+
+    # ------------------------------------------------------------------ rollout
+    @torch.no_grad()
+    def predict_action_batch(self, env_obs: dict, mode: str = "eval", **kwargs):
+        """Predict an action chunk for a batch of LIBERO observations.
+
+        Args:
+            env_obs: dict from :class:`~rlinf.envs.libero.libero_env.LiberoEnv`
+                with ``main_images`` / ``wrist_images`` ``[B,H,W,3]`` uint8,
+                ``states`` ``[B,8]`` and ``task_descriptions`` list[str].
+
+        Returns:
+            (actions, result): ``actions`` is ``np.ndarray`` of shape
+            ``[B, num_action_chunks, action_dim]`` ready for ``env.chunk_step``;
+            ``result`` is an (empty) metadata dict for the eval path.
+        """
+        cfg = self.infer_cfg
+        main_images = env_obs["main_images"]
+        wrist_images = env_obs.get("wrist_images")
+        states = env_obs["states"]
+        task_descriptions = env_obs["task_descriptions"]
+        batch_size = int(main_images.shape[0])
+
+        chunks = []
+        for i in range(batch_size):
+            image = self._build_input_image(
+                main_images[i], None if wrist_images is None else wrist_images[i]
+            )
+            proprio = self._normalize_proprio(states[i])
+            prompt = DEFAULT_PROMPT.format(task=str(task_descriptions[i]))
+
+            common = dict(
+                prompt=prompt,
+                input_image=image,
+                action_horizon=cfg.action_horizon,
+                proprio=proprio,
+                negative_prompt=cfg.negative_prompt,
+                text_cfg_scale=cfg.text_cfg_scale,
+                num_inference_steps=cfg.num_inference_steps,
+                sigma_shift=cfg.sigma_shift,
+                seed=cfg.seed,
+                rand_device=cfg.rand_device,
+                tiled=cfg.tiled,
+            )
+            # World-model imagination: also decode the predicted future video for
+            # env 0 (capped) when enabled. infer_joint denoises video latents + VAE
+            # decode (slower); the fast action-only path is used otherwise.
+            do_viz = (
+                cfg.visualize_future_video
+                and cfg.future_video_dir is not None
+                and i == 0
+                and self._video_saves < cfg.max_video_saves
+            )
+            if do_viz:
+                pred = self.model.infer_joint(
+                    num_video_frames=cfg.num_video_frames,
+                    test_action_with_infer_action=False,
+                    **common,
+                )
+                self._save_future_video(pred["video"])
+            else:
+                pred = self.model.infer_action(**common)
+            action = self._denormalize_action(pred["action"])[0]  # [T, D]
+
+            # FastWAM dataloader maps gripper to (0=close, 1=open); undo that and
+            # restore LIBERO's (-1=open, +1=close) convention before execution.
+            action[..., -1] = action[..., -1] * 2 - 1
+            action = _invert_gripper_action(action)
+            if cfg.binarize_gripper:
+                action[..., -1] = np.sign(action[..., -1])
+
+            chunks.append(action[: cfg.num_action_chunks])
+
+        actions = np.stack(chunks, axis=0).astype(np.float32)
+        return actions, {}
+
+    # ------------------------------------------------------------------ SFT
+    def forward(self, forward_type=ForwardType.DEFAULT, **kwargs):
+        if forward_type == ForwardType.SFT:
+            return self.sft_forward(**kwargs)
+        if forward_type == ForwardType.DEFAULT:
+            return self.default_forward(**kwargs)
+        raise NotImplementedError(f"FastWAMPolicy does not support {forward_type}.")
+
+    def sft_forward(self, data: Any = None, **kwargs):
+        """Supervised flow-matching loss over a FastWAM sample batch.
+
+        ``data`` is a dict produced by FastWAM's ``RobotVideoDataset`` collate
+        (``video``, ``action``, ``context``, ``context_mask`` and optional
+        ``proprio`` / ``*_is_pad``). Returns a dict with at least ``loss``.
+        """
+        if data is None:
+            raise ValueError("FastWAMPolicy.sft_forward requires `data`.")
+        loss, metrics = self.model.training_loss(data)
+        out = {"loss": loss}
+        # Surface video / action sub-losses for logging (worker reads .item()).
+        if isinstance(metrics, dict):
+            if "loss_video" in metrics:
+                out["dynamics_loss"] = torch.as_tensor(metrics["loss_video"])
+            if "loss_action" in metrics:
+                out["action_loss"] = torch.as_tensor(metrics["loss_action"])
+        return out
+
+    def default_forward(self, **kwargs):
+        raise NotImplementedError(
+            "FastWAMPolicy.default_forward is unused; rollout uses predict_action_batch "
+            "and SFT uses sft_forward."
+        )
+
+    def gradient_checkpointing_enable(self, **kwargs):
+        # FastWAM toggles gradient checkpointing through its DiT configs
+        # (``use_gradient_checkpointing`` / ``mot_checkpoint_mixed_attn``); this is a
+        # no-op so RLinf's FSDP manager can call it uniformly.
+        return

--- a/rlinf/workers/sft/fsdp_vla_sft_worker.py
+++ b/rlinf/workers/sft/fsdp_vla_sft_worker.py
@@ -73,6 +73,14 @@ class FSDPVlaSftWorker(FSDPSftWorker):
             return build_dreamzero_sft_dataloader(
                 self.cfg, self._world_size, self._rank, data_paths, eval_dataset
             )
+        elif SupportedModel(self.cfg.actor.model.model_type) in [
+            SupportedModel.FASTWAM
+        ]:
+            from rlinf.data.datasets.fastwam import build_fastwam_sft_dataloader
+
+            return build_fastwam_sft_dataloader(
+                self.cfg, self._world_size, self._rank, data_paths, eval_dataset
+            )
         else:
             raise KeyError(
                 f"not support such model type {self.cfg.actor.model.model_type} for SFT right now."


### PR DESCRIPTION
Wrap the upstream FastWAM (Wan2.2 video-diffusion world-action model) behind RLinf's embodied interfaces for LIBERO eval and SFT (predict_action_batch -> infer_action, sft_forward -> training_loss).

<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR integrates FastWAM into RLinf.
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
Tested with LIBERO-spatial evaluation (SR meets the paper's results) and a smoke run of sft
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.