### PR TITLE
fix: record stream to keep async copy safe

### DIFF
--- a/rlinf/hybrid_engines/weight_syncer/bucket_syncer.py
+++ b/rlinf/hybrid_engines/weight_syncer/bucket_syncer.py
@@ -24,6 +24,8 @@ from rlinf.utils.utils import (
     materialize_tensor,
     normalize_device,
     normalize_dtype,
+    record_async_copy_source,
+    record_async_copy_sources,
     synchronize_pending_accel_copies,
 )
 
@@ -209,14 +211,21 @@ class BucketWeightSyncer(WeightSyncer):
 
         if self.load_instant:
             model.load_state_dict(bucket, strict=False)
+            pending_copy_devices, source_keepalive = record_async_copy_sources(
+                bucket.values()
+            )
+            synchronize_pending_accel_copies(pending_copy_devices)
+            source_keepalive.clear()
         else:
             cpu_buffer: dict[str, torch.Tensor] = {}
             pending_copy_devices: set[torch.device] = set()
+            staged_source_tensors: list[torch.Tensor] = []
             for key, value in bucket.items():
                 if value.device.type == "cpu":
                     cpu_buffer[key] = value
                 else:
                     cpu_buffer[key] = value.to("cpu", non_blocking=True)
+                    record_async_copy_source(value, staged_source_tensors)
                     pending_copy_devices.add(value.device)
         del bucket
 
@@ -224,17 +233,24 @@ class BucketWeightSyncer(WeightSyncer):
             bucket = await recv()
             if self.load_instant:
                 model.load_state_dict(bucket, strict=False)
+                pending_copy_devices, source_keepalive = record_async_copy_sources(
+                    bucket.values()
+                )
+                synchronize_pending_accel_copies(pending_copy_devices)
+                source_keepalive.clear()
             else:
                 for key, value in bucket.items():
                     if value.device.type == "cpu":
                         cpu_buffer[key] = value
                     else:
                         cpu_buffer[key] = value.to("cpu", non_blocking=True)
+                        record_async_copy_source(value, staged_source_tensors)
                         pending_copy_devices.add(value.device)
             del bucket
 
         if not self.load_instant:
             synchronize_pending_accel_copies(pending_copy_devices)
+            staged_source_tensors.clear()
             model.load_state_dict(cpu_buffer, strict=False)
             del cpu_buffer
 

--- a/rlinf/hybrid_engines/weight_syncer/bucket_syncer.py
+++ b/rlinf/hybrid_engines/weight_syncer/bucket_syncer.py
@@ -21,12 +21,11 @@ from torch.distributed.tensor import DTensor
 
 from rlinf.scheduler import Worker
 from rlinf.utils.utils import (
+    dtype_size,
     materialize_tensor,
     normalize_device,
     normalize_dtype,
-    record_async_copy_source,
-    record_async_copy_sources,
-    synchronize_pending_accel_copies,
+    tensors_record_stream,
 )
 
 from .base import RecvFn, SendFn, WeightSyncer
@@ -40,16 +39,28 @@ def iter_named_tensor_buckets(
     bucket_device: str | torch.device,
     dtype_resolver: Callable[[str, torch.dtype], torch.dtype] | None = None,
 ) -> Iterator[dict[str, torch.Tensor]]:
-    """Yield transport-ready buckets from already-selected named tensors."""
+    """
+    Iterate transport-ready buckets from already-selected named tensors.
+
+    Args:
+        - items (Iterable[tuple[str, torch.Tensor | DTensor]]): An iterable of tuples containing parameter names and their corresponding tensors.
+        - version (int | torch.Tensor): The version of the model weights.
+        - bucket_size (int): The maximum threshold (in bytes) of each bucket.
+        - bucket_device (str | torch.device): The device to which the buckets will be moved, cpu or accelerator device.
+        - dtype_resolver (Callable[[str, torch.dtype], torch.dtype] | None): A function that takes a parameter name and its original dtype,
+            and returns the dtype to be used for transport. If None, the original dtype is used.
+
+    Yields:
+        dict[str, torch.Tensor]: A dictionary representing a bucket of parameters to be synchronized.
+    """
     metadata_keys = {
         BucketWeightSyncer._TOTAL_BUCKETS_KEY,
         BucketWeightSyncer._SYNCER_VERSION_KEY,
     }
     bucket_device = normalize_device(bucket_device)
     prepared_items: list[tuple[str, torch.Tensor | DTensor, torch.dtype]] = []
-    currently_hold = 0
-    total_buckets = 0
-
+    currently_hold: int = 0
+    bucket_plan: list[list[tuple[str, torch.Tensor | DTensor, torch.dtype]]] = []
     for key, value in items:
         if key in metadata_keys:
             raise ValueError(f"Bucket payload key conflicts with metadata key: {key}")
@@ -60,63 +71,71 @@ def iter_named_tensor_buckets(
             else value.dtype
         )
         prepared_items.append((key, value, transport_dtype))
-        currently_hold += (
-            value.numel() * torch.empty((), dtype=transport_dtype).element_size()
-        )
+        currently_hold += value.numel() * dtype_size(transport_dtype)
         if currently_hold >= bucket_size:
-            total_buckets += 1
+            bucket_plan.append(prepared_items)
+            prepared_items = []
             currently_hold = 0
 
     if currently_hold > 0:
-        total_buckets += 1
-    assert total_buckets > 0, "No parameters to sync"
+        bucket_plan.append(prepared_items)
+        prepared_items = []
+        currently_hold = 0
 
-    metadata = {
+    if len(bucket_plan) == 0:
+        raise ValueError("No parameters to sync")
+
+    bucket: dict[str, torch.Tensor] = {
         BucketWeightSyncer._TOTAL_BUCKETS_KEY: torch.tensor(
-            total_buckets, dtype=torch.int32, device=bucket_device
+            len(bucket_plan), dtype=torch.int32, device=bucket_device
         ),
         BucketWeightSyncer._SYNCER_VERSION_KEY: torch.as_tensor(
-            version, dtype=torch.int64, device=bucket_device
+            version, dtype=torch.int32, device=bucket_device
         ),
     }
+    for bucket_items in bucket_plan:
+        for key, value, transport_dtype in bucket_items:
+            tensor = materialize_tensor(value)
 
-    bucket_idx = 0
-    currently_hold = 0
-    bucket: dict[str, torch.Tensor] = {}
-    pending_copy_devices: set[torch.device] = set()
-    for key, value, transport_dtype in prepared_items:
-        tensor = materialize_tensor(value)
-        async_accel_to_cpu = (
-            bucket_device.type == "cpu"
-            and tensor.device.type == Worker.torch_device_type
-        )
-        bucket[key] = tensor.to(
-            device=bucket_device,
-            dtype=transport_dtype,
-            non_blocking=async_accel_to_cpu or bucket_device.type != "cpu",
-        )
-        if async_accel_to_cpu:
-            pending_copy_devices.add(tensor.device)
-        currently_hold += bucket[key].numel() * bucket[key].element_size()
-
-        if currently_hold >= bucket_size:
-            if bucket_idx == 0:
-                bucket.update(metadata)
-            synchronize_pending_accel_copies(pending_copy_devices)
-            yield bucket
-            bucket_idx += 1
-            bucket = {}
-            currently_hold = 0
-            pending_copy_devices = set()
+            bucket[key] = tensor.to(
+                device=bucket_device,
+                dtype=transport_dtype,
+                non_blocking=False,
+            )
+        yield bucket
+        bucket = {}
 
     if bucket:
-        if bucket_idx == 0:
-            bucket.update(metadata)
-        synchronize_pending_accel_copies(pending_copy_devices)
         yield bucket
+        bucket = {}
 
 
 class BucketWeightSyncer(WeightSyncer):
+    """Synchronize model weights by sending state dict tensors in buckets.
+
+    The sender materializes selected tensors, optionally casts floating-point
+    tensors to ``bucket_dtype`` for transport, moves them to ``bucket_device``,
+    and sends them as dictionaries whose payload entries are parameter or buffer
+    names. The receiver applies the received buckets to the target model with
+    ``load_state_dict(strict=False)``.
+
+    The first bucket also carries metadata used by the receiver-side protocol:
+    ``_TOTAL_BUCKETS_KEY`` stores the number of buckets to receive, and
+    ``_SYNCER_VERSION_KEY`` stores the weight version associated with the
+    transfer. These keys are reserved and must not collide with state dict keys.
+
+    Attributes:
+        bucket_size: Target maximum bucket payload size in bytes. A single tensor
+            is never split, so an individual payload may exceed this value.
+        bucket_dtype: Optional dtype used to transport floating-point tensors.
+            Non-floating tensors keep their original dtype.
+        bucket_device: Device where bucket payload tensors are staged before
+            sending.
+        is_agent: Whether to apply agent-specific language-model key rewriting.
+        load_instant: Whether the receiver loads each bucket immediately instead
+            of staging all buckets on CPU before one final model load.
+    """
+
     _TOTAL_BUCKETS_KEY = "total_buckets"
     _SYNCER_VERSION_KEY = "syncer_version"
 
@@ -130,14 +149,26 @@ class BucketWeightSyncer(WeightSyncer):
     ):
         super().__init__()
         self.bucket_size = bucket_size
-        self.bucket_dtype = (
-            normalize_dtype(bucket_dtype) if bucket_dtype is not None else None
-        )
+        self.bucket_dtype = normalize_dtype(bucket_dtype)
         self.bucket_device = normalize_device(bucket_device)
         self.is_agent = is_agent
         self.load_instant = load_instant
 
     def _bucket_key(self, key: str, has_visual: bool) -> str | None:
+        """
+        Handle special cases for parameter names when syncing weights.
+        If the key contains "_extra_state", it is ignored (returns None).
+        If the model has visual components and is an agent, and the key starts with
+        "model.language_model.", it is transformed to start with "model." instead.
+        Otherwise, the key is returned unchanged.
+
+        Args:
+            key (str): The original parameter name.
+            has_visual (bool): Indicates if the model has visual components.
+
+        Returns:
+            str | None: The transformed parameter name, or None if it should be ignored.
+        """
         if "_extra_state" in key:
             return None
         if has_visual and self.is_agent and key.startswith("model.language_model."):
@@ -145,6 +176,17 @@ class BucketWeightSyncer(WeightSyncer):
         return key
 
     def _transport_dtype(self, dtype: torch.dtype) -> torch.dtype:
+        """
+        Determine the dtype for transporting tensors in buckets.
+        If it's floating point and a bucket_dtype is specified, use the bucket_dtype.
+        Otherwise, use the original dtype.
+
+        Args:
+            dtype (torch.dtype): The original dtype of the tensor.
+
+        Returns:
+            torch.dtype: The dtype to be used for transporting the tensor.
+        """
         if self.bucket_dtype is not None and dtype.is_floating_point:
             return self.bucket_dtype
         return dtype
@@ -153,35 +195,39 @@ class BucketWeightSyncer(WeightSyncer):
         self,
         state_dict: dict[str, torch.Tensor | DTensor],
         version: int | torch.Tensor,
-    ):
-        has_visual = any("visual." in key for key in state_dict.keys())
-        named_items: list[tuple[str, torch.Tensor | DTensor]] = []
+    ) -> Iterator[dict[str, torch.Tensor]]:
+        """
+        Iterate over the state_dict and yield buckets of parameters that need to be synchronized.
 
-        assert self.param_names_need_sync, (
-            "param_names_need_sync must be set and not empty"
+        Args:
+            state_dict (dict[str, torch.Tensor | DTensor]): The model's state dictionary. If the tensor is a DTensor,
+                it will be materialized to a regular torch.Tensor before being added to the bucket.
+            version (int | torch.Tensor): The version of the model weights being synchronized.
+
+        Yields:
+            dict[str, torch.Tensor]: A dictionary representing a bucket of parameters to be synchronized.
+        """
+
+        has_visual = any(
+            "visual." in key for key in self.param_names_need_sync if key in state_dict
         )
-        for key, value in state_dict.items():
-            if key not in self.param_names_need_sync:
-                continue
-            name = self._bucket_key(key, has_visual)
-            if name is None:
-                continue
-            named_items.append((name, value))
+
+        def iter_named_items() -> Iterator[tuple[str, torch.Tensor | DTensor]]:
+            for key in self.param_names_need_sync:
+                value = state_dict.get(key)
+                if value is None:
+                    continue
+                bucket_key = self._bucket_key(key, has_visual)
+                if bucket_key is not None:
+                    yield bucket_key, value
 
         yield from iter_named_tensor_buckets(
-            named_items,
+            iter_named_items(),
             version,
             bucket_size=self.bucket_size,
             bucket_device=self.bucket_device,
-            dtype_resolver=lambda _key, dtype: self._transport_dtype(dtype),
+            dtype_resolver=lambda _, dtype: self._transport_dtype(dtype),
         )
-
-    def divide_into_buckets(
-        self,
-        state_dict: dict[str, torch.Tensor | DTensor],
-        version: int | torch.Tensor,
-    ) -> list[dict[str, torch.Tensor]]:
-        return list(self.iter_buckets(state_dict, version))
 
     async def init_sender(
         self,
@@ -190,8 +236,21 @@ class BucketWeightSyncer(WeightSyncer):
         send: SendFn,
         recv: RecvFn | None = None,
     ) -> None:
+        """
+        Initialize the sender for weight synchronization.
+
+        Args:
+            - state_dict (dict[str, torch.Tensor | DTensor]): The model's state dictionary. For BucketWeightSyncer,
+                it's not used, just to keep the interface consistent with other syncers.
+            - param_names_need_sync (list[str]): A list of parameter names that need to be synchronized.
+            - send (SendFn): The function for sender to communicate with the receiver.
+            - recv (RecvFn | None): The function for receiver to communicate with the sender.
+        """
+
         del state_dict, send, recv
         self.param_names_need_sync = set(param_names_need_sync)
+        if not self.param_names_need_sync:
+            raise ValueError("param_names_need_sync must not be empty")
         self._sender_initialized = True
 
     async def sync(
@@ -200,58 +259,75 @@ class BucketWeightSyncer(WeightSyncer):
         send: SendFn,
         version: int | torch.Tensor,
     ) -> None:
+        """
+        Synchronize the model weights by sending buckets of parameters to the receiver.
+        Called by the sender every time the model weights should update after sender/receiver is initialized.
+
+        Args:
+            - state_dict (dict[str, torch.Tensor | DTensor]): The model's state dictionary
+            - send (SendFn): The function to send synchronized buckets. it should define who sends, how to send, and where to send.
+            - version (int | torch.Tensor): The version of the model weights being synchronized.
+        """
         for bucket in self.iter_buckets(state_dict, version):
             await send(bucket)
             del bucket
 
     async def apply(self, model: torch.nn.Module, recv: RecvFn) -> int:
+        """
+        Apply the synchronized weights to the model by receiving buckets of parameters from the sender.
+        Called by the receiver every time the model weights should update after sender/receiver is initialized.
+
+        Args:
+            - model (torch.nn.Module): The model to which the synchronized weights will be applied.
+            - recv (RecvFn): The function to receive synchronized buckets. it should define who receives, how to receive, and where to receive.
+
+        Returns:
+            int: The version of the model weights that have been applied.
+        """
+
         bucket: dict[str, torch.Tensor] = await recv()
         total_buckets = int(bucket.pop(self._TOTAL_BUCKETS_KEY).item())
         applied_version = int(bucket.pop(self._SYNCER_VERSION_KEY).item())
 
+        fallback_keepalive: list[torch.Tensor] = []
+        current_stream: torch.Stream | None = None
+        # NOTE:
+        # actually only accel -> accel could return without finishing copy (if non_blocking=False)
+        # to simpilify code and keep extensibility, we judge by bucket's device only.
+        # we record buckets because bucket's deleted but tensor comes with another stream.
+        need_record = (
+            self.load_instant and self.bucket_device.type == Worker.torch_device_type
+        )
+
         if self.load_instant:
             model.load_state_dict(bucket, strict=False)
-            pending_copy_devices, source_keepalive = record_async_copy_sources(
-                bucket.values()
-            )
-            synchronize_pending_accel_copies(pending_copy_devices)
-            source_keepalive.clear()
         else:
             cpu_buffer: dict[str, torch.Tensor] = {}
-            pending_copy_devices: set[torch.device] = set()
-            staged_source_tensors: list[torch.Tensor] = []
             for key, value in bucket.items():
-                if value.device.type == "cpu":
-                    cpu_buffer[key] = value
-                else:
-                    cpu_buffer[key] = value.to("cpu", non_blocking=True)
-                    record_async_copy_source(value, staged_source_tensors)
-                    pending_copy_devices.add(value.device)
+                cpu_buffer[key] = value.to("cpu")
+        if need_record:
+            current_stream = Worker.torch_platform.current_stream(self.bucket_device)
+            fallback_keepalive.extend(tensors_record_stream(bucket.values()))
         del bucket
 
         for _ in range(total_buckets - 1):
             bucket = await recv()
             if self.load_instant:
                 model.load_state_dict(bucket, strict=False)
-                pending_copy_devices, source_keepalive = record_async_copy_sources(
-                    bucket.values()
-                )
-                synchronize_pending_accel_copies(pending_copy_devices)
-                source_keepalive.clear()
             else:
                 for key, value in bucket.items():
-                    if value.device.type == "cpu":
-                        cpu_buffer[key] = value
-                    else:
-                        cpu_buffer[key] = value.to("cpu", non_blocking=True)
-                        record_async_copy_source(value, staged_source_tensors)
-                        pending_copy_devices.add(value.device)
+                    cpu_buffer[key] = value.to("cpu")
+
+            if need_record:
+                fallback_keepalive.extend(tensors_record_stream(bucket.values()))
             del bucket
 
         if not self.load_instant:
-            synchronize_pending_accel_copies(pending_copy_devices)
-            staged_source_tensors.clear()
             model.load_state_dict(cpu_buffer, strict=False)
             del cpu_buffer
+
+        if fallback_keepalive:
+            current_stream.synchronize()
+            del fallback_keepalive
 
         return applied_version

--- a/rlinf/hybrid_engines/weight_syncer/patch_syncer.py
+++ b/rlinf/hybrid_engines/weight_syncer/patch_syncer.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 
 import torch
@@ -25,9 +24,7 @@ from rlinf.scheduler import Worker
 from rlinf.utils.utils import (
     materialize_tensor,
     normalize_device,
-    record_async_copy_source,
-    record_async_copy_sources,
-    synchronize_pending_accel_copies,
+    tensors_record_stream,
 )
 
 from .base import RecvFn, SendFn, WeightSyncer
@@ -36,6 +33,19 @@ from .compressor import PatchCompressor
 
 
 def downscale_nonnegative_indices(tensor: torch.Tensor) -> torch.Tensor:
+    """Cast nonnegative index tensors to the smallest supported integer dtype.
+
+    Empty tensors are encoded as ``torch.uint8``. Non-empty tensors are cast to
+    ``torch.uint8``, ``torch.int32``, or ``torch.int64`` according to the maximum
+    value they contain. Callers must only pass nonnegative indices.
+
+    Args:
+        tensor: Index tensor whose values are expected to be nonnegative.
+
+    Returns:
+        A tensor with the same values stored in the smallest supported integer
+        dtype.
+    """
     if tensor.numel() == 0:
         return tensor.to(torch.uint8)
     max_value = int(tensor.max().item())
@@ -47,6 +57,24 @@ def downscale_nonnegative_indices(tensor: torch.Tensor) -> torch.Tensor:
 
 
 def as_coo_2d_view(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Size]:
+    """View a tensor as a 2-D COO indexing target.
+
+    Scalars are viewed as shape ``(1, 1)``, vectors as ``(1, N)``, matrices are
+    returned as-is, and higher-rank tensors are viewed as
+    ``(shape[0], prod(shape[1:]))``. Higher-rank tensors must be flattenable as a
+    view, so non-contiguous layouts that require a copy are rejected.
+
+    Args:
+        tensor: Tensor to expose as a 2-D view for COO row/column indexing.
+
+    Returns:
+        A tuple ``(view, original_shape)`` where ``view`` is the 2-D tensor view
+        and ``original_shape`` is the input tensor shape.
+
+    Raises:
+        ValueError: If a tensor with rank three or higher cannot flatten its
+            trailing dimensions as a view.
+    """
     original_shape = tensor.shape
     if tensor.ndim == 0:
         view = tensor.unsqueeze(0).unsqueeze(0)
@@ -68,19 +96,65 @@ def as_coo_2d_view(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Size]:
 
 @dataclass
 class EmptyWeightPatch:
+    """
+    Patch payload used when no synchronized tensor values changed.
+
+    Attributes:
+        version: Weight version represented by this empty patch.
+    """
+
     version: torch.Tensor
 
     def to(
         self, device: torch.device | str, non_blocking: bool = False
     ) -> "EmptyWeightPatch":
+        """
+        Move the empty patch metadata to a device.
+
+        Args:
+            device: Target device for the version tensor.
+            non_blocking: Whether to request non-blocking tensor movement.
+
+        Returns:
+            A new ``EmptyWeightPatch`` whose tensor fields are on ``device``.
+        """
         device = normalize_device(device)
         return EmptyWeightPatch(
             version=self.version.to(device=device, non_blocking=non_blocking),
         )
 
+    def tensors(self) -> list[torch.Tensor]:
+        """
+        Return a list of all tensor fields in the empty patch.
+
+        Returns:
+            A list of all tensor fields in the order they are defined in the
+            dataclass.
+        """
+        return [self.version]
+
 
 @dataclass
 class WeightPatch:
+    """Sparse patch payload for changed state dict entries.
+
+    The patch stores changed tensors in COO-like form. ``ordinals`` identifies
+    which state dict entries changed, ``nnz_per_tensor`` stores how many changed
+    values belong to each ordinal, ``rows`` and ``cols`` store the changed
+    positions in each entry's 2-D view, and ``values`` stores the raw bytes of
+    the changed values.
+
+    Attributes:
+        version: Weight version represented by this patch.
+        ordinals: State dict key ordinals for tensors with at least one changed
+            value.
+        nnz_per_tensor: Number of changed values for each ordinal.
+        rows: Row indices for changed values, concatenated across tensors.
+        cols: Column indices for changed values, concatenated across tensors.
+        values: Raw byte representation of changed values, concatenated across
+            tensors.
+    """
+
     version: torch.Tensor
     ordinals: torch.Tensor
     nnz_per_tensor: torch.Tensor
@@ -91,6 +165,15 @@ class WeightPatch:
     def to(
         self, device: torch.device | str, non_blocking: bool = False
     ) -> "WeightPatch":
+        """Move all patch tensors to a device.
+
+        Args:
+            device: Target device for every tensor field.
+            non_blocking: Whether to request non-blocking tensor movement.
+
+        Returns:
+            A new ``WeightPatch`` whose tensor fields are on ``device``.
+        """
         device = normalize_device(device)
         return WeightPatch(
             version=self.version.to(device=device, non_blocking=non_blocking),
@@ -103,9 +186,44 @@ class WeightPatch:
             values=self.values.to(device=device, non_blocking=non_blocking),
         )
 
+    def tensors(self) -> list[torch.Tensor]:
+        """Return a list of all tensor fields in the patch.
+
+        Returns:
+            A list of all tensor fields in the order they are defined in the
+            dataclass.
+        """
+        return [
+            self.version,
+            self.ordinals,
+            self.nnz_per_tensor,
+            self.rows,
+            self.cols,
+            self.values,
+        ]
+
 
 @dataclass
 class CompressedWeightPatch:
+    """Compressed sparse patch payload.
+
+    This payload mirrors ``WeightPatch`` but stores the row indices, column
+    indices, and raw value bytes in compressed byte tensors. The dtype-code
+    tensors record the original dtypes needed by the compressor to reconstruct
+    each compressed field.
+
+    Attributes:
+        version: Weight version represented by this patch.
+        ordinals: State dict key ordinals for tensors with changed values.
+        nnz_per_tensor: Number of changed values for each ordinal.
+        rows_compressed: Compressed representation of the row-index tensor.
+        cols_compressed: Compressed representation of the column-index tensor.
+        values_compressed: Compressed representation of the raw value bytes.
+        rows_dtype_code: Encoded dtype metadata for decompressed rows.
+        cols_dtype_code: Encoded dtype metadata for decompressed columns.
+        values_dtype_code: Encoded dtype metadata for decompressed values.
+    """
+
     version: torch.Tensor
     ordinals: torch.Tensor
     nnz_per_tensor: torch.Tensor
@@ -115,6 +233,25 @@ class CompressedWeightPatch:
     rows_dtype_code: torch.Tensor
     cols_dtype_code: torch.Tensor
     values_dtype_code: torch.Tensor
+
+    def tensors(self) -> list[torch.Tensor]:
+        """Return a list of all tensor fields in the compressed patch.
+
+        Returns:
+            A list of all tensor fields in the order they are defined in the
+            dataclass.
+        """
+        return [
+            self.version,
+            self.ordinals,
+            self.nnz_per_tensor,
+            self.rows_compressed,
+            self.cols_compressed,
+            self.values_compressed,
+            self.rows_dtype_code,
+            self.cols_dtype_code,
+            self.values_dtype_code,
+        ]
 
 
 WeightPatchTransport = EmptyWeightPatch | WeightPatch | CompressedWeightPatch
@@ -151,6 +288,23 @@ class PatchBuilder(ABC):
     def delta_encode(
         rows: torch.Tensor, cols: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Delta-encode COO row and column indices for compact transport.
+
+        The input indices are expected to be ordered as produced by
+        ``Tensor.nonzero(as_tuple=True)`` on a 2-D view: rows are nondecreasing,
+        and columns are ordered within each row. Row indices are encoded as
+        first-order deltas. Column indices are encoded as deltas within the same
+        row and reset to the absolute column value when a new row starts.
+
+        Args:
+            rows: One-dimensional row indices for changed values.
+            cols: One-dimensional column indices for changed values. Must have
+                the same number of elements as ``rows``.
+
+        Returns:
+            A tuple ``(row_deltas, col_deltas)`` with the same shapes and dtypes
+            as the input tensors.
+        """
         assert rows.numel() > 0, "No indices to encode"
         assert rows.numel() == cols.numel(), (
             "Rows and columns must have the same number of elements"
@@ -172,8 +326,27 @@ class PatchBuilder(ABC):
     def delta_decode(
         rows_delta: torch.Tensor, cols_delta: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        assert rows_delta.numel() > 0
-        assert rows_delta.numel() == cols_delta.numel()
+        """Decode row and column deltas produced by ``delta_encode``.
+
+        Row indices are reconstructed with a cumulative sum. Column deltas are
+        accumulated within each row segment and reset whenever the decoded row
+        changes. The returned tensors use ``torch.int64`` so they can be used
+        directly as PyTorch advanced-indexing inputs after transport dtypes have
+        been downscaled.
+
+        Args:
+            rows_delta: One-dimensional row deltas produced by ``delta_encode``.
+            cols_delta: One-dimensional column deltas produced by
+                ``delta_encode``. Must have the same number of elements as
+                ``rows_delta``.
+
+        Returns:
+            A tuple ``(rows, cols)`` containing decoded ``torch.int64`` indices.
+        """
+        if rows_delta.numel() == 0:
+            raise ValueError("No indices to decode")
+        if rows_delta.numel() != cols_delta.numel():
+            raise ValueError("Rows and columns must have the same number of elements")
 
         rows = torch.cumsum(rows_delta, dim=0, dtype=torch.int64)
 
@@ -240,15 +413,6 @@ class _PrefetchedCPUSnapshot:
     copy_done: torch.Event
 
 
-@dataclass
-class _PendingSnapshotUpdate:
-    snapshot_value: torch.Tensor
-    rows: torch.Tensor
-    cols: torch.Tensor
-    values: torch.Tensor
-    copy_done: torch.Event
-
-
 class CPUSnapshotPatchBuilder(PatchBuilder):
     def __init__(
         self,
@@ -266,25 +430,17 @@ class CPUSnapshotPatchBuilder(PatchBuilder):
             delta_encoding=delta_encoding,
         )
         self._copy_streams: dict[torch.device, torch.Stream] = {}
-        self._snapshot_flush_executor = ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix="patch-snapshot-flush",
-        )
-        self._pending_snapshot_flush: Future[None] | None = None
 
     def create_patch(
         self,
         state_dict: dict[str, torch.Tensor | DTensor],
         version: torch.Tensor | int,
     ) -> EmptyWeightPatch | WeightPatch:
-        self._wait_pending_snapshot_flush()
-
         ordinals: list[torch.Tensor] = []
         nnz_per_tensor: list[torch.Tensor] = []
         row_chunks: list[torch.Tensor] = []
         col_chunks: list[torch.Tensor] = []
         value_byte_chunks: list[torch.Tensor] = []
-        pending_snapshot_updates: list[_PendingSnapshotUpdate] = []
         patch_device: torch.device | None = None
 
         prefetched = self._prefetch_snapshot(state_dict, 0)
@@ -327,13 +483,11 @@ class CPUSnapshotPatchBuilder(PatchBuilder):
             cols = cols.to(torch.int64)
             values = compare_value[rows, cols]
 
-            pending_snapshot_updates.append(
-                self._stage_snapshot_update(
-                    snapshot_value=current.snapshot_value,
-                    rows=rows,
-                    cols=cols,
-                    values=values,
-                )
+            self._update_snapshot(
+                snapshot_value=current.snapshot_value,
+                rows=rows,
+                cols=cols,
+                values=values,
             )
 
             if self.delta_encoding:
@@ -368,7 +522,6 @@ class CPUSnapshotPatchBuilder(PatchBuilder):
                 cols=cols_tensor,
                 values=torch.cat(value_byte_chunks, dim=0),
             )
-            self._submit_snapshot_updates(pending_snapshot_updates)
             return patch
 
         if patch_device is None:
@@ -376,25 +529,7 @@ class CPUSnapshotPatchBuilder(PatchBuilder):
         patch = EmptyWeightPatch(
             version=torch.tensor(version, dtype=torch.int64, device=patch_device)
         )
-        self._submit_snapshot_updates(pending_snapshot_updates)
         return patch
-
-    def _wait_pending_snapshot_flush(self) -> None:
-        if self._pending_snapshot_flush is None:
-            return
-        self._pending_snapshot_flush.result()
-        self._pending_snapshot_flush = None
-
-    def _submit_snapshot_updates(
-        self,
-        pending_snapshot_updates: list[_PendingSnapshotUpdate],
-    ) -> None:
-        if not pending_snapshot_updates:
-            return
-        self._pending_snapshot_flush = self._snapshot_flush_executor.submit(
-            self._flush_snapshot,
-            pending_snapshot_updates,
-        )
 
     def _get_copy_stream(self, device: torch.device | None) -> torch.Stream:
         if device.index is None:
@@ -452,40 +587,17 @@ class CPUSnapshotPatchBuilder(PatchBuilder):
             copy_done=copy_done,
         )
 
-    def _stage_snapshot_update(
+    def _update_snapshot(
         self,
         snapshot_value: torch.Tensor,
         rows: torch.Tensor,
         cols: torch.Tensor,
         values: torch.Tensor,
-    ) -> _PendingSnapshotUpdate:
-        rows_cpu = torch.empty_like(rows, device="cpu", pin_memory=True)
-        cols_cpu = torch.empty_like(cols, device="cpu", pin_memory=True)
-        values_cpu = torch.empty_like(values, device="cpu", pin_memory=True)
-
-        with Worker.torch_platform.device(values.device):
-            stream = Worker.torch_platform.current_stream(values.device)
-            rows_cpu.copy_(rows, non_blocking=True)
-            cols_cpu.copy_(cols, non_blocking=True)
-            values_cpu.copy_(values, non_blocking=True)
-            copy_done = Worker.torch_platform.Event()
-            copy_done.record(stream)
-
-        return _PendingSnapshotUpdate(
-            snapshot_value=snapshot_value,
-            rows=rows_cpu,
-            cols=cols_cpu,
-            values=values_cpu,
-            copy_done=copy_done,
-        )
-
-    def _flush_snapshot(
-        self,
-        pending_snapshot_updates: list[_PendingSnapshotUpdate],
     ) -> None:
-        for update in pending_snapshot_updates:
-            update.copy_done.synchronize()
-            update.snapshot_value[update.rows, update.cols] = update.values
+        rows_cpu = rows.to(device="cpu", non_blocking=False)
+        cols_cpu = cols.to(device="cpu", non_blocking=False)
+        values_cpu = values.to(device="cpu", non_blocking=False)
+        snapshot_value[rows_cpu, cols_cpu] = values_cpu
 
 
 class GPUSnapshotPatchBuilder(PatchBuilder):
@@ -672,9 +784,8 @@ class PatchWeightSyncer(WeightSyncer):
         self,
         state_dict: dict[str, torch.Tensor | DTensor],
         bucket: dict[str, torch.Tensor],
-        source_keepalive: list[torch.Tensor],
-    ) -> set[torch.device]:
-        pending_copy_devices: set[torch.device] = set()
+    ) -> list[torch.Tensor]:
+        fallback_keepalive: list[torch.Tensor] = []
         for key, value in bucket.items():
             if key not in state_dict:
                 raise ValueError(
@@ -686,32 +797,25 @@ class PatchWeightSyncer(WeightSyncer):
                     "Patch init sync receiver does not support DTensor state_dict values"
                 )
             target.copy_(value, non_blocking=True)
-            if value.device.type == Worker.torch_device_type:
-                record_async_copy_source(value, source_keepalive)
-                pending_copy_devices.add(value.device)
-            if target.device.type == Worker.torch_device_type:
-                pending_copy_devices.add(target.device)
-        return pending_copy_devices
+        if self.transport_device.type == Worker.torch_device_type:
+            fallback_keepalive.extend(tensors_record_stream(bucket.values()))
+        return fallback_keepalive
 
     async def _apply_init_weights(
         self,
         state_dict: dict[str, torch.Tensor | DTensor],
         recv: RecvFn,
     ) -> None:
-        first_bucket = await recv()
-        if not isinstance(first_bucket, dict):
+        bucket = await recv()
+        if not isinstance(bucket, dict):
             raise TypeError(
                 "Patch init sync receiver expected a bucket payload dictionary"
             )
 
-        total_buckets = int(
-            first_bucket.pop(BucketWeightSyncer._TOTAL_BUCKETS_KEY).item()
-        )
-        first_bucket.pop(BucketWeightSyncer._SYNCER_VERSION_KEY)
-        source_keepalive: list[torch.Tensor] = []
-        pending_copy_devices = self._apply_init_weight_bucket(
-            state_dict, first_bucket, source_keepalive
-        )
+        total_buckets = int(bucket.pop(BucketWeightSyncer._TOTAL_BUCKETS_KEY).item())
+        bucket.pop(BucketWeightSyncer._SYNCER_VERSION_KEY)
+        fallback_keepalive: list[torch.Tensor] = []
+        fallback_keepalive.extend(self._apply_init_weight_bucket(state_dict, bucket))
 
         for _ in range(total_buckets - 1):
             bucket = await recv()
@@ -719,11 +823,11 @@ class PatchWeightSyncer(WeightSyncer):
                 raise TypeError(
                     "Patch init sync receiver expected a bucket payload dictionary"
                 )
-            pending_copy_devices.update(
-                self._apply_init_weight_bucket(state_dict, bucket, source_keepalive)
+            fallback_keepalive.extend(
+                self._apply_init_weight_bucket(state_dict, bucket)
             )
-        synchronize_pending_accel_copies(pending_copy_devices)
-        source_keepalive.clear()
+        Worker.torch_platform.current_stream().synchronize()
+        fallback_keepalive.clear()
 
     async def init_sender(
         self,
@@ -776,7 +880,6 @@ class PatchWeightSyncer(WeightSyncer):
                 snapshot_value = value_2dview.detach().to(
                     device=snapshot_device,
                     dtype=receiver_dtypes[key],
-                    non_blocking=self.snapshot_device.type != "cpu",
                     copy=True,
                 )
                 snapshot[key] = (
@@ -828,16 +931,6 @@ class PatchWeightSyncer(WeightSyncer):
             await self._apply_init_weights(state_dict, recv)
         self._receiver_initialized = True
 
-    def delta_encode(
-        self, rows: torch.Tensor, cols: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        return PatchBuilder.delta_encode(rows, cols)
-
-    def delta_decode(
-        self, rows_delta: torch.Tensor, cols_delta: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        return PatchBuilder.delta_decode(rows_delta, cols_delta)
-
     @torch.no_grad()
     def create_patch(
         self,
@@ -874,13 +967,16 @@ class PatchWeightSyncer(WeightSyncer):
             "Snapshot info not initialized"
         )
 
-        payload = await recv()
+        payload: WeightPatchTransport = await recv()
 
-        pending_copy_devices, source_keepalive = record_async_copy_sources(
-            value for value in vars(payload).values() if torch.is_tensor(value)
-        )
+        fallback_keepalive: list[torch.Tensor] = []
+        if self.transport_device.type == Worker.torch_device_type:
+            fallback_keepalive = tensors_record_stream(payload.tensors())
 
         if isinstance(payload, EmptyWeightPatch):
+            if fallback_keepalive:
+                Worker.torch_platform.current_stream().synchronize()
+                fallback_keepalive.clear()
             return int(payload.version.item())
         patch = self.compressor.decompress(payload)
         applied_version = int(patch.version.item())
@@ -954,6 +1050,9 @@ class PatchWeightSyncer(WeightSyncer):
             )
 
         assert offset == patch.rows.numel(), "Patch offsets do not match payload size"
-        if source_keepalive:
-            synchronize_pending_accel_copies(pending_copy_devices)
+
+        if fallback_keepalive:
+            Worker.torch_platform.current_stream().synchronize()
+            fallback_keepalive.clear()
+
         return applied_version

--- a/rlinf/hybrid_engines/weight_syncer/patch_syncer.py
+++ b/rlinf/hybrid_engines/weight_syncer/patch_syncer.py
@@ -25,6 +25,7 @@ from rlinf.scheduler import Worker
 from rlinf.utils.utils import (
     materialize_tensor,
     normalize_device,
+    record_async_copy_source,
     synchronize_pending_accel_copies,
 )
 
@@ -670,6 +671,7 @@ class PatchWeightSyncer(WeightSyncer):
         self,
         state_dict: dict[str, torch.Tensor | DTensor],
         bucket: dict[str, torch.Tensor],
+        source_keepalive: list[torch.Tensor],
     ) -> set[torch.device]:
         pending_copy_devices: set[torch.device] = set()
         for key, value in bucket.items():
@@ -683,10 +685,11 @@ class PatchWeightSyncer(WeightSyncer):
                     "Patch init sync receiver does not support DTensor state_dict values"
                 )
             target.copy_(value, non_blocking=True)
+            if value.device.type == Worker.torch_device_type:
+                record_async_copy_source(value, source_keepalive)
+                pending_copy_devices.add(value.device)
             if target.device.type == Worker.torch_device_type:
                 pending_copy_devices.add(target.device)
-            elif value.device.type == Worker.torch_device_type:
-                pending_copy_devices.add(value.device)
         return pending_copy_devices
 
     async def _apply_init_weights(
@@ -704,7 +707,10 @@ class PatchWeightSyncer(WeightSyncer):
             first_bucket.pop(BucketWeightSyncer._TOTAL_BUCKETS_KEY).item()
         )
         first_bucket.pop(BucketWeightSyncer._SYNCER_VERSION_KEY)
-        pending_copy_devices = self._apply_init_weight_bucket(state_dict, first_bucket)
+        source_keepalive: list[torch.Tensor] = []
+        pending_copy_devices = self._apply_init_weight_bucket(
+            state_dict, first_bucket, source_keepalive
+        )
 
         for _ in range(total_buckets - 1):
             bucket = await recv()
@@ -713,9 +719,10 @@ class PatchWeightSyncer(WeightSyncer):
                     "Patch init sync receiver expected a bucket payload dictionary"
                 )
             pending_copy_devices.update(
-                self._apply_init_weight_bucket(state_dict, bucket)
+                self._apply_init_weight_bucket(state_dict, bucket, source_keepalive)
             )
         synchronize_pending_accel_copies(pending_copy_devices)
+        source_keepalive.clear()
 
     async def init_sender(
         self,

--- a/rlinf/hybrid_engines/weight_syncer/patch_syncer.py
+++ b/rlinf/hybrid_engines/weight_syncer/patch_syncer.py
@@ -26,6 +26,7 @@ from rlinf.utils.utils import (
     materialize_tensor,
     normalize_device,
     record_async_copy_source,
+    record_async_copy_sources,
     synchronize_pending_accel_copies,
 )
 
@@ -875,6 +876,10 @@ class PatchWeightSyncer(WeightSyncer):
 
         payload = await recv()
 
+        pending_copy_devices, source_keepalive = record_async_copy_sources(
+            value for value in vars(payload).values() if torch.is_tensor(value)
+        )
+
         if isinstance(payload, EmptyWeightPatch):
             return int(payload.version.item())
         patch = self.compressor.decompress(payload)
@@ -949,4 +954,6 @@ class PatchWeightSyncer(WeightSyncer):
             )
 
         assert offset == patch.rows.numel(), "Patch offsets do not match payload size"
+        if source_keepalive:
+            synchronize_pending_accel_copies(pending_copy_devices)
         return applied_version

--- a/rlinf/utils/utils.py
+++ b/rlinf/utils/utils.py
@@ -20,7 +20,7 @@ import random
 import sys
 from contextlib import contextmanager
 from functools import partial, wraps
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Iterable, Literal, Optional
 
 import numpy as np
 import torch
@@ -133,6 +133,31 @@ def synchronize_pending_accel_copies(copy_devices: set[torch.device]) -> None:
 
     for event in events:
         event.synchronize()
+
+
+def record_async_copy_source(
+    value: torch.Tensor, fallback_keepalive: list[torch.Tensor]
+) -> torch.device | None:
+    """Keep accelerator storage alive until a queued async copy consumes it."""
+    if value.device.type != Worker.torch_device_type:
+        return None
+    try:
+        value.record_stream(Worker.torch_platform.current_stream(value.device))
+    except (AttributeError, RuntimeError, TypeError):
+        fallback_keepalive.append(value)
+    return value.device
+
+
+def record_async_copy_sources(
+    values: Iterable[torch.Tensor],
+) -> tuple[set[torch.device], list[torch.Tensor]]:
+    """Protect accelerator tensors that may be read by queued async copies."""
+    pending_copy_devices: set[torch.device] = set()
+    source_keepalive: list[torch.Tensor] = []
+    for value in values:
+        if (device := record_async_copy_source(value, source_keepalive)) is not None:
+            pending_copy_devices.add(device)
+    return pending_copy_devices, source_keepalive
 
 
 def seed_everything(seed: int) -> int:

--- a/rlinf/utils/utils.py
+++ b/rlinf/utils/utils.py
@@ -28,12 +28,11 @@ import torch.nn.functional as F
 from torch.distributed.tensor import DTensor
 from torch.optim import Optimizer
 
+from rlinf.scheduler import Worker
 from rlinf.utils.metric_utils import compute_loss_mask
 
 
 def clear_memory(sync=True):
-    from rlinf.scheduler.worker.worker import Worker
-
     if sync:
         Worker.torch_platform.synchronize()
     gc.collect()
@@ -64,30 +63,55 @@ def materialize_tensor(tensor: torch.Tensor | DTensor) -> torch.Tensor:
     return tensor
 
 
-def normalize_dtype(dtype: torch.dtype | str) -> torch.dtype:
+_TORCH_STR_DTYPE_MAPPING = {
+    "float32": torch.float32,
+    "fp32": torch.float32,
+    "float16": torch.float16,
+    "fp16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "bf16": torch.bfloat16,
+}
+
+_TORCH_DTYPE_SIZE_MAPPING = {
+    torch.bool: 1,
+    torch.uint8: 1,
+    torch.int8: 1,
+    torch.int16: 2,
+    torch.int32: 4,
+    torch.int64: 8,
+    torch.float16: 2,
+    torch.bfloat16: 2,
+    torch.float32: 4,
+    torch.float64: 8,
+    torch.complex64: 8,
+    torch.complex128: 16,
+}
+
+
+def dtype_size(dtype: torch.dtype | str) -> int:
+    """Return the size in bytes of a given torch.dtype."""
+    dtype = normalize_dtype(dtype)
+    if dtype not in _TORCH_DTYPE_SIZE_MAPPING:
+        return torch.empty((), dtype=dtype).element_size()
+    return _TORCH_DTYPE_SIZE_MAPPING[dtype]
+
+
+def normalize_dtype(dtype: torch.dtype | str | None) -> torch.dtype | None:
     """Normalize string dtype aliases into torch.dtype values."""
+    if dtype is None:
+        return None
     if isinstance(dtype, torch.dtype):
         return dtype
     if isinstance(dtype, str):
-        mapping = {
-            "float32": torch.float32,
-            "fp32": torch.float32,
-            "float16": torch.float16,
-            "fp16": torch.float16,
-            "bfloat16": torch.bfloat16,
-            "bf16": torch.bfloat16,
-        }
         key = dtype.lower()
-        if key in mapping:
-            return mapping[key]
+        if key in _TORCH_STR_DTYPE_MAPPING:
+            return _TORCH_STR_DTYPE_MAPPING[key]
     raise TypeError(f"Unsupported dtype: {dtype}")
 
 
 def normalize_device(device: torch.device | str | None) -> torch.device:
     """Convert a device string into torch.device, defaulting to the worker device."""
     if device is None:
-        from rlinf.scheduler.worker.worker import Worker
-
         device = Worker.torch_device_type
     return device if isinstance(device, torch.device) else torch.device(device)
 
@@ -118,46 +142,42 @@ def collect_param_names_need_sync(module: torch.nn.Module) -> list[str]:
     return trainable_param_names + persistent_buffer_names
 
 
-def synchronize_pending_accel_copies(copy_devices: set[torch.device]) -> None:
-    """Wait for queued accelerator copies before host-side consumption."""
-    if not copy_devices:
-        return
+def tensors_record_stream(
+    tensors: Iterable[torch.Tensor], stream: torch.Stream | None = None
+) -> list[torch.Tensor]:
+    """
+    Record a stream for a collection of accelerator tensors.
 
-    events: list[torch.Event] = []
-    for device in copy_devices:
-        from rlinf.scheduler.worker.worker import Worker
+    In some cases, the backend may not support record_stream,
+    in which case we keep a reference to the tensors in a list to prevent the tensor storage
+    from being freed prematurely and allocated again by pytorch caching allocator.
+    The caller should synchronize before clearing these tensors.
 
-        event = Worker.torch_platform.Event()
-        event.record(Worker.torch_platform.current_stream(device))
-        events.append(event)
+    Args:
+        tensors (Iterable[torch.Tensor]): An iterable of tensors to record.
+        stream (torch.Stream | None): Stream to record for every tensor. When
+            unset, each tensor records the current stream for its own device.
 
-    for event in events:
-        event.synchronize()
-
-
-def record_async_copy_source(
-    value: torch.Tensor, fallback_keepalive: list[torch.Tensor]
-) -> torch.device | None:
-    """Keep accelerator storage alive until a queued async copy consumes it."""
-    if value.device.type != Worker.torch_device_type:
-        return None
-    try:
-        value.record_stream(Worker.torch_platform.current_stream(value.device))
-    except (AttributeError, RuntimeError, TypeError):
-        fallback_keepalive.append(value)
-    return value.device
-
-
-def record_async_copy_sources(
-    values: Iterable[torch.Tensor],
-) -> tuple[set[torch.device], list[torch.Tensor]]:
-    """Protect accelerator tensors that may be read by queued async copies."""
-    pending_copy_devices: set[torch.device] = set()
-    source_keepalive: list[torch.Tensor] = []
-    for value in values:
-        if (device := record_async_copy_source(value, source_keepalive)) is not None:
-            pending_copy_devices.add(device)
-    return pending_copy_devices, source_keepalive
+    Returns:
+        list[torch.Tensor]: A list of tensors that failed to record the stream,
+            which should be kept alive until synchronization.
+    """
+    if not Worker.torch_platform.is_initialized():
+        raise RuntimeError("Torch platform is not initialized, cannot record stream.")
+    fallback_keepalive: list[torch.Tensor] = []
+    for tensor in tensors:
+        if tensor.device.type != Worker.torch_device_type:
+            raise RuntimeError(
+                "Tensor device type does not match the worker device type, cannot record stream."
+            )
+        try:
+            record_stream = stream or Worker.torch_platform.current_stream(
+                tensor.device
+            )
+            tensor.record_stream(record_stream)
+        except (AttributeError, RuntimeError, TypeError):
+            fallback_keepalive.append(tensor)
+    return fallback_keepalive
 
 
 def seed_everything(seed: int) -> int:

--- a/tests/unit_tests/test_weight_syncer.py
+++ b/tests/unit_tests/test_weight_syncer.py
@@ -25,13 +25,14 @@ from rlinf.hybrid_engines.weight_syncer import (
     PatchWeightSyncer,
     WeightSyncer,
 )
-from rlinf.hybrid_engines.weight_syncer import (
-    patch_syncer as patch_syncer_module,
-)
 from rlinf.hybrid_engines.weight_syncer.bucket_syncer import (
     iter_named_tensor_buckets,
 )
 from rlinf.hybrid_engines.weight_syncer.patch_syncer import (
+    CPUSnapshotPatchBuilder,
+    EmptyWeightPatch,
+    GPUSnapshotPatchBuilder,
+    WeightPatch,
     as_coo_2d_view,
     downscale_nonnegative_indices,
 )
@@ -194,6 +195,33 @@ def _assert_state_dict_equal_on_cpu(
         )
 
 
+def _assert_patch_equal(
+    lhs: EmptyWeightPatch | WeightPatch, rhs: EmptyWeightPatch | WeightPatch
+) -> None:
+    assert type(lhs) is type(rhs)
+    for field_name, lhs_value in vars(lhs).items():
+        rhs_value = getattr(rhs, field_name)
+        torch.testing.assert_close(
+            lhs_value.cpu(),
+            rhs_value.cpu(),
+            msg=f"Mismatch at patch field={field_name}",
+        )
+
+
+def _stress_cuda_allocator(device: torch.device, num_tensors: int = 128) -> None:
+    streams = [Worker.torch_platform.Stream(device=device) for _ in range(2)]
+    tensors: list[torch.Tensor] = []
+    for stream in streams:
+        with Worker.torch_platform.stream(stream):
+            for _ in range(num_tensors):
+                tensors.append(
+                    torch.empty((256, 256), device=device, dtype=torch.float32)
+                )
+    for stream in streams:
+        stream.synchronize()
+    del tensors
+
+
 def _get_param_names_need_sync(model: torch.nn.Module) -> list[str]:
     return collect_param_names_need_sync(model)
 
@@ -297,23 +325,6 @@ def test_downscale_nonnegative_indices_selects_expected_dtype():
         torch.tensor([0, torch.iinfo(torch.int32).max + 1], dtype=torch.int64)
     )
     assert large.dtype == torch.int64
-
-
-def test_patch_delta_encode_decode_roundtrip():
-    syncer = PatchWeightSyncer(
-        snapshot_device="cpu",
-        transport_device="cpu",
-        delta_encoding=True,
-        compression_algorithm="none",
-    )
-    rows = torch.tensor([0, 0, 0, 2, 2, 5], dtype=torch.int64)
-    cols = torch.tensor([1, 4, 7, 0, 8, 3], dtype=torch.int64)
-
-    row_deltas, col_deltas = syncer.delta_encode(rows, cols)
-    decoded_rows, decoded_cols = syncer.delta_decode(row_deltas, col_deltas)
-
-    torch.testing.assert_close(decoded_rows, rows)
-    torch.testing.assert_close(decoded_cols, cols)
 
 
 def test_patch_weight_syncer_roundtrip_delta_enabled():
@@ -563,6 +574,66 @@ def test_patch_weight_syncer_cpu_snapshot_cuda_state_roundtrip():
     )
 
 
+def test_cpu_snapshot_patch_builder_matches_gpu_snapshot_under_allocator_pressure():
+    device = _get_cuda_device()
+    model = _make_model(device)
+    state_dict = model.state_dict()
+    ordered_keys = list(state_dict.keys())
+    param_names_need_sync = _get_param_names_need_sync(model)
+    original_shapes = {
+        key: as_coo_2d_view(value)[1] for key, value in state_dict.items()
+    }
+
+    cpu_snapshot = {
+        key: as_coo_2d_view(value.detach())[0].cpu().pin_memory()
+        for key, value in state_dict.items()
+        if key in param_names_need_sync
+    }
+    gpu_snapshot = {
+        key: as_coo_2d_view(value.detach())[0].clone()
+        for key, value in state_dict.items()
+        if key in param_names_need_sync
+    }
+    cpu_builder = CPUSnapshotPatchBuilder(
+        cpu_snapshot,
+        ordered_keys,
+        param_names_need_sync,
+        original_shapes,
+        delta_encoding=True,
+    )
+    gpu_builder = GPUSnapshotPatchBuilder(
+        gpu_snapshot,
+        ordered_keys,
+        param_names_need_sync,
+        original_shapes,
+        delta_encoding=True,
+    )
+
+    for step in range(1, 25):
+        with torch.no_grad():
+            for key in param_names_need_sync:
+                value_2dview, _ = as_coo_2d_view(state_dict[key])
+                row = step % value_2dview.shape[0]
+                col = (step * 7 + len(key)) % value_2dview.shape[1]
+                value_2dview[row, col] += (step % 5 + 1) * 0.125
+                if value_2dview.numel() > 1:
+                    row2 = (row + 1) % value_2dview.shape[0]
+                    col2 = (col + 3) % value_2dview.shape[1]
+                    value_2dview[row2, col2] -= (step % 3 + 1) * 0.25
+
+        cpu_patch = cpu_builder.create_patch(state_dict, version=step)
+        _stress_cuda_allocator(device)
+        gpu_patch = gpu_builder.create_patch(state_dict, version=step)
+
+        _assert_patch_equal(cpu_patch, gpu_patch)
+        for key in param_names_need_sync:
+            torch.testing.assert_close(
+                cpu_snapshot[key],
+                gpu_snapshot[key].cpu(),
+                msg=f"Mismatch at snapshot key={key}, step={step}",
+            )
+
+
 def test_patch_weight_syncer_uses_receiver_dtypes_for_snapshot():
     device = _get_cuda_device()
     sender_model = _make_mixed_dtype_model(device)
@@ -720,55 +791,6 @@ def test_patch_weight_syncer_init_sync_bootstraps_full_state_dict():
     _assert_state_dict_equal(
         _clone_state_dict(sender_model), _clone_state_dict(receiver_model)
     )
-
-
-def test_patch_weight_syncer_init_sync_waits_once_after_all_buckets(monkeypatch):
-    device = _get_cuda_device()
-    sender_model = _make_bucket_dtype_model(device)
-    receiver_model = copy.deepcopy(sender_model)
-    transport = _InMemoryDuplexTransport()
-
-    sender_syncer = PatchWeightSyncer(
-        snapshot_device="cpu",
-        transport_device="cpu",
-        delta_encoding=True,
-        compression_algorithm="none",
-        init_sync_enabled=True,
-        init_sync_prefixes=None,
-        init_sync_bucket_size=32,
-    )
-    receiver_syncer = PatchWeightSyncer(
-        snapshot_device="cpu",
-        transport_device="cpu",
-        delta_encoding=True,
-        compression_algorithm="none",
-        init_sync_enabled=True,
-        init_sync_prefixes=None,
-        init_sync_bucket_size=32,
-    )
-
-    calls: list[set[torch.device]] = []
-    original_sync = patch_syncer_module.synchronize_pending_accel_copies
-
-    def _spy(copy_devices: set[torch.device]) -> None:
-        calls.append(set(copy_devices))
-        original_sync(copy_devices)
-
-    monkeypatch.setattr(patch_syncer_module, "synchronize_pending_accel_copies", _spy)
-
-    async def _run() -> None:
-        await _init_patch_syncers(
-            sender_syncer,
-            receiver_syncer,
-            sender_model,
-            receiver_model,
-            transport,
-        )
-
-    asyncio.run(_run())
-
-    assert len(calls) == 1
-    assert calls[0] == {device}
 
 
 def test_patch_weight_syncer_preserves_nonfloating_buffers():
@@ -1026,7 +1048,7 @@ def test_bucket_weight_syncer_preserves_original_dtypes_when_bucket_dtype_none()
         sender_model.bool_buf.logical_not_()
 
     asyncio.run(_init_bucket_syncer(syncer, sender_model))
-    buckets = syncer.divide_into_buckets(sender_model.state_dict(), version=11)
+    buckets = list(syncer.iter_buckets(sender_model.state_dict(), version=11))
     payload = {
         key: value
         for bucket in buckets
@@ -1076,7 +1098,7 @@ def test_iter_named_tensor_buckets_supports_custom_dtype_resolver():
     assert payload["int64_buf"].dtype == torch.int64
     assert payload["bool_buf"].dtype == torch.bool
     assert buckets[0]["total_buckets"].dtype == torch.int32
-    assert buckets[0]["syncer_version"].dtype == torch.int64
+    assert buckets[0]["syncer_version"].dtype == torch.int32
 
 
 def test_bucket_weight_syncer_preserves_nonfloating_dtypes_when_bucket_dtype_set():
@@ -1089,7 +1111,7 @@ def test_bucket_weight_syncer_preserves_nonfloating_dtypes_when_bucket_dtype_set
     )
 
     asyncio.run(_init_bucket_syncer(syncer, model))
-    buckets = syncer.divide_into_buckets(model.state_dict(), version=12)
+    buckets = list(syncer.iter_buckets(model.state_dict(), version=12))
     payload = {
         key: value
         for bucket in buckets
@@ -1170,32 +1192,7 @@ def test_bucket_weight_syncer_rejects_metadata_key_collision():
     )
 
     with pytest.raises(ValueError, match="conflicts with metadata key"):
-        syncer.divide_into_buckets(state_dict, version=1)
-
-
-def test_bucket_weight_syncer_sync_streams_without_prebuilding_buckets(monkeypatch):
-    model = _make_bucket_dtype_model()
-    transport = _InMemoryTransport()
-    syncer = BucketWeightSyncer(
-        bucket_size=32,
-        bucket_dtype=None,
-        bucket_device="cpu",
-        load_instant=True,
-    )
-
-    def _raise_if_called(*args, **kwargs):
-        del args, kwargs
-        raise AssertionError("sync should not prebuild all buckets")
-
-    monkeypatch.setattr(syncer, "divide_into_buckets", _raise_if_called)
-
-    async def _run() -> None:
-        await _init_bucket_syncer(syncer, model)
-        await syncer.sync(model.state_dict(), transport.send, version=3)
-
-    asyncio.run(_run())
-
-    assert len(transport._queue) == int(transport._queue[0]["total_buckets"].item())
+        list(syncer.iter_buckets(state_dict, version=1))
 
 
 def test_bucket_weight_syncer_metadata_dtypes_are_nccl_safe():
@@ -1208,11 +1205,11 @@ def test_bucket_weight_syncer_metadata_dtypes_are_nccl_safe():
     )
 
     asyncio.run(_init_bucket_syncer(syncer, model))
-    buckets = syncer.divide_into_buckets(model.state_dict(), version=13)
+    buckets = list(syncer.iter_buckets(model.state_dict(), version=13))
 
     assert buckets
     assert buckets[0]["total_buckets"].dtype == torch.int32
-    assert buckets[0]["syncer_version"].dtype == torch.int64
+    assert buckets[0]["syncer_version"].dtype == torch.int32
 
 
 def test_bucket_weight_syncer_skips_frozen_params_but_syncs_persistent_buffers():


### PR DESCRIPTION

### Description
Channel use specified cuda stream to transfer data tensor, if we use the default cuda stream to copy it asynchronously, pytorch caching allocator may take it to cache pool again and release.  This PR makes tensor record current cuda stream to avoid this.


### How has this been tested?

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.