### PR TITLE
Pin ABot-M0 commit hash in install.sh

### DIFF
--- a/requirements/install.sh
+++ b/requirements/install.sh
@@ -1469,6 +1469,10 @@ install_abot_m0_model() {
     local abot_path
     local vggt_path
     abot_path=$(clone_or_reuse_repo ABOT_PATH "$VENV_DIR/abot" https://github.com/RLinf/ABot-Manipulation.git)
+    if [ -z "${ABOT_PATH:-}" ]; then
+      git -C "$abot_path" fetch --depth 1 origin ee9013cd8341d5424aa722a8cf25e8985a6e673b
+      git -C "$abot_path" checkout --detach ee9013cd8341d5424aa722a8cf25e8985a6e673b
+    fi	
     vggt_path=$(clone_or_reuse_repo VGGT_PATH "$VENV_DIR/vggt" https://github.com/RLinf/vggt.git)
 
     uv pip install -e "$vggt_path"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This PR pins the installer-managed ABot-M0 dependency to commit `ee9013cd8341d5424aa722a8cf25e8985a6e673b` in `requirements/install.sh`.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The upstream ABot repository default branch is moving from ABot-M0 to ABot-M0.5, while RLinf currently integrates and tests against ABot-M0. Without pinning the ABot source version, RLinf CI can pick up incompatible upstream changes from the default branch and fail during ABot-M0 tests.
### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
  - Verified the shell syntax with `bash -n requirements/install.sh`.
  - Verified that the pinned commit exists on the upstream ABot repository and is the current head of the `ABot-M0` branch.
  - Verified that `git fetch --depth 1 origin ee9013cd8341d5424aa722a8cf25e8985a6e673b` succeeds.
### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.