### PR TITLE
fix(docker): add gr00t_n1d7 venv to maniskill_libero image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -214,6 +214,7 @@ RUN bash requirements/install.sh ${INSTALL_MIRROR_OPTION} --platform ${RLINF_PLA
     bash requirements/install.sh ${INSTALL_MIRROR_OPTION} --platform ${RLINF_PLATFORM} embodied --venv openpi --model openpi --env maniskill_libero && \
     bash requirements/install.sh ${INSTALL_MIRROR_OPTION} --platform ${RLINF_PLATFORM} embodied --venv gr00t --model gr00t --env maniskill_libero && \
     bash requirements/install.sh ${INSTALL_MIRROR_OPTION} --platform ${RLINF_PLATFORM} embodied --venv gr00t_n1d6 --model gr00t_n1d6 --env maniskill_libero && \
+    bash requirements/install.sh ${INSTALL_MIRROR_OPTION} --platform ${RLINF_PLATFORM} embodied --venv gr00t_n1d7 --model gr00t_n1d7 --env maniskill_libero && \
     bash requirements/install.sh ${INSTALL_MIRROR_OPTION} --platform ${RLINF_PLATFORM} embodied --venv dexbotic --model dexbotic --env maniskill_libero && \
     bash requirements/install.sh ${INSTALL_MIRROR_OPTION} --platform ${RLINF_PLATFORM} embodied --venv starvla --model starvla --env maniskill_libero && \
     bash requirements/install.sh ${INSTALL_MIRROR_OPTION} --platform ${RLINF_PLATFORM} embodied --venv abot_m0 --model abot_m0 --env maniskill_libero


### PR DESCRIPTION
PR #1241 added GR00T N1.7 support (install.sh model, e2e test, docs) but missed installing the gr00t_n1d7 venv in the
embodied-maniskill_libero Docker stage. As a result, the documented `source switch_env gr00t_n1d7` fails inside the published images with "Environment gr00t_n1d7 does not exist in /opt/venv."

Install the gr00t_n1d7 venv alongside the other GR00T variants so the next image build includes it.

Fixes #1300 