### PR TITLE
Opened by mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ rlinf/envs/maniskill/assets
 PKG-INFO
 *.egg-info/
 .claude/settings.json
+/.sii
+/ocl-data

--- a/docs/source-en/rst_source/examples/embodied/recap.rst
+++ b/docs/source-en/rst_source/examples/embodied/recap.rst
@@ -265,6 +265,7 @@ The configuration file is located at ``examples/offline_rl/config/recap_compute_
 
      gamma: 1.0              # discount factor
      failure_reward: -300.0   # terminal reward for failed trajectories
+     hitl_aware_returns: false  # split successful HITL episodes at first teleop frame
      tag: "fail300"           # output file tag
      num_workers: 128         # parallel processing threads
 
@@ -283,6 +284,9 @@ The configuration file is located at ``examples/offline_rl/config/recap_compute_
    * - ``data.failure_reward``
      - ``-300.0``
      - Penalty for failed trajectory terminal steps. Larger magnitude increases separation between success and failure returns
+   * - ``data.hitl_aware_returns``
+     - ``false``
+     - Enables HITL-aware returns for rollout datasets with ``teleop_mask``. Successful episodes split at the first teleop frame; the autonomous prefix receives failed returns and the intervention suffix receives successful returns. Entries in ``data.train_data_paths`` can override this value.
    * - ``data.tag``
      - ``null``
      - Output file tag, generates ``meta/returns_{tag}.parquet``

--- a/docs/source-en/rst_source/examples/embodied/recap.rst
+++ b/docs/source-en/rst_source/examples/embodied/recap.rst
@@ -245,6 +245,70 @@ RECAP uses **tags** for data passing and version management across steps:
      - Reads ``meta/advantages_{tag}.parquet``
 
 
+ALOHA Sandwich HITL Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RLinf also supports running RECAP on an ALOHA sandwich HITL rollout dataset.
+This path keeps the data as ``robot_type: aloha`` and uses the existing
+``pi05_aloha_robotwin`` OpenPI configuration.
+
+The expected raw data and checkpoint locations are:
+
+.. code:: text
+
+   /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl
+   /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999
+
+Convert the raw HDF5 episodes to LeRobot v2.1:
+
+.. code:: bash
+
+   python examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py \
+      --raw-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl \
+      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21 \
+      --repo-id local/aloha_sandwich \
+      --task "Assemble a sandwich." \
+      --overwrite
+
+The converter writes three ALOHA cameras, 14-D state/action, per-frame
+``is_success``, per-frame ``teleop_mask``, and ``meta/hil_segments.json`` for
+auditability. Use ``type: rollout`` because the dataset contains both successes
+and failures.
+
+Convert the OpenPI JAX checkpoint to the PyTorch checkpoint expected by CFG
+training:
+
+.. code:: bash
+
+   python /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/examples/convert_jax_model_to_pytorch.py \
+      --input-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
+      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+
+Run the four RECAP stages:
+
+.. code:: bash
+
+   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_returns.sh \
+      aloha_sandwich_recap_compute_returns
+
+   bash examples/offline_rl/advantage_labeling/recap/run_value_sft.sh \
+      aloha_sandwich_recap_value_model_sft
+
+   export ALOHA_SANDWICH_VALUE_CHECKPOINT=/absolute/path/to/value/checkpoint
+   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_advantages.sh \
+      aloha_sandwich_recap_compute_advantages --nproc 1
+
+   bash examples/offline_rl/policy_optimization/cfg_rl/run_cfg_rl.sh \
+      aloha_sandwich_cfg_rl_openpi
+
+When ``data.hitl_aware_returns`` is enabled, successful episodes with human
+intervention are split at the first teleop frame: the autonomous prefix receives
+failed returns, and the intervention suffix receives successful returns. During
+advantage labeling, continuous advantages remain value-model based, while
+teleop frames force the boolean ``advantage`` label to positive and record the
+override in ``teleop_positive``.
+
+
 Step 1: Compute Returns
 ---------------------------
 

--- a/docs/source-en/rst_source/examples/embodied/recap.rst
+++ b/docs/source-en/rst_source/examples/embodied/recap.rst
@@ -281,8 +281,9 @@ training:
 .. code:: bash
 
    python /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/examples/convert_jax_model_to_pytorch.py \
-      --input-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
-      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+      --checkpoint-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
+      --config-name pi05_sandwich_new_all \
+      --output-path /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
 
 Run the four RECAP stages:
 

--- a/docs/source-en/rst_source/examples/embodied/recap.rst
+++ b/docs/source-en/rst_source/examples/embodied/recap.rst
@@ -330,7 +330,7 @@ The configuration file is located at ``examples/offline_rl/config/recap_compute_
 
      gamma: 1.0              # discount factor
      failure_reward: -300.0   # terminal reward for failed trajectories
-     hitl_aware_returns: false  # split successful HITL episodes at first teleop frame
+     hitl_aware_returns: false  # set true to split successful HITL episodes at first teleop frame
      tag: "fail300"           # output file tag
      num_workers: 128         # parallel processing threads
 
@@ -367,7 +367,7 @@ The configuration file is located at ``examples/offline_rl/config/recap_compute_
 
 **Output Files**
 
-- ``meta/returns_{tag}.parquet``: Each row contains ``episode_index``, ``frame_index``, ``return``, ``reward``, ``prompt``
+- ``meta/returns_{tag}.parquet``: Each row contains ``episode_index``, ``frame_index``, ``return``, ``reward``, ``done``, ``prompt``
 - ``meta/stats.json``: Updated with return statistics (mean, std, min, max)
 
 **Verification**

--- a/docs/source-zh/rst_source/examples/embodied/recap.rst
+++ b/docs/source-zh/rst_source/examples/embodied/recap.rst
@@ -270,8 +270,9 @@ RLinf 支持在 ALOHA sandwich HITL rollout 数据集上运行 RECAP。该路径
 .. code:: bash
 
    python /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/examples/convert_jax_model_to_pytorch.py \
-      --input-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
-      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+      --checkpoint-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
+      --config-name pi05_sandwich_new_all \
+      --output-path /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
 
 依次运行四个 RECAP 阶段：
 

--- a/docs/source-zh/rst_source/examples/embodied/recap.rst
+++ b/docs/source-zh/rst_source/examples/embodied/recap.rst
@@ -317,7 +317,7 @@ Step 1：计算回报（Compute Returns）
 
      gamma: 1.0              # 折扣因子
      failure_reward: -300.0   # 失败轨迹终止奖励
-     hitl_aware_returns: false  # 在首个 teleop 帧切分成功的 HITL episode
+     hitl_aware_returns: false  # 设为 true 后在首个 teleop 帧切分成功的 HITL episode
      tag: "fail300"           # 输出文件标签
      num_workers: 128         # 并行处理线程数
 
@@ -354,7 +354,7 @@ Step 1：计算回报（Compute Returns）
 
 **输出文件**
 
-- ``meta/returns_{tag}.parquet``：每行包含 ``episode_index``、``frame_index``、``return``、``reward``、``prompt``
+- ``meta/returns_{tag}.parquet``：每行包含 ``episode_index``、``frame_index``、``return``、``reward``、``done``、``prompt``
 - ``meta/stats.json``：更新回报统计信息（均值、标准差、最小值、最大值）
 
 **验证方法**

--- a/docs/source-zh/rst_source/examples/embodied/recap.rst
+++ b/docs/source-zh/rst_source/examples/embodied/recap.rst
@@ -237,6 +237,65 @@ RECAP 通过 **tag** 实现各步骤之间的数据传递和版本管理：
      - 读取 ``meta/advantages_{tag}.parquet``
 
 
+ALOHA Sandwich HITL 示例
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RLinf 支持在 ALOHA sandwich HITL rollout 数据集上运行 RECAP。该路径保持
+``robot_type: aloha``，并复用已有的 ``pi05_aloha_robotwin`` OpenPI 配置。
+
+原始数据和 SFT 检查点位置如下：
+
+.. code:: text
+
+   /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl
+   /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999
+
+先将 HDF5 episode 转换为 LeRobot v2.1：
+
+.. code:: bash
+
+   python examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py \
+      --raw-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl \
+      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21 \
+      --repo-id local/aloha_sandwich \
+      --task "Assemble a sandwich." \
+      --overwrite
+
+转换器会写入三个 ALOHA 相机、14 维 state/action、逐帧 ``is_success``、
+逐帧 ``teleop_mask``，以及用于审计的 ``meta/hil_segments.json``。由于数据
+同时包含成功和失败轨迹，应使用 ``type: rollout``。
+
+再将 OpenPI JAX 检查点转换为 CFG 训练需要的 PyTorch 检查点：
+
+.. code:: bash
+
+   python /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/examples/convert_jax_model_to_pytorch.py \
+      --input-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
+      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+
+依次运行四个 RECAP 阶段：
+
+.. code:: bash
+
+   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_returns.sh \
+      aloha_sandwich_recap_compute_returns
+
+   bash examples/offline_rl/advantage_labeling/recap/run_value_sft.sh \
+      aloha_sandwich_recap_value_model_sft
+
+   export ALOHA_SANDWICH_VALUE_CHECKPOINT=/absolute/path/to/value/checkpoint
+   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_advantages.sh \
+      aloha_sandwich_recap_compute_advantages --nproc 1
+
+   bash examples/offline_rl/policy_optimization/cfg_rl/run_cfg_rl.sh \
+      aloha_sandwich_cfg_rl_openpi
+
+启用 ``data.hitl_aware_returns`` 后，带有人类介入的成功 episode 会在第一个
+teleop 帧切分：自主执行前缀使用失败回报，介入后的后缀使用成功回报。优势
+标注阶段不会修改连续优势值；teleop 帧只会强制布尔 ``advantage`` 标签为正，
+并在 ``teleop_positive`` 中记录该覆盖。
+
+
 Step 1：计算回报（Compute Returns）
 ----------------------------------------
 

--- a/docs/source-zh/rst_source/examples/embodied/recap.rst
+++ b/docs/source-zh/rst_source/examples/embodied/recap.rst
@@ -257,6 +257,7 @@ Step 1：计算回报（Compute Returns）
 
      gamma: 1.0              # 折扣因子
      failure_reward: -300.0   # 失败轨迹终止奖励
+     hitl_aware_returns: false  # 在首个 teleop 帧切分成功的 HITL episode
      tag: "fail300"           # 输出文件标签
      num_workers: 128         # 并行处理线程数
 
@@ -275,6 +276,9 @@ Step 1：计算回报（Compute Returns）
    * - ``data.failure_reward``
      - ``-300.0``
      - 失败轨迹终止步的惩罚值。值越大（绝对值），成功/失败的回报区分度越高
+   * - ``data.hitl_aware_returns``
+     - ``false``
+     - 为带有 ``teleop_mask`` 的 rollout 数据集启用 HITL-aware returns。成功 episode 会在首个 teleop 帧切分；自主执行前缀使用 failed returns，人工介入后缀使用 successful returns。``data.train_data_paths`` 中的每个条目可以覆盖该值。
    * - ``data.tag``
      - ``null``
      - 输出文件标签，生成 ``meta/returns_{tag}.parquet``

--- a/docs/superpowers/plans/2026-07-05-aloha-sandwich-recap.md
+++ b/docs/superpowers/plans/2026-07-05-aloha-sandwich-recap.md
@@ -1,0 +1,2167 @@
+# ALOHA Sandwich RECAP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an RLinf-native RECAP path for ALOHA sandwich off-policy fine-tuning from raw HITL HDF5 data and a converted pi0.5 SFT checkpoint.
+
+**Architecture:** Keep the merged RECAP four-stage pipeline intact and add `aloha` as another robot type at the data conversion, return labeling, value-transform, advantage-inference, and CFG config boundaries. Store RECAP labels as LeRobot sidecars and metadata so the raw dataset semantics remain ALOHA-specific rather than disguised as LIBERO or Franka. Convert the OpenPI JAX checkpoint outside RLinf before CFG training and fail fast when the configured PyTorch checkpoint or HF value backbones are missing.
+
+**Tech Stack:** Python, Hydra/OmegaConf, PyArrow/Parquet, pandas, NumPy, h5py, LeRobot v2.1, OpenPI ALOHA transforms, PyTorch/FSDP, Sphinx RST.
+
+---
+
+## File Map
+
+- Create: `examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py`
+  - CLI and testable helpers to convert raw ALOHA HDF5 episodes into LeRobot v2.1 with `is_success`, `teleop_mask`, optional velocity/effort, and `meta/hil_segments.json`.
+- Create: `tests/unit_tests/test_aloha_recap_converter.py`
+  - Lightweight HDF5 helper tests for reward, teleop mask, episode loading, and audit metadata.
+- Create: `tests/unit_tests/test_aloha_recap_returns.py`
+  - HITL-aware return split tests for successful rescued episodes and failed intervention episodes.
+- Create: `tests/unit_tests/test_aloha_recap_transforms.py`
+  - Unit tests for ALOHA value dataset transforms, checkpoint transforms, `build_obs`, and teleop label override.
+- Modify: `examples/offline_rl/advantage_labeling/recap/process/compute_returns.py`
+  - Add `data.hitl_aware_returns`, optional `teleop_mask` reading, and successful-episode split logic.
+- Modify: `rlinf/data/datasets/recap/value_dataset.py`
+  - Add `_REPACK_KEYS["aloha"]` and `aloha_policy.AlohaInputs` support.
+- Modify: `rlinf/models/embodiment/value_model/recap/checkpoint_utils.py`
+  - Add `env_type == "aloha"` value-checkpoint inference transforms.
+- Modify: `examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py`
+  - Add ALOHA observation construction, carry `teleop_mask`, override only boolean labels, and emit `teleop_positive`.
+- Create: `examples/offline_rl/config/aloha_sandwich_recap_compute_returns.yaml`
+  - Step 1 config for the converted sandwich rollout dataset.
+- Create: `examples/offline_rl/config/aloha_sandwich_recap_value_model_sft.yaml`
+  - Step 2 config for ALOHA value SFT.
+- Create: `examples/offline_rl/config/aloha_sandwich_recap_compute_advantages.yaml`
+  - Step 3 config for ALOHA advantage inference.
+- Create: `examples/offline_rl/config/aloha_sandwich_cfg_rl_openpi.yaml`
+  - Step 4 CFG config using `pi05_aloha_robotwin`.
+- Modify: `docs/source-en/rst_source/examples/embodied/recap.rst`
+  - Add an ALOHA sandwich subsection with conversion, checkpoint conversion, and four-stage commands.
+- Modify: `docs/source-zh/rst_source/examples/embodied/recap.rst`
+  - Add the matching Chinese subsection.
+
+## Task 1: ALOHA Converter Helper Tests
+
+**Files:**
+- Create: `tests/unit_tests/test_aloha_recap_converter.py`
+- Create later in this task: `examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py`
+
+- [ ] **Step 1: Write the failing converter helper tests**
+
+Create `tests/unit_tests/test_aloha_recap_converter.py` with this content:
+
+```python
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from examples.offline_rl.data.convert_aloha_hdf5_to_lerobot_v21 import (
+    _aloha_features,
+    _build_hil_segments_entry,
+    _episode_success_array,
+    _load_episode_payload,
+    _teleop_mask,
+)
+
+
+def _write_episode(path: Path, reward: float = 1.0) -> None:
+    with h5py.File(path, "w") as f:
+        f.create_dataset("action", data=np.arange(56, dtype=np.float32).reshape(4, 14))
+        f.create_dataset("reward", data=np.asarray(reward, dtype=np.float32))
+        f.create_dataset(
+            "teleop_segments",
+            data=np.asarray([[1, 3]], dtype=np.int64),
+        )
+
+        obs = f.create_group("observations")
+        obs.create_dataset("qpos", data=np.ones((4, 14), dtype=np.float32))
+        obs.create_dataset("qvel", data=np.full((4, 14), 2.0, dtype=np.float32))
+        obs.create_dataset("effort", data=np.full((4, 14), 3.0, dtype=np.float32))
+
+        images = obs.create_group("images")
+        for name in ("cam_high", "cam_left_wrist", "cam_right_wrist"):
+            images.create_dataset(
+                name,
+                data=np.zeros((4, 8, 8, 3), dtype=np.uint8),
+            )
+
+
+def test_teleop_mask_maps_half_open_segments() -> None:
+    segments = np.asarray([[1, 3], [4, 5]], dtype=np.int64)
+    mask = _teleop_mask(segments, num_frames=6, episode_name="episode_0.hdf5")
+
+    np.testing.assert_array_equal(mask, np.asarray([0, 1, 1, 0, 1, 0], dtype=np.int64))
+
+
+def test_teleop_mask_rejects_invalid_segment() -> None:
+    with pytest.raises(ValueError, match="invalid teleop segment"):
+        _teleop_mask(
+            np.asarray([[2, 7]], dtype=np.int64),
+            num_frames=6,
+            episode_name="episode_bad.hdf5",
+        )
+
+
+def test_episode_success_array_uses_scalar_reward() -> None:
+    np.testing.assert_array_equal(
+        _episode_success_array(1.0, num_frames=3),
+        np.asarray([True, True, True], dtype=bool),
+    )
+    np.testing.assert_array_equal(
+        _episode_success_array(0.0, num_frames=3),
+        np.asarray([False, False, False], dtype=bool),
+    )
+
+
+def test_aloha_features_include_required_recap_columns() -> None:
+    features = _aloha_features(
+        image_shape=(8, 8, 3),
+        include_velocity=True,
+        include_effort=True,
+    )
+
+    assert features["observation.images.cam_high"]["dtype"] == "image"
+    assert features["observation.images.cam_left_wrist"]["dtype"] == "image"
+    assert features["observation.images.cam_right_wrist"]["dtype"] == "image"
+    assert features["observation.state"]["shape"] == (14,)
+    assert features["observation.velocity"]["shape"] == (14,)
+    assert features["observation.effort"]["shape"] == (14,)
+    assert features["action"]["shape"] == (14,)
+    assert features["is_success"]["dtype"] == "bool"
+    assert features["teleop_mask"]["dtype"] == "int64"
+
+
+def test_load_episode_payload_reads_sandwich_hdf5(tmp_path: Path) -> None:
+    episode_path = tmp_path / "episode_0.hdf5"
+    _write_episode(episode_path, reward=1.0)
+
+    payload = _load_episode_payload(episode_path, task="Assemble a sandwich.")
+
+    assert payload.episode_name == "episode_0.hdf5"
+    assert payload.raw_reward == 1.0
+    assert payload.num_frames == 4
+    assert payload.frames[0]["task"] == "Assemble a sandwich."
+    assert payload.frames[0]["observation.state"].shape == (14,)
+    assert payload.frames[0]["action"].shape == (14,)
+    assert payload.frames[1]["teleop_mask"] == 1
+    assert payload.frames[3]["teleop_mask"] == 0
+    assert payload.frames[0]["is_success"] is True
+
+
+def test_build_hil_segments_entry_is_json_serializable(tmp_path: Path) -> None:
+    episode_path = tmp_path / "episode_0.hdf5"
+    _write_episode(episode_path, reward=0.0)
+
+    payload = _load_episode_payload(episode_path, task="Assemble a sandwich.")
+    entry = _build_hil_segments_entry(payload)
+
+    assert entry == {
+        "episode_index": 0,
+        "episode_name": "episode_0.hdf5",
+        "num_frames": 4,
+        "raw_reward": 0.0,
+        "is_success": False,
+        "teleop_segments": [[1, 3]],
+    }
+    json.dumps(entry)
+```
+
+- [ ] **Step 2: Run the new tests and verify the expected import failure**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_converter.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'examples.offline_rl.data'` or `ImportError` for the new converter functions.
+
+- [ ] **Step 3: Add the converter module package directory**
+
+Run:
+
+```bash
+mkdir -p examples/offline_rl/data
+```
+
+Create `examples/offline_rl/data/__init__.py` with this content:
+
+```python
+"""Offline RL data conversion utilities."""
+```
+
+- [ ] **Step 4: Implement testable converter helpers**
+
+Create `examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py` with this initial content:
+
+```python
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert ALOHA sandwich HITL HDF5 episodes to LeRobot v2.1."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+from tqdm import tqdm
+
+
+ALOHA_CAMERAS = ("cam_high", "cam_left_wrist", "cam_right_wrist")
+DEFAULT_TASK = "Assemble a sandwich."
+
+
+@dataclass(frozen=True)
+class EpisodePayload:
+    """Loaded ALOHA episode ready to write into LeRobot."""
+
+    episode_index: int
+    episode_name: str
+    raw_reward: float
+    teleop_segments: list[list[int]]
+    frames: list[dict[str, Any]]
+
+    @property
+    def num_frames(self) -> int:
+        return len(self.frames)
+
+    @property
+    def is_success(self) -> bool:
+        return self.raw_reward > 0.0
+
+
+def _aloha_features(
+    image_shape: tuple[int, int, int],
+    include_velocity: bool,
+    include_effort: bool,
+) -> dict[str, dict[str, Any]]:
+    features: dict[str, dict[str, Any]] = {
+        "observation.state": {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": ["state"],
+        },
+        "action": {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": ["action"],
+        },
+        "is_success": {
+            "dtype": "bool",
+            "shape": (1,),
+            "names": ["is_success"],
+        },
+        "teleop_mask": {
+            "dtype": "int64",
+            "shape": (1,),
+            "names": ["teleop_mask"],
+        },
+    }
+
+    if include_velocity:
+        features["observation.velocity"] = {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": ["velocity"],
+        }
+    if include_effort:
+        features["observation.effort"] = {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": ["effort"],
+        }
+
+    for camera in ALOHA_CAMERAS:
+        features[f"observation.images.{camera}"] = {
+            "dtype": "image",
+            "shape": image_shape,
+            "names": ["height", "width", "channel"],
+        }
+
+    return features
+
+
+def _episode_success_array(raw_reward: float, num_frames: int) -> np.ndarray:
+    return np.full(num_frames, raw_reward > 0.0, dtype=bool)
+
+
+def _teleop_mask(
+    segments: np.ndarray,
+    num_frames: int,
+    episode_name: str,
+) -> np.ndarray:
+    if segments.size == 0:
+        return np.zeros(num_frames, dtype=np.int64)
+    if segments.ndim != 2 or segments.shape[1] != 2:
+        raise ValueError(
+            f"{episode_name}: teleop_segments must have shape (N, 2), got {segments.shape}"
+        )
+
+    mask = np.zeros(num_frames, dtype=np.int64)
+    for raw_start, raw_end in segments.astype(np.int64):
+        start = int(raw_start)
+        end = int(raw_end)
+        if start < 0 or end < start or end > num_frames:
+            raise ValueError(
+                f"{episode_name}: invalid teleop segment [{start}, {end}) "
+                f"for {num_frames} frames"
+            )
+        mask[start:end] = 1
+    return mask
+
+
+def _read_scalar_reward(ep: h5py.File, episode_name: str) -> float:
+    if "reward" not in ep:
+        raise ValueError(f"{episode_name}: missing scalar reward")
+    reward = np.asarray(ep["reward"][()])
+    if reward.shape not in ((), (1,)):
+        raise ValueError(f"{episode_name}: reward must be scalar or shape (1,), got {reward.shape}")
+    return float(reward.reshape(-1)[0])
+
+
+def _read_teleop_segments(ep: h5py.File) -> np.ndarray:
+    if "teleop_segments" not in ep:
+        return np.zeros((0, 2), dtype=np.int64)
+    return np.asarray(ep["teleop_segments"][:], dtype=np.int64)
+
+
+def _read_images(ep: h5py.File, episode_name: str) -> dict[str, np.ndarray]:
+    images_group = ep.get("observations/images")
+    if not isinstance(images_group, h5py.Group):
+        raise ValueError(f"{episode_name}: missing observations/images group")
+
+    images: dict[str, np.ndarray] = {}
+    for camera in ALOHA_CAMERAS:
+        if camera not in images_group:
+            available = ", ".join(sorted(images_group.keys()))
+            raise ValueError(
+                f"{episode_name}: missing camera {camera}; available cameras: {available}"
+            )
+        camera_data = np.asarray(images_group[camera][:])
+        if camera_data.ndim != 4 or camera_data.shape[-1] != 3:
+            raise ValueError(
+                f"{episode_name}: camera {camera} must have shape (T, H, W, 3), "
+                f"got {camera_data.shape}"
+            )
+        images[camera] = camera_data
+    return images
+
+
+def _load_episode_payload(
+    episode_path: Path,
+    task: str,
+    episode_index: int = 0,
+) -> EpisodePayload:
+    episode_name = episode_path.name
+    with h5py.File(episode_path, "r") as ep:
+        qpos = np.asarray(ep["observations/qpos"][:], dtype=np.float32)
+        action = np.asarray(ep["action"][:], dtype=np.float32)
+        if qpos.ndim != 2 or qpos.shape[1] != 14:
+            raise ValueError(f"{episode_name}: observations/qpos must have shape (T, 14)")
+        if action.shape != qpos.shape:
+            raise ValueError(
+                f"{episode_name}: action shape {action.shape} must match qpos shape {qpos.shape}"
+            )
+
+        qvel = (
+            np.asarray(ep["observations/qvel"][:], dtype=np.float32)
+            if "observations/qvel" in ep
+            else None
+        )
+        effort = (
+            np.asarray(ep["observations/effort"][:], dtype=np.float32)
+            if "observations/effort" in ep
+            else None
+        )
+        raw_reward = _read_scalar_reward(ep, episode_name)
+        segments = _read_teleop_segments(ep)
+        images = _read_images(ep, episode_name)
+
+    num_frames = qpos.shape[0]
+    success = _episode_success_array(raw_reward, num_frames)
+    teleop = _teleop_mask(segments, num_frames, episode_name)
+
+    frames: list[dict[str, Any]] = []
+    for idx in range(num_frames):
+        frame: dict[str, Any] = {
+            "observation.state": qpos[idx],
+            "action": action[idx],
+            "task": task,
+            "is_success": bool(success[idx]),
+            "teleop_mask": int(teleop[idx]),
+        }
+        if qvel is not None:
+            frame["observation.velocity"] = qvel[idx]
+        if effort is not None:
+            frame["observation.effort"] = effort[idx]
+        for camera, camera_frames in images.items():
+            frame[f"observation.images.{camera}"] = camera_frames[idx]
+        frames.append(frame)
+
+    return EpisodePayload(
+        episode_index=episode_index,
+        episode_name=episode_name,
+        raw_reward=raw_reward,
+        teleop_segments=segments.astype(int).tolist(),
+        frames=frames,
+    )
+
+
+def _build_hil_segments_entry(payload: EpisodePayload) -> dict[str, Any]:
+    return {
+        "episode_index": payload.episode_index,
+        "episode_name": payload.episode_name,
+        "num_frames": payload.num_frames,
+        "raw_reward": payload.raw_reward,
+        "is_success": payload.is_success,
+        "teleop_segments": payload.teleop_segments,
+    }
+```
+
+- [ ] **Step 5: Run converter helper tests**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_converter.py -q
+```
+
+Expected: PASS for all tests in `test_aloha_recap_converter.py`.
+
+- [ ] **Step 6: Commit helper coverage and module skeleton**
+
+Run:
+
+```bash
+git add examples/offline_rl/data/__init__.py examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py tests/unit_tests/test_aloha_recap_converter.py
+git commit -s -m "test: cover aloha recap converter helpers"
+```
+
+## Task 2: ALOHA Converter CLI and Dataset Writing
+
+**Files:**
+- Modify: `examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py`
+- Modify: `tests/unit_tests/test_aloha_recap_converter.py`
+
+- [ ] **Step 1: Add a fake LeRobot writer test for converter output**
+
+Append this test code to `tests/unit_tests/test_aloha_recap_converter.py`:
+
+```python
+class _FakeLeRobotDataset:
+    created_kwargs: dict | None = None
+
+    def __init__(self) -> None:
+        self.frames: list[dict] = []
+        self.episode_lengths: list[int] = []
+
+    @classmethod
+    def create(cls, **kwargs):
+        cls.created_kwargs = kwargs
+        return cls()
+
+    def add_frame(self, frame: dict) -> None:
+        self.frames.append(frame)
+
+    def save_episode(self) -> None:
+        self.episode_lengths.append(len(self.frames) - sum(self.episode_lengths))
+
+
+def test_convert_dataset_writes_frames_and_hil_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from examples.offline_rl.data import convert_aloha_hdf5_to_lerobot_v21 as converter
+
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_episode(raw_dir / "episode_0.hdf5", reward=1.0)
+    _write_episode(raw_dir / "episode_1.hdf5", reward=0.0)
+    output_dir = tmp_path / "lerobot"
+
+    monkeypatch.setattr(converter, "LeRobotDataset", _FakeLeRobotDataset)
+
+    dataset = converter.convert_dataset(
+        raw_dir=raw_dir,
+        output_dir=output_dir,
+        repo_id="local/aloha_sandwich",
+        task="Assemble a sandwich.",
+        fps=25,
+        overwrite=True,
+        image_writer_threads=1,
+        image_writer_processes=1,
+    )
+
+    assert dataset.episode_lengths == [4, 4]
+    assert _FakeLeRobotDataset.created_kwargs["repo_id"] == "local/aloha_sandwich"
+    assert _FakeLeRobotDataset.created_kwargs["root"] == output_dir
+    assert _FakeLeRobotDataset.created_kwargs["robot_type"] == "aloha"
+
+    metadata_path = output_dir / "meta" / "hil_segments.json"
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["total_episodes"] == 2
+    assert metadata["total_frames"] == 8
+    assert metadata["successful_episodes"] == 1
+    assert metadata["failed_episodes"] == 1
+    assert metadata["episodes"][0]["teleop_segments"] == [[1, 3]]
+```
+
+- [ ] **Step 2: Run the converter tests and verify the expected missing CLI failure**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_converter.py -q
+```
+
+Expected: FAIL with `AttributeError: module ... has no attribute 'convert_dataset'`.
+
+- [ ] **Step 3: Add LeRobot imports, dataset writing, audit metadata, and CLI**
+
+Modify `examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py` by adding the LeRobot import after the existing imports:
+
+```python
+try:
+    from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+except ImportError:  # pragma: no cover - exercised only when converter deps are absent
+    LeRobotDataset = None
+```
+
+Append this code to the end of the file:
+
+```python
+def _discover_hdf5_files(raw_dir: Path) -> list[Path]:
+    files = sorted(raw_dir.glob("*.hdf5"))
+    if not files:
+        files = sorted(raw_dir.glob("*.h5"))
+    if not files:
+        raise FileNotFoundError(f"No .hdf5 or .h5 episodes found under {raw_dir}")
+    return files
+
+
+def _first_image_shape(first_episode: Path) -> tuple[int, int, int]:
+    with h5py.File(first_episode, "r") as ep:
+        images = _read_images(ep, first_episode.name)
+    first = images[ALOHA_CAMERAS[0]]
+    return tuple(int(v) for v in first.shape[1:])
+
+
+def _has_dataset(first_episode: Path, key: str) -> bool:
+    with h5py.File(first_episode, "r") as ep:
+        return key in ep
+
+
+def _write_hil_segments(output_dir: Path, entries: list[dict[str, Any]]) -> None:
+    total_frames = sum(int(entry["num_frames"]) for entry in entries)
+    successful = sum(1 for entry in entries if bool(entry["is_success"]))
+    data = {
+        "total_episodes": len(entries),
+        "total_frames": total_frames,
+        "successful_episodes": successful,
+        "failed_episodes": len(entries) - successful,
+        "episodes": entries,
+    }
+    meta_dir = output_dir / "meta"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    with open(meta_dir / "hil_segments.json", "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def convert_dataset(
+    raw_dir: Path,
+    output_dir: Path,
+    repo_id: str,
+    task: str = DEFAULT_TASK,
+    fps: int = 25,
+    overwrite: bool = False,
+    image_writer_threads: int = 5,
+    image_writer_processes: int = 10,
+):
+    if LeRobotDataset is None:
+        raise ImportError("lerobot is required to run ALOHA HDF5 conversion")
+
+    raw_dir = raw_dir.resolve()
+    output_dir = output_dir.resolve()
+    hdf5_files = _discover_hdf5_files(raw_dir)
+
+    if output_dir.exists():
+        if not overwrite:
+            raise FileExistsError(
+                f"Output directory exists: {output_dir}. Pass --overwrite to replace it."
+            )
+        shutil.rmtree(output_dir)
+
+    features = _aloha_features(
+        image_shape=_first_image_shape(hdf5_files[0]),
+        include_velocity=_has_dataset(hdf5_files[0], "observations/qvel"),
+        include_effort=_has_dataset(hdf5_files[0], "observations/effort"),
+    )
+    dataset = LeRobotDataset.create(
+        repo_id=repo_id,
+        root=output_dir,
+        robot_type="aloha",
+        fps=fps,
+        features=features,
+        image_writer_threads=image_writer_threads,
+        image_writer_processes=image_writer_processes,
+    )
+
+    metadata_entries: list[dict[str, Any]] = []
+    for episode_index, episode_path in enumerate(tqdm(hdf5_files, desc="Converting ALOHA episodes")):
+        payload = _load_episode_payload(
+            episode_path,
+            task=task,
+            episode_index=episode_index,
+        )
+        for frame in payload.frames:
+            dataset.add_frame(frame)
+        dataset.save_episode()
+        metadata_entries.append(_build_hil_segments_entry(payload))
+
+    _write_hil_segments(output_dir, metadata_entries)
+    return dataset
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--repo-id", type=str, default="local/aloha_sandwich")
+    parser.add_argument("--task", type=str, default=DEFAULT_TASK)
+    parser.add_argument("--fps", type=int, default=25)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--image-writer-threads", type=int, default=5)
+    parser.add_argument("--image-writer-processes", type=int, default=10)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    convert_dataset(
+        raw_dir=args.raw_dir,
+        output_dir=args.output_dir,
+        repo_id=args.repo_id,
+        task=args.task,
+        fps=args.fps,
+        overwrite=args.overwrite,
+        image_writer_threads=args.image_writer_threads,
+        image_writer_processes=args.image_writer_processes,
+    )
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run converter tests**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_converter.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run converter help**
+
+Run:
+
+```bash
+python examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py --help
+```
+
+Expected: command exits 0 and prints arguments including `--raw-dir`, `--output-dir`, `--repo-id`, and `--overwrite`.
+
+- [ ] **Step 6: Commit converter CLI**
+
+Run:
+
+```bash
+git add examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py tests/unit_tests/test_aloha_recap_converter.py
+git commit -s -m "feat: add aloha sandwich lerobot converter"
+```
+
+## Task 3: HITL-Aware Return Computation
+
+**Files:**
+- Create: `tests/unit_tests/test_aloha_recap_returns.py`
+- Modify: `examples/offline_rl/advantage_labeling/recap/process/compute_returns.py`
+
+- [ ] **Step 1: Write failing return split tests**
+
+Create `tests/unit_tests/test_aloha_recap_returns.py` with this content:
+
+```python
+import numpy as np
+
+from examples.offline_rl.advantage_labeling.recap.process.compute_returns import (
+    compute_hitl_aware_returns_for_episode,
+    compute_returns_for_episode,
+)
+
+
+def test_successful_episode_split_at_first_teleop_frame() -> None:
+    returns, rewards = compute_hitl_aware_returns_for_episode(
+        episode_length=6,
+        is_success=True,
+        teleop_mask=np.asarray([0, 0, 0, 1, 1, 0], dtype=np.int64),
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+
+    np.testing.assert_array_equal(
+        rewards,
+        np.asarray([-1.0, -1.0, -300.0, -1.0, -1.0, 0.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        returns,
+        np.asarray([-302.0, -301.0, -300.0, -2.0, -1.0, 0.0], dtype=np.float32),
+    )
+
+
+def test_successful_episode_without_teleop_uses_standard_returns() -> None:
+    hitl_returns, hitl_rewards = compute_hitl_aware_returns_for_episode(
+        episode_length=4,
+        is_success=True,
+        teleop_mask=np.zeros(4, dtype=np.int64),
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+    normal_returns, normal_rewards = compute_returns_for_episode(
+        episode_length=4,
+        is_success=True,
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+
+    np.testing.assert_array_equal(hitl_returns, normal_returns)
+    np.testing.assert_array_equal(hitl_rewards, normal_rewards)
+
+
+def test_failed_episode_with_teleop_remains_failed() -> None:
+    hitl_returns, hitl_rewards = compute_hitl_aware_returns_for_episode(
+        episode_length=4,
+        is_success=False,
+        teleop_mask=np.asarray([0, 1, 1, 0], dtype=np.int64),
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+    normal_returns, normal_rewards = compute_returns_for_episode(
+        episode_length=4,
+        is_success=False,
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+
+    np.testing.assert_array_equal(hitl_returns, normal_returns)
+    np.testing.assert_array_equal(hitl_rewards, normal_rewards)
+```
+
+- [ ] **Step 2: Run the tests and verify the expected missing function failure**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_returns.py -q
+```
+
+Expected: FAIL with `ImportError` for `compute_hitl_aware_returns_for_episode`.
+
+- [ ] **Step 3: Add HITL-aware helper and optional column reading**
+
+In `examples/offline_rl/advantage_labeling/recap/process/compute_returns.py`, replace:
+
+```python
+_READ_COLUMNS = ["episode_index", "frame_index", "is_success", "task_index", "task"]
+```
+
+with:
+
+```python
+_READ_COLUMNS = [
+    "episode_index",
+    "frame_index",
+    "is_success",
+    "teleop_mask",
+    "task_index",
+    "task",
+]
+```
+
+Add this function immediately after `compute_returns_for_episode`:
+
+```python
+def compute_hitl_aware_returns_for_episode(
+    episode_length: int,
+    is_success: bool,
+    teleop_mask: np.ndarray,
+    gamma: float,
+    failure_reward: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute returns that mark pre-intervention prefixes as failed.
+
+    Successful HITL episodes are split at the first teleop frame. The
+    autonomous prefix receives failed-episode returns and the suffix receives
+    successful returns. Failed episodes remain failed even when they contain
+    teleop frames.
+    """
+    if not is_success:
+        return compute_returns_for_episode(
+            episode_length=episode_length,
+            is_success=False,
+            gamma=gamma,
+            failure_reward=failure_reward,
+        )
+
+    mask = np.asarray(teleop_mask).astype(bool)
+    if mask.shape[0] != episode_length:
+        raise ValueError(
+            f"teleop_mask length {mask.shape[0]} does not match episode length {episode_length}"
+        )
+    teleop_indices = np.flatnonzero(mask)
+    if len(teleop_indices) == 0:
+        return compute_returns_for_episode(
+            episode_length=episode_length,
+            is_success=True,
+            gamma=gamma,
+            failure_reward=failure_reward,
+        )
+
+    split = int(teleop_indices[0])
+    if split == 0:
+        return compute_returns_for_episode(
+            episode_length=episode_length,
+            is_success=True,
+            gamma=gamma,
+            failure_reward=failure_reward,
+        )
+
+    prefix_returns, prefix_rewards = compute_returns_for_episode(
+        episode_length=split,
+        is_success=False,
+        gamma=gamma,
+        failure_reward=failure_reward,
+    )
+    suffix_returns, suffix_rewards = compute_returns_for_episode(
+        episode_length=episode_length - split,
+        is_success=True,
+        gamma=gamma,
+        failure_reward=failure_reward,
+    )
+    return (
+        np.concatenate([prefix_returns, suffix_returns]).astype(np.float32),
+        np.concatenate([prefix_rewards, suffix_rewards]).astype(np.float32),
+    )
+```
+
+- [ ] **Step 4: Thread `hitl_aware_returns` through parquet processing**
+
+Change `_process_single_parquet` signature to:
+
+```python
+def _process_single_parquet(
+    pq_file: str,
+    dataset_type: str,
+    gamma: float,
+    failure_reward: float,
+    tasks: dict[int, str],
+    hitl_aware_returns: bool = False,
+) -> pa.Table | None:
+```
+
+After `is_success_col` is resolved, add:
+
+```python
+    teleop_col = None
+    if hitl_aware_returns and "teleop_mask" in col_names:
+        teleop_col = np.asarray(table.column("teleop_mask").to_pylist(), dtype=np.int64)
+    elif hitl_aware_returns:
+        logger.warning(
+            "data.hitl_aware_returns is enabled but teleop_mask is missing in %s; "
+            "falling back to standard returns for this file.",
+            pq_file,
+        )
+```
+
+Replace the `ep_returns, ep_rewards = compute_returns_for_episode(...)` block inside the episode loop with:
+
+```python
+        if hitl_aware_returns and teleop_col is not None:
+            ep_returns, ep_rewards = compute_hitl_aware_returns_for_episode(
+                episode_length=ep_length,
+                is_success=is_success,
+                teleop_mask=teleop_col[ep_start:ep_end],
+                gamma=gamma,
+                failure_reward=failure_reward,
+            )
+        else:
+            ep_returns, ep_rewards = compute_returns_for_episode(
+                episode_length=ep_length,
+                is_success=is_success,
+                gamma=gamma,
+                failure_reward=failure_reward,
+            )
+```
+
+- [ ] **Step 5: Thread the Hydra config option through `process_dataset` and callers**
+
+Add `hitl_aware_returns: bool = False` to `process_dataset(...)`.
+
+In the serial call to `_process_single_parquet`, pass:
+
+```python
+                hitl_aware_returns,
+```
+
+In the `pool.submit(...)` call, pass:
+
+```python
+                    hitl_aware_returns,
+```
+
+In `compute_returns`, read:
+
+```python
+    hitl_aware_returns = cfg.data.get("hitl_aware_returns", False)
+```
+
+Add `"hitl_aware_returns": entry.get("hitl_aware_returns", hitl_aware_returns),` to each dataset config dictionary. Add `"hitl_aware_returns": hitl_aware_returns,` to the single-dataset config dictionary. Pass `hitl_aware_returns=ds_config["hitl_aware_returns"]` into `process_dataset(...)`.
+
+- [ ] **Step 6: Add config default**
+
+In `examples/offline_rl/config/recap_compute_returns.yaml`, add this under `data:`:
+
+```yaml
+  hitl_aware_returns: false
+```
+
+- [ ] **Step 7: Run return tests**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_returns.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run import smoke test for compute_returns**
+
+Run:
+
+```bash
+python - <<'PY'
+from examples.offline_rl.advantage_labeling.recap.process.compute_returns import compute_hitl_aware_returns_for_episode
+print(compute_hitl_aware_returns_for_episode.__name__)
+PY
+```
+
+Expected output:
+
+```text
+compute_hitl_aware_returns_for_episode
+```
+
+- [ ] **Step 9: Commit HITL-aware returns**
+
+Run:
+
+```bash
+git add examples/offline_rl/advantage_labeling/recap/process/compute_returns.py examples/offline_rl/config/recap_compute_returns.yaml tests/unit_tests/test_aloha_recap_returns.py
+git commit -s -m "feat: add hitl-aware recap returns"
+```
+
+## Task 4: ALOHA Value Dataset and Checkpoint Transforms
+
+**Files:**
+- Create: `tests/unit_tests/test_aloha_recap_transforms.py`
+- Modify: `rlinf/data/datasets/recap/value_dataset.py`
+- Modify: `rlinf/models/embodiment/value_model/recap/checkpoint_utils.py`
+
+- [ ] **Step 1: Write failing transform tests**
+
+Create `tests/unit_tests/test_aloha_recap_transforms.py` with this content:
+
+```python
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def test_value_dataset_builds_aloha_transform() -> None:
+    pytest.importorskip("openpi")
+
+    from rlinf.data.datasets.recap.value_dataset import ValueDataset
+
+    transform = ValueDataset._build_transform(
+        robot_type="aloha",
+        model_type="pi05",
+        action_dim=14,
+        default_prompt="Assemble a sandwich.",
+    )
+    sample = {
+        "observation.images.cam_high": np.zeros((3, 8, 8), dtype=np.uint8),
+        "observation.images.cam_left_wrist": np.ones((3, 8, 8), dtype=np.uint8),
+        "observation.images.cam_right_wrist": np.full((3, 8, 8), 2, dtype=np.uint8),
+        "observation.state": np.zeros((14,), dtype=np.float32),
+        "action": np.zeros((10, 14), dtype=np.float32),
+        "prompt": "Assemble a sandwich.",
+    }
+
+    transformed = transform(sample)
+
+    assert set(transformed["image"]) == {
+        "base_0_rgb",
+        "left_wrist_0_rgb",
+        "right_wrist_0_rgb",
+    }
+    assert transformed["state"].shape == (14,)
+    assert transformed["actions"].shape[-1] == 14
+    assert transformed["prompt"] == "Assemble a sandwich."
+
+
+def test_checkpoint_utils_builds_aloha_input_transforms() -> None:
+    pytest.importorskip("openpi")
+
+    from rlinf.models.embodiment.value_model.recap.checkpoint_utils import (
+        build_input_transforms,
+    )
+
+    transforms = build_input_transforms(
+        env_type="aloha",
+        model_type="pi05",
+        action_dim=14,
+        default_prompt="Assemble a sandwich.",
+        norm_stats=None,
+        use_quantile_norm=True,
+    )
+
+    names = [type(transform).__name__ for transform in transforms]
+    assert names == ["InjectDefaultPrompt", "AlohaInputs", "PadStatesAndActions"]
+```
+
+- [ ] **Step 2: Run transform tests and verify the expected unsupported robot failures**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_transforms.py::test_value_dataset_builds_aloha_transform tests/unit_tests/test_aloha_recap_transforms.py::test_checkpoint_utils_builds_aloha_input_transforms -q
+```
+
+Expected: FAIL with `Unknown robot type: aloha` or `Unknown environment type: aloha`.
+
+- [ ] **Step 3: Add ALOHA to value dataset transforms**
+
+In `rlinf/data/datasets/recap/value_dataset.py`, replace:
+
+```python
+from rlinf.models.embodiment.openpi.policies import franka_policy, libero_policy
+```
+
+with:
+
+```python
+from rlinf.models.embodiment.openpi.policies import (
+    aloha_policy,
+    franka_policy,
+    libero_policy,
+)
+```
+
+Add this entry to `_REPACK_KEYS`:
+
+```python
+    "aloha": {
+        "images": {
+            "cam_high": "observation.images.cam_high",
+            "cam_left_wrist": "observation.images.cam_left_wrist",
+            "cam_right_wrist": "observation.images.cam_right_wrist",
+        },
+        "state": "observation.state",
+        "actions": "action",
+        "prompt": "prompt",
+    },
+```
+
+In `_build_transform`, after the `libero` branch and before the `franka` branch, add:
+
+```python
+        elif robot == "aloha":
+            transforms_list.append(
+                aloha_policy.AlohaInputs(adapt_to_pi=True)
+            )
+```
+
+- [ ] **Step 4: Add ALOHA to value checkpoint inference transforms**
+
+In `rlinf/models/embodiment/value_model/recap/checkpoint_utils.py`, replace:
+
+```python
+    from rlinf.models.embodiment.openpi.policies import franka_policy, libero_policy
+```
+
+with:
+
+```python
+    from rlinf.models.embodiment.openpi.policies import (
+        aloha_policy,
+        franka_policy,
+        libero_policy,
+    )
+```
+
+In `build_input_transforms`, add this branch after the LIBERO branch:
+
+```python
+    elif env_type == "aloha":
+        input_transforms.append(_openpi_transforms.InjectDefaultPrompt(default_prompt))
+        input_transforms.append(aloha_policy.AlohaInputs(adapt_to_pi=True))
+```
+
+- [ ] **Step 5: Run transform tests**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_transforms.py::test_value_dataset_builds_aloha_transform tests/unit_tests/test_aloha_recap_transforms.py::test_checkpoint_utils_builds_aloha_input_transforms -q
+```
+
+Expected: PASS or SKIP only when `openpi` is unavailable in the active environment.
+
+- [ ] **Step 6: Commit ALOHA transform support**
+
+Run:
+
+```bash
+git add rlinf/data/datasets/recap/value_dataset.py rlinf/models/embodiment/value_model/recap/checkpoint_utils.py tests/unit_tests/test_aloha_recap_transforms.py
+git commit -s -m "feat: support aloha recap value transforms"
+```
+
+## Task 5: ALOHA Advantage Observations and Teleop Label Override
+
+**Files:**
+- Modify: `tests/unit_tests/test_aloha_recap_transforms.py`
+- Modify: `examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py`
+
+- [ ] **Step 1: Add failing tests for ALOHA `build_obs` and teleop override**
+
+Append this code to `tests/unit_tests/test_aloha_recap_transforms.py`:
+
+```python
+def test_compute_advantages_build_obs_supports_aloha() -> None:
+    from examples.offline_rl.advantage_labeling.recap.process.compute_advantages import (
+        build_obs,
+    )
+
+    sample = {
+        "observation.images.cam_high": np.zeros((3, 8, 8), dtype=np.uint8),
+        "observation.images.cam_left_wrist": np.ones((3, 8, 8), dtype=np.uint8),
+        "observation.images.cam_right_wrist": np.full((3, 8, 8), 2, dtype=np.uint8),
+        "observation.state": np.arange(14, dtype=np.float32),
+        "task_index": np.asarray(0),
+    }
+
+    obs = build_obs(sample, robot_type="aloha", tasks={0: "Assemble a sandwich."})
+
+    assert set(obs["images"]) == {"cam_high", "cam_left_wrist", "cam_right_wrist"}
+    assert obs["images"]["cam_high"].shape == (3, 8, 8)
+    np.testing.assert_array_equal(obs["state"], np.arange(14, dtype=np.float32))
+    assert obs["prompt"] == "Assemble a sandwich."
+
+
+def test_save_advantages_teleop_override_preserves_continuous_values(tmp_path) -> None:
+    from examples.offline_rl.advantage_labeling.recap.process.compute_advantages import (
+        save_advantages_to_dataset,
+    )
+
+    dataset_path = tmp_path / "dataset"
+    (dataset_path / "meta").mkdir(parents=True)
+    df = pd.DataFrame(
+        {
+            "episode_index": [0, 0, 0],
+            "frame_index": [0, 1, 2],
+            "advantage": [-0.5, 0.2, -0.4],
+            "teleop_mask": [0, 1, 1],
+        }
+    )
+
+    save_advantages_to_dataset(
+        dataset_path=dataset_path,
+        advantages_df=df,
+        threshold=0.0,
+        dataset_type="rollout",
+        tag="teleop",
+    )
+
+    saved = pd.read_parquet(dataset_path / "meta" / "advantages_teleop.parquet")
+    assert saved["advantage_continuous"].tolist() == [-0.5, 0.2, -0.4]
+    assert saved["advantage"].tolist() == [False, True, True]
+    assert saved["teleop_positive"].tolist() == [False, False, True]
+```
+
+- [ ] **Step 2: Run the new tests and verify expected failures**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_transforms.py::test_compute_advantages_build_obs_supports_aloha tests/unit_tests/test_aloha_recap_transforms.py::test_save_advantages_teleop_override_preserves_continuous_values -q
+```
+
+Expected: FAIL with `Unknown robot_type 'aloha'` and missing `teleop_positive`.
+
+- [ ] **Step 3: Add prompt resolution and ALOHA observation construction**
+
+In `examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py`, add this helper immediately before `build_obs`:
+
+```python
+def _resolve_prompt(sample: dict, tasks: dict) -> str:
+    if "prompt" in sample:
+        return str(to_scalar(sample["prompt"]))
+    if "task" in sample:
+        return str(to_scalar(sample["task"]))
+    if "task_index" in sample and tasks:
+        task_idx = int(to_scalar(sample["task_index"]))
+        if task_idx not in tasks:
+            raise ValueError(
+                f"task_index {task_idx} not found in tasks dict. "
+                f"Available task indices: {list(tasks.keys())}."
+            )
+        return tasks[task_idx]
+    raise ValueError(
+        "Sample has no prompt, task, or task_index field. "
+        "Cannot determine task prompt for value model inference."
+    )
+```
+
+At the start of `build_obs`, before `if robot_type not in KEY_MAPPINGS`, add:
+
+```python
+    if robot_type == "aloha":
+        required = (
+            "observation.images.cam_high",
+            "observation.images.cam_left_wrist",
+            "observation.images.cam_right_wrist",
+            "observation.state",
+        )
+        missing = [key for key in required if key not in sample]
+        if missing:
+            raise KeyError(f"ALOHA sample missing required keys: {missing}")
+        return {
+            "images": {
+                "cam_high": to_numpy(sample["observation.images.cam_high"]),
+                "cam_left_wrist": to_numpy(sample["observation.images.cam_left_wrist"]),
+                "cam_right_wrist": to_numpy(sample["observation.images.cam_right_wrist"]),
+            },
+            "state": to_numpy(sample["observation.state"]),
+            "prompt": _resolve_prompt(sample, tasks),
+        }
+```
+
+In the generic `task` branch inside `build_obs`, replace the current prompt resolution block with:
+
+```python
+            obs[dst_key] = _resolve_prompt(sample, tasks)
+```
+
+- [ ] **Step 4: Carry `teleop_mask` through advantage inference metadata**
+
+In `ValueInferenceDataset.__getitem__`, after reward is resolved, add:
+
+```python
+        teleop_mask = 0
+        if "teleop_mask" in sample:
+            teleop_mask = int(to_scalar(sample["teleop_mask"]))
+```
+
+Add `"teleop_mask": teleop_mask,` to the returned dictionary.
+
+In `advantage_collate_fn`, add this field to each metadata dictionary:
+
+```python
+            "teleop_mask": item.get("teleop_mask", 0),
+```
+
+In `compute_advantages_for_dataset`, add this key to `results`:
+
+```python
+        "teleop_mask": [],
+```
+
+Add a `meta_teleop_mask` array next to `meta_reward`:
+
+```python
+    meta_teleop_mask = np.zeros(extended_size, dtype=np.int64)
+```
+
+Inside `process_value_batch`, set:
+
+```python
+            meta_teleop_mask[local_idx] = int(meta_info.get("teleop_mask", 0))
+```
+
+Inside the Phase 2 loop, append:
+
+```python
+        results["teleop_mask"].append(int(meta_teleop_mask[i]))
+```
+
+- [ ] **Step 5: Override only boolean labels in `save_advantages_to_dataset`**
+
+In `save_advantages_to_dataset`, replace the non-SFT boolean label block with:
+
+```python
+        if (dataset_type or "").lower() == "sft":
+            save_df["advantage"] = True
+            save_df["teleop_positive"] = False
+        else:
+            value_positive = apply_boolean_label(
+                save_df["advantage_continuous"], threshold, inclusive=True
+            )
+            teleop_mask = (
+                save_df["teleop_mask"].astype(bool)
+                if "teleop_mask" in save_df.columns
+                else pd.Series(False, index=save_df.index)
+            )
+            save_df["teleop_positive"] = teleop_mask & ~value_positive
+            save_df["advantage"] = value_positive | teleop_mask
+            if teleop_mask.any():
+                overridden = int(save_df["teleop_positive"].sum())
+                teleop_total = int(teleop_mask.sum())
+                logger.info(
+                    "  Teleop positive override: %d/%d teleop frames forced positive (%.2f%% of dataset)",
+                    overridden,
+                    teleop_total,
+                    100.0 * overridden / max(len(save_df), 1),
+                )
+```
+
+- [ ] **Step 6: Run ALOHA advantage tests**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_transforms.py::test_compute_advantages_build_obs_supports_aloha tests/unit_tests/test_aloha_recap_transforms.py::test_save_advantages_teleop_override_preserves_continuous_values -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run all ALOHA RECAP unit tests**
+
+Run:
+
+```bash
+python -m pytest tests/unit_tests/test_aloha_recap_converter.py tests/unit_tests/test_aloha_recap_returns.py tests/unit_tests/test_aloha_recap_transforms.py -q
+```
+
+Expected: PASS, with OpenPI transform tests skipped only if `openpi` is unavailable.
+
+- [ ] **Step 8: Commit ALOHA advantage support**
+
+Run:
+
+```bash
+git add examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py tests/unit_tests/test_aloha_recap_transforms.py
+git commit -s -m "feat: add aloha recap advantage labeling"
+```
+
+## Task 6: Sandwich RECAP Configs
+
+**Files:**
+- Create: `examples/offline_rl/config/aloha_sandwich_recap_compute_returns.yaml`
+- Create: `examples/offline_rl/config/aloha_sandwich_recap_value_model_sft.yaml`
+- Create: `examples/offline_rl/config/aloha_sandwich_recap_compute_advantages.yaml`
+- Create: `examples/offline_rl/config/aloha_sandwich_cfg_rl_openpi.yaml`
+
+- [ ] **Step 1: Add Step 1 returns config**
+
+Create `examples/offline_rl/config/aloha_sandwich_recap_compute_returns.yaml`:
+
+```yaml
+# Usage:
+#   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_returns.sh aloha_sandwich_recap_compute_returns
+
+data:
+  data_root: null
+  train_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      type: rollout
+
+  dataset_type: rollout
+  gamma: 1.0
+  failure_reward: -300.0
+  hitl_aware_returns: true
+  tag: sandwich_fail300
+  num_workers: 128
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  job:
+    chdir: false
+```
+
+- [ ] **Step 2: Add Step 2 value SFT config**
+
+Create `examples/offline_rl/config/aloha_sandwich_recap_value_model_sft.yaml`:
+
+```yaml
+# Usage:
+#   bash examples/offline_rl/advantage_labeling/recap/run_value_sft.sh aloha_sandwich_recap_value_model_sft
+
+defaults:
+  - model/recap_value_model@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - _self_
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/offline_rl/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: all
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "../results/aloha_sandwich_value"
+    project_name: rlinf
+    experiment_name: "aloha_sandwich_value"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 30000
+  max_steps: -1
+  val_check_interval: 500
+  save_interval: 3000
+
+data:
+  tag: sandwich_fail300
+
+  train_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      type: rollout
+      weight: 1.0
+      robot_type: aloha
+      model_type: pi05
+
+  eval_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      max_samples: 4096
+      robot_type: aloha
+      model_type: pi05
+
+  train_num_workers: 8
+  eval_num_workers: 4
+  prefetch_factor: 4
+  persistent_workers: false
+  pin_memory: false
+  include_state: true
+  gamma: 1.0
+  action_horizon: 10
+  normalize_to_minus_one_zero: true
+  include_next_obs: false
+  action_dim: 14
+  robot_type: aloha
+  model_type: pi05
+  balance_weights: true
+  seed: 42
+
+algorithm:
+  adv_type: gae
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 32
+  global_batch_size: 256
+  seed: 0
+
+  model:
+    precision: bf16
+    siglip_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/siglip2-so400m-patch14-224
+    gemma3_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m
+    tokenizer_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m
+    freeze_vlm: false
+    action_dim: 14
+    action_horizon: 10
+
+  optim:
+    lr: 5.0e-5
+    value_lr: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 1e-10
+    clip_grad: 1.0
+    lr_scheduler: "constant"
+    lr_warmup_steps: 500
+    total_training_steps: 8000
+
+  fsdp_config:
+    strategy: "fsdp"
+    sharding_strategy: "no_shard"
+    use_orig_params: false
+    gradient_checkpointing: false
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+
+reward:
+  use_reward_model: false
+
+critic:
+  use_critic_model: false
+```
+
+- [ ] **Step 3: Add Step 3 advantage config**
+
+Create `examples/offline_rl/config/aloha_sandwich_recap_compute_advantages.yaml`:
+
+```yaml
+# Usage:
+#   ALOHA_SANDWICH_VALUE_CHECKPOINT=/abs/path/to/value/checkpoint \
+#   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_advantages.sh aloha_sandwich_recap_compute_advantages --nproc 1
+
+defaults:
+  - model/recap_value_model@advantage.model
+
+advantage:
+  value_checkpoint: ${oc.env:ALOHA_SANDWICH_VALUE_CHECKPOINT}
+  batch_size: 1024
+  flush_interval: 256
+  num_dataloader_workers_per_gpu: 12
+  prefetch_factor: 2
+  discount_next_value: true
+  positive_quantile: 0.3
+  tag: sandwich_fail300_N10_q30_teleop
+  returns_tag: sandwich_fail300
+
+  model:
+    critic_expert_variant: "gemma_1m"
+    tokenizer_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m
+    siglip_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/siglip2-so400m-patch14-224
+    gemma3_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m
+
+data:
+  model_type: pi05
+
+  train_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      robot_type: aloha
+      type: rollout
+      weight: 1.0
+
+  advantage_lookahead_step: 10
+  gamma: 1.0
+
+distributed:
+  enabled: true
+  backend: "nccl"
+  timeout: 3600
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/offline_rl/config/
+  job:
+    chdir: false
+```
+
+- [ ] **Step 4: Add Step 4 CFG config**
+
+Create `examples/offline_rl/config/aloha_sandwich_cfg_rl_openpi.yaml`:
+
+```yaml
+# Usage:
+#   bash examples/offline_rl/policy_optimization/cfg_rl/run_cfg_rl.sh aloha_sandwich_cfg_rl_openpi
+
+defaults:
+  - model/pi0_5@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - _self_
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/offline_rl/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: all
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "../results/aloha_sandwich_cfg"
+    project_name: rlinf
+    experiment_name: "aloha_sandwich_cfg"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 30000
+  max_steps: -1
+  val_check_interval: -1
+  save_interval: 3000
+
+data:
+  num_workers: 8
+  advantage_tag: sandwich_fail300_N10_q30_teleop
+  balance_dataset_weights: true
+  seed: 42
+
+  train_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      type: rollout
+      weight: 1.0
+
+algorithm:
+  adv_type: gae
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 32
+  global_batch_size: 512
+  seed: 0
+
+  model:
+    precision: null
+    model_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+    model_type: cfg_model
+    add_value_head: false
+    action_dim: 14
+    num_action_chunks: 10
+    openpi:
+      config_name: pi05_aloha_robotwin
+      num_images_in_input: 3
+      action_env_dim: 14
+      cfgrl_guidance_scale: 1.0
+      unconditional_prob: 0.1
+      train_expert_only: false
+      guidance_type: positive
+      positive_only_conditional: true
+
+  optim:
+    lr: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 1.0e-10
+    clip_grad: 1.0
+    lr_scheduler: "cosine"
+    lr_warmup_steps: 5000
+    total_training_steps: 30000
+    min_lr: 0.0
+
+  fsdp_config:
+    strategy: "fsdp"
+    sharding_strategy: "no_shard"
+    use_orig_params: false
+    gradient_checkpointing: true
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+
+reward:
+  use_reward_model: false
+
+critic:
+  use_critic_model: false
+```
+
+- [ ] **Step 5: Validate Hydra config composition without launching training**
+
+Run:
+
+```bash
+REPO_PATH="$(pwd)" python - <<'PY'
+from pathlib import Path
+from hydra import compose, initialize_config_dir
+
+config_dir = str(Path("examples/offline_rl/config").resolve())
+configs = [
+    "aloha_sandwich_recap_compute_returns",
+    "aloha_sandwich_recap_value_model_sft",
+    "aloha_sandwich_recap_compute_advantages",
+    "aloha_sandwich_cfg_rl_openpi",
+]
+with initialize_config_dir(version_base=None, config_dir=config_dir):
+    for name in configs:
+        cfg = compose(config_name=name)
+        print(name, "ok")
+PY
+```
+
+Expected output:
+
+```text
+aloha_sandwich_recap_compute_returns ok
+aloha_sandwich_recap_value_model_sft ok
+aloha_sandwich_recap_compute_advantages ok
+aloha_sandwich_cfg_rl_openpi ok
+```
+
+- [ ] **Step 6: Commit sandwich configs**
+
+Run:
+
+```bash
+git add examples/offline_rl/config/aloha_sandwich_recap_compute_returns.yaml examples/offline_rl/config/aloha_sandwich_recap_value_model_sft.yaml examples/offline_rl/config/aloha_sandwich_recap_compute_advantages.yaml examples/offline_rl/config/aloha_sandwich_cfg_rl_openpi.yaml
+git commit -s -m "feat: add aloha sandwich recap configs"
+```
+
+## Task 7: Documentation
+
+**Files:**
+- Modify: `docs/source-en/rst_source/examples/embodied/recap.rst`
+- Modify: `docs/source-zh/rst_source/examples/embodied/recap.rst`
+
+- [ ] **Step 1: Add English ALOHA sandwich section**
+
+In `docs/source-en/rst_source/examples/embodied/recap.rst`, insert this section after the "Pipeline Tag System" table:
+
+```rst
+ALOHA Sandwich HITL Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RLinf also supports running RECAP on an ALOHA sandwich HITL rollout dataset.
+This path keeps the data as ``robot_type: aloha`` and uses the existing
+``pi05_aloha_robotwin`` OpenPI configuration.
+
+The expected raw data and checkpoint locations are:
+
+.. code:: text
+
+   /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl
+   /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999
+
+Convert the raw HDF5 episodes to LeRobot v2.1:
+
+.. code:: bash
+
+   python examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py \
+      --raw-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl \
+      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21 \
+      --repo-id local/aloha_sandwich \
+      --task "Assemble a sandwich." \
+      --overwrite
+
+The converter writes three ALOHA cameras, 14-D state/action, per-frame
+``is_success``, per-frame ``teleop_mask``, and ``meta/hil_segments.json`` for
+auditability. Use ``type: rollout`` because the dataset contains both successes
+and failures.
+
+Convert the OpenPI JAX checkpoint to the PyTorch checkpoint expected by CFG
+training:
+
+.. code:: bash
+
+   python /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/examples/convert_jax_model_to_pytorch.py \
+      --input-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
+      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+
+Run the four RECAP stages:
+
+.. code:: bash
+
+   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_returns.sh \
+      aloha_sandwich_recap_compute_returns
+
+   bash examples/offline_rl/advantage_labeling/recap/run_value_sft.sh \
+      aloha_sandwich_recap_value_model_sft
+
+   export ALOHA_SANDWICH_VALUE_CHECKPOINT=/absolute/path/to/value/checkpoint
+   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_advantages.sh \
+      aloha_sandwich_recap_compute_advantages --nproc 1
+
+   bash examples/offline_rl/policy_optimization/cfg_rl/run_cfg_rl.sh \
+      aloha_sandwich_cfg_rl_openpi
+
+When ``data.hitl_aware_returns`` is enabled, successful episodes with human
+intervention are split at the first teleop frame: the autonomous prefix receives
+failed returns, and the intervention suffix receives successful returns. During
+advantage labeling, continuous advantages remain value-model based, while
+teleop frames force the boolean ``advantage`` label to positive and record the
+override in ``teleop_positive``.
+```
+
+- [ ] **Step 2: Add Chinese ALOHA sandwich section**
+
+In `docs/source-zh/rst_source/examples/embodied/recap.rst`, insert this matching section after the "Pipeline Tag" table:
+
+```rst
+ALOHA Sandwich HITL 示例
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RLinf 支持在 ALOHA sandwich HITL rollout 数据集上运行 RECAP。该路径保持
+``robot_type: aloha``，并复用已有的 ``pi05_aloha_robotwin`` OpenPI 配置。
+
+原始数据和 SFT 检查点位置如下：
+
+.. code:: text
+
+   /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl
+   /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999
+
+先将 HDF5 episode 转换为 LeRobot v2.1：
+
+.. code:: bash
+
+   python examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py \
+      --raw-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl \
+      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21 \
+      --repo-id local/aloha_sandwich \
+      --task "Assemble a sandwich." \
+      --overwrite
+
+转换器会写入三个 ALOHA 相机、14 维 state/action、逐帧 ``is_success``、
+逐帧 ``teleop_mask``，以及用于审计的 ``meta/hil_segments.json``。由于数据
+同时包含成功和失败轨迹，应使用 ``type: rollout``。
+
+再将 OpenPI JAX 检查点转换为 CFG 训练需要的 PyTorch 检查点：
+
+.. code:: bash
+
+   python /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/examples/convert_jax_model_to_pytorch.py \
+      --input-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
+      --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+
+依次运行四个 RECAP 阶段：
+
+.. code:: bash
+
+   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_returns.sh \
+      aloha_sandwich_recap_compute_returns
+
+   bash examples/offline_rl/advantage_labeling/recap/run_value_sft.sh \
+      aloha_sandwich_recap_value_model_sft
+
+   export ALOHA_SANDWICH_VALUE_CHECKPOINT=/absolute/path/to/value/checkpoint
+   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_advantages.sh \
+      aloha_sandwich_recap_compute_advantages --nproc 1
+
+   bash examples/offline_rl/policy_optimization/cfg_rl/run_cfg_rl.sh \
+      aloha_sandwich_cfg_rl_openpi
+
+启用 ``data.hitl_aware_returns`` 后，带有人类介入的成功 episode 会在第一个
+teleop 帧切分：自主执行前缀使用失败回报，介入后的后缀使用成功回报。优势
+标注阶段不会修改连续优势值；teleop 帧只会强制布尔 ``advantage`` 标签为正，
+并在 ``teleop_positive`` 中记录该覆盖。
+```
+
+- [ ] **Step 3: Check docs syntax around the new sections**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+for path in [
+    Path("docs/source-en/rst_source/examples/embodied/recap.rst"),
+    Path("docs/source-zh/rst_source/examples/embodied/recap.rst"),
+]:
+    text = path.read_text()
+    assert "ALOHA Sandwich" in text
+    assert "teleop_positive" in text
+    assert "aloha_sandwich_cfg_rl_openpi" in text
+    print(path, "ok")
+PY
+```
+
+Expected output:
+
+```text
+docs/source-en/rst_source/examples/embodied/recap.rst ok
+docs/source-zh/rst_source/examples/embodied/recap.rst ok
+```
+
+- [ ] **Step 4: Commit docs**
+
+Run:
+
+```bash
+git add docs/source-en/rst_source/examples/embodied/recap.rst docs/source-zh/rst_source/examples/embodied/recap.rst
+git commit -s -m "docs: add aloha sandwich recap guide"
+```
+
+## Task 8: Local Validation and Smoke Commands
+
+**Files:**
+- No source edits unless a previous task exposes a failure.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+python -m pytest \
+  tests/unit_tests/test_aloha_recap_converter.py \
+  tests/unit_tests/test_aloha_recap_returns.py \
+  tests/unit_tests/test_aloha_recap_transforms.py \
+  -q
+```
+
+Expected: PASS, with OpenPI transform tests skipped only if `openpi` is unavailable.
+
+- [ ] **Step 2: Run import check for the touched RECAP modules**
+
+Run:
+
+```bash
+python - <<'PY'
+import examples.offline_rl.advantage_labeling.recap.process.compute_advantages as compute_advantages
+import examples.offline_rl.advantage_labeling.recap.process.compute_returns as compute_returns
+import rlinf.data.datasets.recap.value_dataset as value_dataset
+import rlinf.models.embodiment.value_model.recap.checkpoint_utils as checkpoint_utils
+
+print(compute_returns.compute_hitl_aware_returns_for_episode.__name__)
+print(compute_advantages.build_obs.__name__)
+print("aloha" in value_dataset._REPACK_KEYS)
+print(callable(checkpoint_utils.build_input_transforms))
+PY
+```
+
+Expected output:
+
+```text
+compute_hitl_aware_returns_for_episode
+build_obs
+True
+True
+```
+
+- [ ] **Step 3: Convert the full sandwich dataset**
+
+Run:
+
+```bash
+python examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py \
+  --raw-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl \
+  --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21 \
+  --repo-id local/aloha_sandwich \
+  --task "Assemble a sandwich." \
+  --overwrite
+```
+
+Expected: conversion completes, writes 26 episodes, and writes `/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21/meta/hil_segments.json`.
+
+- [ ] **Step 4: Validate converted dataset counts**
+
+Run:
+
+```bash
+python - <<'PY'
+import json
+from pathlib import Path
+
+meta_path = Path("/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21/meta/hil_segments.json")
+data = json.loads(meta_path.read_text())
+assert data["total_episodes"] == 26, data["total_episodes"]
+assert data["total_frames"] == 60162, data["total_frames"]
+assert data["successful_episodes"] == 17, data["successful_episodes"]
+assert data["failed_episodes"] == 9, data["failed_episodes"]
+print("aloha sandwich metadata ok")
+PY
+```
+
+Expected output:
+
+```text
+aloha sandwich metadata ok
+```
+
+- [ ] **Step 5: Run Step 1 returns smoke**
+
+Run:
+
+```bash
+bash examples/offline_rl/advantage_labeling/recap/process/run_compute_returns.sh \
+  aloha_sandwich_recap_compute_returns
+```
+
+Expected: writes `/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21/meta/returns_sandwich_fail300.parquet` and updates `meta/stats.json`.
+
+- [ ] **Step 6: Validate Step 1 output**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import pandas as pd
+
+path = Path("/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21/meta/returns_sandwich_fail300.parquet")
+df = pd.read_parquet(path)
+assert len(df) == 60162, len(df)
+assert {"episode_index", "frame_index", "return", "reward", "prompt"} <= set(df.columns)
+print("returns rows", len(df))
+PY
+```
+
+Expected output starts with:
+
+```text
+returns rows 60162
+```
+
+- [ ] **Step 7: Convert the pi0.5 SFT checkpoint before CFG training**
+
+Run:
+
+```bash
+python /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/examples/convert_jax_model_to_pytorch.py \
+  --input-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999 \
+  --output-dir /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+```
+
+Expected: output directory contains a PyTorch weight file accepted by RLinf and an `assets/` directory with sandwich normalization stats.
+
+- [ ] **Step 8: Run a Step 3 smoke after a value checkpoint exists**
+
+Run after Step 2 has created a checkpoint:
+
+```bash
+export ALOHA_SANDWICH_VALUE_CHECKPOINT=/absolute/path/to/value/checkpoint
+bash examples/offline_rl/advantage_labeling/recap/process/run_compute_advantages.sh \
+  aloha_sandwich_recap_compute_advantages \
+  --nproc 1 \
+  advantage.max_samples=128 \
+  advantage.num_dataloader_workers_per_gpu=0
+```
+
+Expected: writes `meta/advantages_sandwich_fail300_N10_q30_teleop.parquet` with columns `advantage_continuous`, `advantage`, `teleop_mask`, and `teleop_positive`.
+
+- [ ] **Step 9: Validate Step 3 teleop override output**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import pandas as pd
+
+path = Path("/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21/meta/advantages_sandwich_fail300_N10_q30_teleop.parquet")
+df = pd.read_parquet(path)
+assert {"advantage_continuous", "advantage", "teleop_mask", "teleop_positive"} <= set(df.columns)
+assert (df.loc[df["teleop_mask"].astype(bool), "advantage"] == True).all()
+print("advantages rows", len(df))
+PY
+```
+
+Expected output starts with:
+
+```text
+advantages rows
+```
+
+- [ ] **Step 10: Run CFG dataloader/model-init smoke**
+
+Run after checkpoint conversion and Step 3 smoke:
+
+```bash
+bash examples/offline_rl/policy_optimization/cfg_rl/run_cfg_rl.sh \
+  aloha_sandwich_cfg_rl_openpi \
+  runner.max_steps=1 \
+  runner.save_interval=-1 \
+  actor.global_batch_size=4 \
+  actor.micro_batch_size=2 \
+  data.num_workers=0
+```
+
+Expected: training initializes the CFG dataset and model, runs one step, and exits without attempting a long training run.
+
+- [ ] **Step 11: Run lint on touched Python files**
+
+Run:
+
+```bash
+python -m ruff check \
+  examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py \
+  examples/offline_rl/advantage_labeling/recap/process/compute_returns.py \
+  examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py \
+  rlinf/data/datasets/recap/value_dataset.py \
+  rlinf/models/embodiment/value_model/recap/checkpoint_utils.py \
+  tests/unit_tests/test_aloha_recap_converter.py \
+  tests/unit_tests/test_aloha_recap_returns.py \
+  tests/unit_tests/test_aloha_recap_transforms.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Run formatter check on touched Python files**
+
+Run:
+
+```bash
+python -m ruff format --check \
+  examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py \
+  examples/offline_rl/advantage_labeling/recap/process/compute_returns.py \
+  examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py \
+  rlinf/data/datasets/recap/value_dataset.py \
+  rlinf/models/embodiment/value_model/recap/checkpoint_utils.py \
+  tests/unit_tests/test_aloha_recap_converter.py \
+  tests/unit_tests/test_aloha_recap_returns.py \
+  tests/unit_tests/test_aloha_recap_transforms.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Commit final verification fixes if any source changed**
+
+Run only if Steps 1-12 required additional source edits:
+
+```bash
+git add examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py examples/offline_rl/advantage_labeling/recap/process/compute_returns.py examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py rlinf/data/datasets/recap/value_dataset.py rlinf/models/embodiment/value_model/recap/checkpoint_utils.py tests/unit_tests/test_aloha_recap_converter.py tests/unit_tests/test_aloha_recap_returns.py tests/unit_tests/test_aloha_recap_transforms.py
+git commit -s -m "fix: stabilize aloha sandwich recap validation"
+```
+
+## Self-Review
+
+- Spec coverage: The plan covers ALOHA as a first-class RECAP robot type, HDF5-to-LeRobot conversion, HITL-aware returns, ALOHA value transforms, ALOHA advantage inference, teleop positive-label override, PyTorch checkpoint conversion requirement, sandwich configs, docs, unit tests, and smoke validation.
+- Non-goals respected: The plan does not replace RECAP with OpenPI scripts, does not disguise ALOHA as another robot type, keeps continuous advantage math unchanged, and limits full training to explicit smoke or later full runs.
+- Type consistency: The plan consistently uses `teleop_mask` for per-frame input metadata, `teleop_positive` for boolean-label overrides, `advantage_continuous` for the unchanged scalar advantage, `robot_type: aloha`, `model_type: pi05`, `action_dim: 14`, and `action_horizon: 10`.
+- Placeholder scan: The only intentionally runtime-supplied value is `ALOHA_SANDWICH_VALUE_CHECKPOINT`, because it is produced by Step 2. All dataset, model, and config paths otherwise use concrete paths from the spec.
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-05-aloha-sandwich-recap.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-05-aloha-sandwich-recap-design.md
+++ b/docs/superpowers/specs/2026-07-05-aloha-sandwich-recap-design.md
@@ -1,0 +1,301 @@
+# ALOHA Sandwich RECAP Design
+
+Date: 2026-07-05
+
+## Goal
+
+Add an RLinf-native path to run RECAP off-policy fine-tuning on the ALOHA
+sandwich human-in-the-loop dataset and an existing pi0.5 SFT checkpoint.
+
+The target data and checkpoint are:
+
+- Raw HDF5 data:
+  `/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_rl`
+- SFT checkpoint:
+  `/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all/pi05_sandwich_new_all_20260628_193430/49999`
+- Reference converter:
+  `/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/.worktrees/offline-recap-design/examples/aloha_real/convert_aloha_data_to_lerobot_v21.py`
+
+The result should use RLinf's merged RECAP pipeline from PR
+https://github.com/RLinf/RLinf/pull/1015, not a one-off OpenPI worktree
+pipeline.
+
+## Current Context
+
+PR 1015 is merged and local RLinf already contains the RECAP stages under:
+
+- `examples/offline_rl/advantage_labeling/recap/process/compute_returns.py`
+- `examples/offline_rl/advantage_labeling/recap/train_value.py`
+- `examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py`
+- `examples/offline_rl/policy_optimization/cfg_rl/train_cfg.py`
+
+The local code already has OpenPI ALOHA policy/data config support through
+`pi05_aloha_robotwin`, `LeRobotAlohaDataConfig`, and
+`aloha_policy.AlohaInputs`. The missing pieces are in the RECAP value and
+advantage data paths, which currently recognize `libero`, `libero_v2`,
+`franka`, `franka_co_train`, and related variants, but not `aloha`.
+
+The raw sandwich dataset contains 26 HDF5 episodes and 60162 frames. The
+episode-level reward split is 17 successful episodes (`reward == 1.0`) and
+9 failed episodes (`reward == 0.0`). Each file contains:
+
+- `action` with shape `(T, 14)`
+- `observations/qpos` with shape `(T, 14)`
+- `observations/qvel` with shape `(T, 14)`
+- `observations/effort` with shape `(T, 14)`
+- `observations/images/cam_high`
+- `observations/images/cam_left_wrist`
+- `observations/images/cam_right_wrist`
+- scalar `reward`
+- `teleop_segments` with shape `(N, 2)`
+
+The SFT checkpoint is an OpenPI/JAX Orbax checkpoint with `params/` and
+`assets/pi05_sandwich_new_all/norm_stats.json`. RLinf CFG training expects a
+PyTorch-style checkpoint directory with `model_state_dict/full_weights.pt` or
+safetensors, so a conversion step is required.
+
+The value-model backbones are available locally under:
+
+- `/inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/siglip2-so400m-patch14-224`
+- `/inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m`
+
+Both directories contain Hugging Face files such as `config.json`,
+`model.safetensors`, tokenizer files, and tokenizer configs.
+
+## Decisions
+
+Use the RLinf-native approach:
+
+1. Add ALOHA as a first-class RECAP robot type.
+2. Convert sandwich HDF5 to LeRobot v2.1 without changing ALOHA semantics.
+3. Treat the data as `type: rollout`, because it contains both successes and
+   failures.
+4. Let Step 1 compute returns from `is_success`.
+5. Let Step 3 compute continuous RECAP advantages with the value model, then
+   force frames inside `teleop_segments` to positive labels for CFG training.
+6. Initialize CFG policy training from a PyTorch conversion of the provided
+   pi0.5 SFT checkpoint.
+
+## Non-Goals
+
+- Do not replace RLinf's RECAP implementation with OpenPI worktree scripts.
+- Do not disguise ALOHA data as LIBERO or Franka data.
+- Do not change the mathematical return and advantage definitions outside the
+  teleop positive-label override.
+- Do not run full long training as part of the first implementation pass unless
+  explicitly requested after the pipeline is validated.
+
+## Data Conversion
+
+Add an RLinf converter, proposed path:
+
+`examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py`
+
+The converter will be based on the reference OpenPI script, but scoped to the
+fields RLinf needs for RECAP. It will write a LeRobot v2.1 dataset with:
+
+- `observation.images.cam_high`
+- `observation.images.cam_left_wrist`
+- `observation.images.cam_right_wrist`
+- `observation.state` as 14 float32 values from `observations/qpos`
+- `action` as 14 float32 values from `action`
+- optional `observation.velocity` from `observations/qvel`
+- optional `observation.effort` from `observations/effort`
+- `task`, using the configured sandwich task prompt
+- `is_success`, per frame, derived from scalar episode `reward > 0.0`
+- `teleop_mask`, per frame, derived from all `[start, end)` ranges in
+  `teleop_segments`
+
+The converter will also write a compact metadata file, for example
+`meta/hil_segments.json`, containing each episode's raw reward and teleop
+segments. This is for auditability; training code will consume `is_success`
+and `teleop_mask`.
+
+The default sandwich task prompt will be "Assemble a sandwich." and can be
+overridden by CLI argument.
+
+## RECAP ALOHA Support
+
+### Value Dataset
+
+Update `rlinf/data/datasets/recap/value_dataset.py`:
+
+- Add `_REPACK_KEYS["aloha"]` mapping:
+  - `images.cam_high` from `observation.images.cam_high`
+  - `images.cam_left_wrist` from `observation.images.cam_left_wrist`
+  - `images.cam_right_wrist` from `observation.images.cam_right_wrist`
+  - `state` from `observation.state`
+  - `actions` from `action`
+  - `prompt` from `prompt`
+- Add transform branch for `robot_type == "aloha"` that uses
+  `aloha_policy.AlohaInputs`.
+- Use `action_dim: 14` and `action_horizon: 10` for sandwich pi0.5 RECAP.
+
+This keeps value-model training aligned with OpenPI ALOHA policy training.
+
+### Advantage Inference
+
+Update
+`examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py`:
+
+- Add an ALOHA branch in `build_obs` that constructs the raw observation shape
+  expected by `aloha_policy.AlohaInputs`:
+  `{"images": {"cam_high": ..., "cam_left_wrist": ..., "cam_right_wrist": ...},
+  "state": ..., "prompt": ...}`.
+- Include `teleop_mask` in the inference dataset metadata when present.
+- Carry `teleop_mask` into the advantages DataFrame.
+- During boolean labeling, compute the normal quantile-based label first, then
+  set `advantage=True` for every row with `teleop_mask == 1`.
+- Store `teleop_positive` in the output parquet so downstream analysis can
+  distinguish value-based positive labels from human-correction overrides.
+- Log the number and percentage of teleop-overridden positive frames.
+
+The continuous `advantage_continuous` value remains unchanged; only the boolean
+training label is overridden.
+
+### Value Checkpoint Inference Transforms
+
+Update `rlinf/models/embodiment/value_model/recap/checkpoint_utils.py`:
+
+- Import `aloha_policy`.
+- Add `env_type == "aloha"` support in `build_input_transforms`.
+- Use `InjectDefaultPrompt`, `aloha_policy.AlohaInputs`, optional
+  normalization, and `PadStatesAndActions(action_dim)`.
+
+This is required because Step 3 loads the trained value model with
+`ValueCriticModel.from_checkpoint(..., env_type="aloha")`.
+
+### CFG Policy Training
+
+Use the existing `FSDPCfgWorker` path with:
+
+- `actor.model.model_type: cfg_model`
+- `actor.model.openpi.config_name: pi05_aloha_robotwin`
+- `actor.model.openpi.positive_only_conditional: true`
+- `actor.model.openpi.unconditional_prob: 0.1`
+- `actor.model.openpi.cfgrl_guidance_scale: 1.0`
+- `actor.model.model_path` pointing to the converted PyTorch checkpoint
+
+No new CFG worker is needed.
+
+## Checkpoint Conversion
+
+Use OpenPI's local converter:
+
+`/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/examples/convert_jax_model_to_pytorch.py`
+
+The design expectation is a converted directory under a writable experiment
+area, such as:
+
+`/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999`
+
+The converted directory must preserve or copy the checkpoint `assets/`
+directory so RLinf can load the sandwich normalization stats.
+
+RLinf should not silently accept the Orbax checkpoint in Step 4. The run
+instructions should require conversion first, and the config should point to
+the converted PyTorch directory.
+
+## Configuration Shape
+
+Add sandwich-specific configs or documented overrides for these values:
+
+Step 1, returns:
+
+- `data.train_data_paths[0].dataset_path`: converted LeRobot dataset
+- `data.train_data_paths[0].type: rollout`
+- `data.gamma: 1.0`
+- `data.failure_reward: -300.0`
+- `data.tag: sandwich_fail300`
+
+Step 2, value SFT:
+
+- `data.robot_type: aloha`
+- `data.model_type: pi05`
+- `data.action_dim: 14`
+- `data.action_horizon: 10`
+- `data.tag: sandwich_fail300`
+- `actor.model.siglip_path`:
+  `/inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/siglip2-so400m-patch14-224`
+- `actor.model.gemma3_path`:
+  `/inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m`
+- `actor.model.tokenizer_path`:
+  `/inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m`
+
+If symlinks are preferred for shorter config paths, create them under a repo
+root `models/` or `models/hf/google/` directory and keep that directory out of
+git. Do not place external model symlinks inside the Python source package
+`rlinf/models/`.
+
+Step 3, advantages:
+
+- `advantage.value_checkpoint`: value SFT checkpoint from Step 2
+- `advantage.returns_tag: sandwich_fail300`
+- `advantage.tag`: e.g. `sandwich_fail300_N10_q30_teleop`
+- `advantage.positive_quantile: 0.3`
+- `data.model_type: pi05`
+- `data.train_data_paths[0].robot_type: aloha`
+- `data.advantage_lookahead_step: 10`
+
+Step 4, CFG:
+
+- `data.advantage_tag`: same as Step 3 `advantage.tag`
+- `data.train_data_paths[0].dataset_path`: converted LeRobot dataset
+- `actor.model.model_path`: converted PyTorch pi0.5 SFT checkpoint
+- `actor.model.openpi.config_name: pi05_aloha_robotwin`
+- `actor.model.openpi.action_env_dim: 14`
+
+## Validation Plan
+
+Data validation:
+
+- Verify the converter writes 26 episodes and 60162 frames.
+- Verify success/failure counts are 17 and 9.
+- Verify every `teleop_segments` range maps to `teleop_mask == 1` on the same
+  frame interval.
+- Verify image columns, state, and action appear in `meta/info.json`.
+
+Unit tests:
+
+- Add a small ALOHA LeRobot fixture or synthetic metadata-backed sample.
+- Test `ValueDataset` can build an ALOHA transformed sample.
+- Test `compute_advantages.build_obs(..., robot_type="aloha")` maps cameras,
+  state, and prompt.
+- Test teleop label override changes only the boolean `advantage` label and
+  preserves `advantage_continuous`.
+
+Smoke tests:
+
+- Run Step 1 on the converted sandwich dataset and verify
+  `meta/returns_sandwich_fail300.parquet`.
+- Run Step 3 with a very small `advantage.max_samples` once a value checkpoint
+  exists, verifying `teleop_positive` appears in the output parquet.
+- Run Step 4 until dataloader/model initialization succeeds with a tiny
+  training budget.
+
+Full training:
+
+- Value SFT and CFG fine-tuning are GPU-heavy and should be run separately with
+  explicit resource allocation.
+- Full run success criteria are decreasing value loss, non-degenerate advantage
+  label distribution, and CFG training loss producing checkpoints.
+
+## Risks
+
+- The value model depends on local SigLIP2 and Gemma3 paths. Known-good paths
+  are listed above. The implementation must still fail early with a clear error
+  when those paths are missing, point at incomplete directories, or do not
+  contain Hugging Face model/tokenizer files.
+- OpenPI checkpoint conversion may need enough CPU memory and disk space for a
+  full pi0.5 checkpoint.
+- `pi05_aloha_robotwin` uses ALOHA action/state adaptation defaults. If the
+  original sandwich SFT used different `adapt_to_pi` or delta-action settings,
+  the RLinf config must match that training setup before a long run.
+- The dataset contains episode-level rewards, not dense task rewards. This is
+  expected for RECAP, but the return signal will mostly encode time-to-success
+  and terminal failure penalty.
+
+## Approval State
+
+The user approved the RLinf-native approach and the recommended teleop-positive
+label rule before this spec was written.

--- a/docs/superpowers/specs/2026-07-05-aloha-sandwich-recap-design.md
+++ b/docs/superpowers/specs/2026-07-05-aloha-sandwich-recap-design.md
@@ -70,7 +70,8 @@ Use the RLinf-native approach:
 2. Convert sandwich HDF5 to LeRobot v2.1 without changing ALOHA semantics.
 3. Treat the data as `type: rollout`, because it contains both successes and
    failures.
-4. Let Step 1 compute returns from `is_success`.
+4. Let Step 1 compute returns from `is_success`, with HITL-aware splitting
+   enabled for successful episodes that contain `teleop_mask`.
 5. Let Step 3 compute continuous RECAP advantages with the value model, then
    force frames inside `teleop_segments` to positive labels for CFG training.
 6. Initialize CFG policy training from a PyTorch conversion of the provided
@@ -113,6 +114,26 @@ and `teleop_mask`.
 
 The default sandwich task prompt will be "Assemble a sandwich." and can be
 overridden by CLI argument.
+
+## HITL-Aware Return Computation
+
+Update `examples/offline_rl/advantage_labeling/recap/process/compute_returns.py`:
+
+- Add `data.hitl_aware_returns`.
+- Keep the default disabled for existing datasets.
+- When enabled, read the optional per-frame `teleop_mask` column.
+- For successful episodes with at least one teleop frame, split returns at the
+  first intervention frame:
+  - Frames before the first intervention use failed returns over the autonomous
+    prefix.
+  - Frames from the first intervention onward use successful returns over the
+    suffix.
+- Failed episodes remain failed episodes even if they contain teleop frames.
+
+This prevents the value model from learning that pre-intervention autonomous
+failure states are high value just because a human later rescued the episode.
+The teleop action preference signal still enters through Step 3's positive
+advantage-label override.
 
 ## RECAP ALOHA Support
 
@@ -206,6 +227,7 @@ Step 1, returns:
 - `data.train_data_paths[0].type: rollout`
 - `data.gamma: 1.0`
 - `data.failure_reward: -300.0`
+- `data.hitl_aware_returns: true`
 - `data.tag: sandwich_fail300`
 
 Step 2, value SFT:
@@ -259,6 +281,8 @@ Unit tests:
 
 - Add a small ALOHA LeRobot fixture or synthetic metadata-backed sample.
 - Test `ValueDataset` can build an ALOHA transformed sample.
+- Test HITL-aware Step 1 returns split successful intervention episodes at the
+  first teleop frame and leave failed intervention episodes failed.
 - Test `compute_advantages.build_obs(..., robot_type="aloha")` maps cameras,
   state, and prompt.
 - Test teleop label override changes only the boolean `advantage` label and

--- a/examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py
+++ b/examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py
@@ -299,6 +299,25 @@ def load_lerobot_dataset(
     return dataset, tasks, meta, returns_sidecar
 
 
+def _resolve_prompt(sample: dict, tasks: dict) -> str:
+    if "prompt" in sample:
+        return str(to_scalar(sample["prompt"]))
+    if "task" in sample:
+        return str(to_scalar(sample["task"]))
+    if "task_index" in sample and tasks:
+        task_idx = int(to_scalar(sample["task_index"]))
+        if task_idx not in tasks:
+            raise ValueError(
+                f"task_index {task_idx} not found in tasks dict. "
+                f"Available task indices: {list(tasks.keys())}."
+            )
+        return tasks[task_idx]
+    raise ValueError(
+        "Sample has no prompt, task, or task_index field. "
+        "Cannot determine task prompt for value model inference."
+    )
+
+
 def build_obs(
     sample: dict,
     robot_type: str,
@@ -314,6 +333,28 @@ def build_obs(
     Returns:
         Raw observation dict compatible with ValueCriticModel.infer()
     """
+    if robot_type == "aloha":
+        required = (
+            "observation.images.cam_high",
+            "observation.images.cam_left_wrist",
+            "observation.images.cam_right_wrist",
+            "observation.state",
+        )
+        missing = [key for key in required if key not in sample]
+        if missing:
+            raise KeyError(f"ALOHA sample missing required keys: {missing}")
+        return {
+            "images": {
+                "cam_high": to_numpy(sample["observation.images.cam_high"]),
+                "cam_left_wrist": to_numpy(sample["observation.images.cam_left_wrist"]),
+                "cam_right_wrist": to_numpy(
+                    sample["observation.images.cam_right_wrist"]
+                ),
+            },
+            "state": to_numpy(sample["observation.state"]),
+            "prompt": _resolve_prompt(sample, tasks),
+        }
+
     if robot_type not in KEY_MAPPINGS:
         raise ValueError(
             f"Unknown robot_type {robot_type!r}. "
@@ -325,22 +366,7 @@ def build_obs(
 
     for src_key, dst_key in key_map.items():
         if src_key == "task":
-            if "task" in sample:
-                obs[dst_key] = str(to_scalar(sample["task"]))
-            elif "task_index" in sample and tasks:
-                task_idx = int(to_scalar(sample["task_index"]))
-                if task_idx not in tasks:
-                    raise ValueError(
-                        f"task_index {task_idx} not found in tasks dict. "
-                        f"Available task indices: {list(tasks.keys())}. "
-                        "Check that meta/tasks.jsonl is complete."
-                    )
-                obs[dst_key] = tasks[task_idx]
-            else:
-                raise ValueError(
-                    "Sample has neither 'task' nor 'task_index' field. "
-                    "Cannot determine task prompt for value model inference."
-                )
+            obs[dst_key] = _resolve_prompt(sample, tasks)
         elif src_key in sample:
             val = to_numpy(sample[src_key])
             obs[dst_key] = val
@@ -412,6 +438,10 @@ class ValueInferenceDataset(torch.utils.data.Dataset):
                 )
             reward = float(to_scalar(sample["reward"]))
 
+        teleop_mask = 0
+        if "teleop_mask" in sample:
+            teleop_mask = int(to_scalar(sample["teleop_mask"]))
+
         return {
             "obs": obs,
             "global_idx": idx,
@@ -419,6 +449,7 @@ class ValueInferenceDataset(torch.utils.data.Dataset):
             "frame_index": frame_idx,
             "true_return": true_return,
             "reward": reward,
+            "teleop_mask": teleop_mask,
         }
 
 
@@ -442,6 +473,7 @@ def advantage_collate_fn(
             "frame_index": item["frame_index"],
             "true_return": item["true_return"],
             "reward": item["reward"],
+            "teleop_mask": item.get("teleop_mask", 0),
         }
         for item in batch
     ]
@@ -559,6 +591,7 @@ def compute_advantages_for_dataset(
         "reward_sum": [],
         "reward_sum_raw": [],
         "num_valid_rewards": [],
+        "teleop_mask": [],
     }
 
     v_curr_stats = RunningStats("V(o_t)")
@@ -647,6 +680,7 @@ def compute_advantages_for_dataset(
     meta_frame_idx = np.full(extended_size, -1, dtype=np.int64)
     meta_return = np.full(extended_size, np.nan, dtype=np.float64)
     meta_reward = np.full(extended_size, np.nan, dtype=np.float64)
+    meta_teleop_mask = np.zeros(extended_size, dtype=np.int64)
     filled_mask = np.zeros(extended_size, dtype=bool)
 
     def process_value_batch(obs_list: list[dict], meta_list: list[dict]):
@@ -675,6 +709,7 @@ def compute_advantages_for_dataset(
             meta_frame_idx[local_idx] = int(meta_info["frame_index"])
             meta_return[local_idx] = float(meta_info["true_return"])
             meta_reward[local_idx] = float(meta_info["reward"])
+            meta_teleop_mask[local_idx] = int(meta_info.get("teleop_mask", 0))
             filled_mask[local_idx] = True
 
     # Prefetch next batch while GPU processes current batch
@@ -816,6 +851,7 @@ def compute_advantages_for_dataset(
         results["reward_sum"].append(reward_sum)
         results["reward_sum_raw"].append(reward_sum_raw)
         results["num_valid_rewards"].append(num_valid)
+        results["teleop_mask"].append(int(meta_teleop_mask[i]))
 
         if (i + 1) % flush_every_samples == 0:
             flush_results_to_disk()
@@ -896,11 +932,27 @@ def save_advantages_to_dataset(
         save_df.rename(columns={"advantage": "advantage_continuous"}, inplace=True)
         if (dataset_type or "").lower() == "sft":
             save_df["advantage"] = True
+            save_df["teleop_positive"] = False
         else:
-            # Shared with STEAM (RECAP uses the inclusive `>=` convention).
-            save_df["advantage"] = apply_boolean_label(
+            value_positive = apply_boolean_label(
                 save_df["advantage_continuous"], threshold, inclusive=True
             )
+            teleop_mask = (
+                save_df["teleop_mask"].astype(bool)
+                if "teleop_mask" in save_df.columns
+                else pd.Series(False, index=save_df.index)
+            )
+            save_df["teleop_positive"] = teleop_mask & ~value_positive
+            save_df["advantage"] = value_positive | teleop_mask
+            if teleop_mask.any():
+                overridden = int(save_df["teleop_positive"].sum())
+                teleop_total = int(teleop_mask.sum())
+                logger.info(
+                    "  Teleop positive override: %d/%d teleop frames forced positive (%.2f%% of dataset)",
+                    overridden,
+                    teleop_total,
+                    100.0 * overridden / max(len(save_df), 1),
+                )
 
         adv_filename = f"advantages_{tag}.parquet" if tag else "advantages.parquet"
         save_df.to_parquet(meta_dir / adv_filename, index=False)

--- a/examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py
+++ b/examples/offline_rl/advantage_labeling/recap/process/compute_advantages.py
@@ -30,6 +30,7 @@ import gc
 import json
 import logging
 import os
+from dataclasses import dataclass
 
 # Disable tokenizers parallelism to avoid warning when using multiprocessing
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -374,6 +375,49 @@ def build_obs(
     return obs
 
 
+@dataclass(frozen=True)
+class _LookaheadResolution:
+    """Resolved reward window and optional next-value index."""
+
+    next_global_idx: int
+    next_local_idx: int | None
+    num_valid: int
+    is_next_pad: bool
+
+
+def _resolve_lookahead(
+    local_idx: int,
+    global_idx: int,
+    shard_start: int,
+    episode_end: int,
+    action_horizon: int,
+    done_flags: np.ndarray | None = None,
+) -> _LookaheadResolution:
+    """Resolve the reward window without crossing episode or sidecar boundaries."""
+    episode_end = max(int(episode_end), global_idx + 1)
+    next_global_idx = global_idx + action_horizon
+    is_next_pad = next_global_idx >= episode_end
+    num_valid = min(action_horizon, episode_end - global_idx)
+
+    if done_flags is not None and num_valid > 0:
+        done_window = np.asarray(
+            done_flags[local_idx : local_idx + num_valid], dtype=bool
+        )
+        done_offsets = np.flatnonzero(done_window)
+        if done_offsets.size > 0:
+            num_valid = int(done_offsets[0]) + 1
+            next_global_idx = global_idx + num_valid
+            is_next_pad = True
+
+    next_local_idx = None if is_next_pad else next_global_idx - shard_start
+    return _LookaheadResolution(
+        next_global_idx=next_global_idx,
+        next_local_idx=next_local_idx,
+        num_valid=num_valid,
+        is_next_pad=is_next_pad,
+    )
+
+
 class ValueInferenceDataset(torch.utils.data.Dataset):
     """Wrapper dataset for DataLoader-based advantage computation.
 
@@ -418,10 +462,13 @@ class ValueInferenceDataset(torch.utils.data.Dataset):
         if self.prepare_observation_cpu is not None:
             obs = self.prepare_observation_cpu(obs)
 
+        done = False
         if self.returns_sidecar is not None and ep_idx in self.returns_sidecar:
             ep_data = self.returns_sidecar[ep_idx]
             true_return = float(ep_data["return"][frame_idx])
             reward = float(ep_data["reward"][frame_idx])
+            if "done" in ep_data:
+                done = bool(ep_data["done"][frame_idx])
         else:
             if "return" not in sample:
                 raise ValueError(
@@ -437,6 +484,8 @@ class ValueInferenceDataset(torch.utils.data.Dataset):
                     "Run compute_returns.py first."
                 )
             reward = float(to_scalar(sample["reward"]))
+            if "done" in sample:
+                done = bool(to_scalar(sample["done"]))
 
         teleop_mask = 0
         if "teleop_mask" in sample:
@@ -449,6 +498,7 @@ class ValueInferenceDataset(torch.utils.data.Dataset):
             "frame_index": frame_idx,
             "true_return": true_return,
             "reward": reward,
+            "done": done,
             "teleop_mask": teleop_mask,
         }
 
@@ -473,6 +523,7 @@ def advantage_collate_fn(
             "frame_index": item["frame_index"],
             "true_return": item["true_return"],
             "reward": item["reward"],
+            "done": item.get("done", False),
             "teleop_mask": item.get("teleop_mask", 0),
         }
         for item in batch
@@ -680,6 +731,7 @@ def compute_advantages_for_dataset(
     meta_frame_idx = np.full(extended_size, -1, dtype=np.int64)
     meta_return = np.full(extended_size, np.nan, dtype=np.float64)
     meta_reward = np.full(extended_size, np.nan, dtype=np.float64)
+    meta_done = np.zeros(extended_size, dtype=bool)
     meta_teleop_mask = np.zeros(extended_size, dtype=np.int64)
     filled_mask = np.zeros(extended_size, dtype=bool)
 
@@ -709,6 +761,7 @@ def compute_advantages_for_dataset(
             meta_frame_idx[local_idx] = int(meta_info["frame_index"])
             meta_return[local_idx] = float(meta_info["true_return"])
             meta_reward[local_idx] = float(meta_info["reward"])
+            meta_done[local_idx] = bool(meta_info.get("done", False))
             meta_teleop_mask[local_idx] = int(meta_info.get("teleop_mask", 0))
             filled_mask[local_idx] = True
 
@@ -798,17 +851,23 @@ def compute_advantages_for_dataset(
         true_return = float(meta_return[i])
 
         ep_end = int(ep_ends.get(ep_idx, gidx + 1))
-        ep_end = max(ep_end, gidx + 1)
-        next_gidx = gidx + action_horizon
-        is_next_pad = next_gidx >= ep_end
-        num_valid = min(action_horizon, ep_end - gidx)
+        lookahead = _resolve_lookahead(
+            local_idx=i,
+            global_idx=gidx,
+            shard_start=shard_start,
+            episode_end=ep_end,
+            action_horizon=action_horizon,
+            done_flags=meta_done,
+        )
+        next_gidx = lookahead.next_global_idx
+        next_local_idx = lookahead.next_local_idx
+        is_next_pad = lookahead.is_next_pad
+        num_valid = lookahead.num_valid
 
         v_curr = float(v_values[i])
         if is_next_pad:
             v_next = 0.0
-            next_local_idx = None
         else:
-            next_local_idx = next_gidx - shard_start
             if next_local_idx < 0 or next_local_idx >= extended_size:
                 raise RuntimeError(
                     "next_local_idx out of range: "

--- a/examples/offline_rl/advantage_labeling/recap/process/compute_returns.py
+++ b/examples/offline_rl/advantage_labeling/recap/process/compute_returns.py
@@ -15,7 +15,7 @@
 """
 Compute returns for LeRobot datasets.
 
-Writes `return`, `reward`, and `prompt` as a sidecar parquet at
+Writes `return`, `reward`, `done`, and `prompt` as a sidecar parquet at
 ``meta/returns_{tag}.parquet``. Updates meta/stats.json and meta/info.json.
 Does not modify original per-episode parquet files.
 
@@ -56,6 +56,63 @@ _READ_COLUMNS = [
     "task_index",
     "task",
 ]
+
+
+def _normalize_scalar_bool(value) -> bool:
+    """Normalize scalar/list-wrapped boolean values from parquet metadata."""
+    if isinstance(value, np.ndarray):
+        if value.shape == ():
+            return bool(value.item())
+        if value.size != 1:
+            raise ValueError(
+                f"Expected scalar boolean value, got array shape {value.shape}"
+            )
+        return _normalize_scalar_bool(value.reshape(-1)[0])
+    if isinstance(value, (list, tuple)):
+        if len(value) != 1:
+            raise ValueError(
+                f"Expected singleton boolean list, got length {len(value)}"
+            )
+        return _normalize_scalar_bool(value[0])
+    return bool(value)
+
+
+def _normalize_teleop_mask(teleop_mask: np.ndarray, episode_length: int) -> np.ndarray:
+    """Normalize LeRobot teleop masks to a 1-D boolean array."""
+    mask = np.asarray(teleop_mask).astype(bool)
+    if mask.ndim == 2 and mask.shape[1] == 1:
+        mask = mask[:, 0]
+    elif mask.ndim != 1:
+        raise ValueError(f"teleop_mask must be 1-D or shape (N, 1), got {mask.shape}")
+    if mask.shape[0] != episode_length:
+        raise ValueError(
+            f"teleop_mask length {mask.shape[0]} does not match episode length {episode_length}"
+        )
+    return mask
+
+
+def _compute_done_flags_for_episode(
+    episode_length: int,
+    is_success: bool,
+    teleop_mask: np.ndarray | None = None,
+    hitl_aware_returns: bool = False,
+) -> np.ndarray:
+    """Compute terminal flags aligned with the returns sidecar rows."""
+    done = np.zeros(episode_length, dtype=bool)
+    done[-1] = True
+
+    if not hitl_aware_returns or not is_success or teleop_mask is None:
+        return done
+
+    mask = _normalize_teleop_mask(teleop_mask, episode_length)
+    teleop_indices = np.flatnonzero(mask)
+    if len(teleop_indices) == 0:
+        return done
+
+    split = int(teleop_indices[0])
+    if split > 0:
+        done[split - 1] = True
+    return done
 
 
 def compute_returns_for_episode(
@@ -115,15 +172,7 @@ def compute_hitl_aware_returns_for_episode(
             failure_reward=failure_reward,
         )
 
-    mask = np.asarray(teleop_mask).astype(bool)
-    if mask.ndim == 2 and mask.shape[1] == 1:
-        mask = mask[:, 0]
-    elif mask.ndim != 1:
-        raise ValueError(f"teleop_mask must be 1-D or shape (N, 1), got {mask.shape}")
-    if mask.shape[0] != episode_length:
-        raise ValueError(
-            f"teleop_mask length {mask.shape[0]} does not match episode length {episode_length}"
-        )
+    mask = _normalize_teleop_mask(teleop_mask, episode_length)
     teleop_indices = np.flatnonzero(mask)
     if len(teleop_indices) == 0:
         return compute_returns_for_episode(
@@ -196,7 +245,7 @@ def _process_single_parquet(
     optional teleop_mask — no images.
 
     Returns:
-        Arrow table with (episode_index, frame_index, return, reward, prompt)
+        Arrow table with (episode_index, frame_index, return, reward, done, prompt)
         columns, or None if the file is empty.
     """
     file_size = Path(pq_file).stat().st_size
@@ -243,6 +292,7 @@ def _process_single_parquet(
 
     returns_arr = np.empty(n, dtype=np.float32)
     rewards_arr = np.empty(n, dtype=np.float32)
+    done_arr = np.zeros(n, dtype=bool)
 
     for _, ep_start, ep_end in episodes:
         ep_length = ep_end - ep_start
@@ -250,7 +300,7 @@ def _process_single_parquet(
         if dataset_type == "sft":
             is_success = True
         else:
-            is_success = bool(is_success_col[ep_end - 1])
+            is_success = _normalize_scalar_bool(is_success_col[ep_end - 1])
 
         if hitl_aware_returns and teleop_col is not None:
             ep_returns, ep_rewards = compute_hitl_aware_returns_for_episode(
@@ -269,6 +319,12 @@ def _process_single_parquet(
             )
         returns_arr[ep_start:ep_end] = ep_returns
         rewards_arr[ep_start:ep_end] = ep_rewards
+        done_arr[ep_start:ep_end] = _compute_done_flags_for_episode(
+            episode_length=ep_length,
+            is_success=is_success,
+            teleop_mask=teleop_col[ep_start:ep_end] if teleop_col is not None else None,
+            hitl_aware_returns=hitl_aware_returns and teleop_col is not None,
+        )
 
     if "task" in col_names:
         prompts_list = [str(t) for t in table.column("task").to_pylist()]
@@ -284,6 +340,7 @@ def _process_single_parquet(
             "frame_index": pa.array(frame_indices),
             "return": pa.array(returns_arr),
             "reward": pa.array(rewards_arr),
+            "done": pa.array(done_arr),
             "prompt": pa.array(prompts_list, type=pa.string()),
         }
     )
@@ -472,6 +529,11 @@ def process_dataset(
         }
         info["features"]["reward"] = {
             "dtype": "float32",
+            "shape": [1],
+            "names": None,
+        }
+        info["features"]["done"] = {
+            "dtype": "bool",
             "shape": [1],
             "names": None,
         }

--- a/examples/offline_rl/advantage_labeling/recap/process/compute_returns.py
+++ b/examples/offline_rl/advantage_labeling/recap/process/compute_returns.py
@@ -48,7 +48,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[5]))
 logger = logging.getLogger(__name__)
 
 # Columns needed for computation (tiny — no images)
-_READ_COLUMNS = ["episode_index", "frame_index", "is_success", "task_index", "task"]
+_READ_COLUMNS = [
+    "episode_index",
+    "frame_index",
+    "is_success",
+    "teleop_mask",
+    "task_index",
+    "task",
+]
 
 
 def compute_returns_for_episode(
@@ -86,6 +93,73 @@ def compute_returns_for_episode(
     return returns, rewards
 
 
+def compute_hitl_aware_returns_for_episode(
+    episode_length: int,
+    is_success: bool,
+    teleop_mask: np.ndarray,
+    gamma: float,
+    failure_reward: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute returns that mark pre-intervention prefixes as failed.
+
+    Successful HITL episodes are split at the first teleop frame. The
+    autonomous prefix receives failed-episode returns and the suffix receives
+    successful returns. Failed episodes remain failed even when they contain
+    teleop frames.
+    """
+    if not is_success:
+        return compute_returns_for_episode(
+            episode_length=episode_length,
+            is_success=False,
+            gamma=gamma,
+            failure_reward=failure_reward,
+        )
+
+    mask = np.asarray(teleop_mask).astype(bool)
+    if mask.ndim == 2 and mask.shape[1] == 1:
+        mask = mask[:, 0]
+    elif mask.ndim != 1:
+        raise ValueError(f"teleop_mask must be 1-D or shape (N, 1), got {mask.shape}")
+    if mask.shape[0] != episode_length:
+        raise ValueError(
+            f"teleop_mask length {mask.shape[0]} does not match episode length {episode_length}"
+        )
+    teleop_indices = np.flatnonzero(mask)
+    if len(teleop_indices) == 0:
+        return compute_returns_for_episode(
+            episode_length=episode_length,
+            is_success=True,
+            gamma=gamma,
+            failure_reward=failure_reward,
+        )
+
+    split = int(teleop_indices[0])
+    if split == 0:
+        return compute_returns_for_episode(
+            episode_length=episode_length,
+            is_success=True,
+            gamma=gamma,
+            failure_reward=failure_reward,
+        )
+
+    prefix_returns, prefix_rewards = compute_returns_for_episode(
+        episode_length=split,
+        is_success=False,
+        gamma=gamma,
+        failure_reward=failure_reward,
+    )
+    suffix_returns, suffix_rewards = compute_returns_for_episode(
+        episode_length=episode_length - split,
+        is_success=True,
+        gamma=gamma,
+        failure_reward=failure_reward,
+    )
+    return (
+        np.concatenate([prefix_returns, suffix_returns]).astype(np.float32),
+        np.concatenate([prefix_rewards, suffix_rewards]).astype(np.float32),
+    )
+
+
 def get_episode_boundaries(episode_indices: np.ndarray) -> list[tuple[int, int, int]]:
     """Extract episode boundaries from episode_index array.
 
@@ -114,10 +188,12 @@ def _process_single_parquet(
     gamma: float,
     failure_reward: float,
     tasks: dict[int, str],
+    hitl_aware_returns: bool = False,
 ) -> pa.Table | None:
     """Process a single parquet file: read only metadata columns, compute returns.
 
-    Only reads episode_index, frame_index, is_success, task_index — no images.
+    Only reads episode_index, frame_index, is_success, task_index, task, and
+    optional teleop_mask — no images.
 
     Returns:
         Arrow table with (episode_index, frame_index, return, reward, prompt)
@@ -155,6 +231,16 @@ def _process_single_parquet(
             "to correctly distinguish successful and failed episodes."
         )
 
+    teleop_col = None
+    if hitl_aware_returns and "teleop_mask" in col_names:
+        teleop_col = np.asarray(table.column("teleop_mask").to_pylist(), dtype=np.int64)
+    elif hitl_aware_returns:
+        logger.warning(
+            "data.hitl_aware_returns is enabled but teleop_mask is missing in %s; "
+            "falling back to standard returns for this file.",
+            pq_file,
+        )
+
     returns_arr = np.empty(n, dtype=np.float32)
     rewards_arr = np.empty(n, dtype=np.float32)
 
@@ -166,12 +252,21 @@ def _process_single_parquet(
         else:
             is_success = bool(is_success_col[ep_end - 1])
 
-        ep_returns, ep_rewards = compute_returns_for_episode(
-            episode_length=ep_length,
-            is_success=is_success,
-            gamma=gamma,
-            failure_reward=failure_reward,
-        )
+        if hitl_aware_returns and teleop_col is not None:
+            ep_returns, ep_rewards = compute_hitl_aware_returns_for_episode(
+                episode_length=ep_length,
+                is_success=is_success,
+                teleop_mask=teleop_col[ep_start:ep_end],
+                gamma=gamma,
+                failure_reward=failure_reward,
+            )
+        else:
+            ep_returns, ep_rewards = compute_returns_for_episode(
+                episode_length=ep_length,
+                is_success=is_success,
+                gamma=gamma,
+                failure_reward=failure_reward,
+            )
         returns_arr[ep_start:ep_end] = ep_returns
         rewards_arr[ep_start:ep_end] = ep_rewards
 
@@ -203,6 +298,7 @@ def process_dataset(
     failure_reward: float,
     num_workers: int = 8,
     tag: str | None = None,
+    hitl_aware_returns: bool = False,
 ) -> dict:
     """Process a LeRobot dataset and compute return/reward/prompt.
 
@@ -218,13 +314,16 @@ def process_dataset(
         failure_reward: Penalty for failed episodes
         num_workers: Number of parallel workers for parquet processing
         tag: Optional tag for the sidecar filename
+        hitl_aware_returns: Whether to split successful HITL episodes at the
+            first teleop frame
 
     Returns:
         Statistics dict with return/reward stats
     """
     logger.info(f"Processing dataset: {dataset_path}")
     logger.info(
-        f"  Type: {dataset_type}, Gamma: {gamma}, Failure reward: {failure_reward}"
+        f"  Type: {dataset_type}, Gamma: {gamma}, "
+        f"Failure reward: {failure_reward}, HITL-aware returns: {hitl_aware_returns}"
     )
 
     if output_path is None:
@@ -260,7 +359,12 @@ def process_dataset(
     if effective_workers <= 1:
         for pq_file in tqdm(parquet_files, desc="Processing parquet files"):
             tbl = _process_single_parquet(
-                pq_file, dataset_type, gamma, failure_reward, tasks
+                pq_file,
+                dataset_type,
+                gamma,
+                failure_reward,
+                tasks,
+                hitl_aware_returns,
             )
             if tbl is not None:
                 result_tables.append(tbl)
@@ -276,6 +380,7 @@ def process_dataset(
                     gamma,
                     failure_reward,
                     tasks,
+                    hitl_aware_returns,
                 )
                 futures[fut] = pq_file
 
@@ -401,6 +506,7 @@ def compute_returns(cfg: DictConfig) -> None:
         )
     num_workers = cfg.data.get("num_workers", 8)
     tag = cfg.data.get("tag", None)
+    hitl_aware_returns = cfg.data.get("hitl_aware_returns", False)
 
     datasets_list = cfg.data.get("train_data_paths", None)
 
@@ -429,6 +535,9 @@ def compute_returns(cfg: DictConfig) -> None:
                     "failure_reward": entry.get(
                         "failure_reward", default_failure_reward
                     ),
+                    "hitl_aware_returns": entry.get(
+                        "hitl_aware_returns", hitl_aware_returns
+                    ),
                 }
             )
     else:
@@ -452,6 +561,7 @@ def compute_returns(cfg: DictConfig) -> None:
                 "dataset_type": default_type,
                 "gamma": default_gamma,
                 "failure_reward": default_failure_reward,
+                "hitl_aware_returns": hitl_aware_returns,
             }
         )
 
@@ -479,6 +589,7 @@ def compute_returns(cfg: DictConfig) -> None:
             failure_reward=ds_config["failure_reward"],
             num_workers=num_workers,
             tag=tag,
+            hitl_aware_returns=ds_config["hitl_aware_returns"],
         )
         all_stats.append(
             {

--- a/examples/offline_rl/config/aloha_sandwich_cfg_rl_openpi.yaml
+++ b/examples/offline_rl/config/aloha_sandwich_cfg_rl_openpi.yaml
@@ -1,0 +1,99 @@
+# Usage:
+#   bash examples/offline_rl/policy_optimization/cfg_rl/run_cfg_rl.sh aloha_sandwich_cfg_rl_openpi
+
+defaults:
+  - model/pi0_5@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - _self_
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/offline_rl/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: all
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "../results/aloha_sandwich_cfg"
+    project_name: rlinf
+    experiment_name: "aloha_sandwich_cfg"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 30000
+  max_steps: -1
+  val_check_interval: -1
+  save_interval: 3000
+
+data:
+  num_workers: 8
+  advantage_tag: sandwich_fail300_N10_q30_teleop
+  balance_dataset_weights: true
+  seed: 42
+
+  train_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      type: rollout
+      weight: 1.0
+
+algorithm:
+  adv_type: gae
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 32
+  global_batch_size: 512
+  seed: 0
+
+  model:
+    precision: null
+    model_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/pi05_sandwich_new_all_pytorch/49999
+    model_type: cfg_model
+    add_value_head: false
+    action_dim: 14
+    num_action_chunks: 10
+    openpi:
+      config_name: pi05_aloha_robotwin
+      num_images_in_input: 3
+      action_env_dim: 14
+      cfgrl_guidance_scale: 1.0
+      unconditional_prob: 0.1
+      train_expert_only: false
+      guidance_type: positive
+      positive_only_conditional: true
+
+  optim:
+    lr: 1.0e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 1.0e-10
+    clip_grad: 1.0
+    lr_scheduler: "cosine"
+    lr_warmup_steps: 5000
+    total_training_steps: 30000
+    min_lr: 0.0
+
+  fsdp_config:
+    strategy: "fsdp"
+    sharding_strategy: "no_shard"
+    use_orig_params: false
+    gradient_checkpointing: true
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+
+reward:
+  use_reward_model: false
+
+critic:
+  use_critic_model: false

--- a/examples/offline_rl/config/aloha_sandwich_recap_compute_advantages.yaml
+++ b/examples/offline_rl/config/aloha_sandwich_recap_compute_advantages.yaml
@@ -1,0 +1,49 @@
+# Usage:
+#   ALOHA_SANDWICH_VALUE_CHECKPOINT=/abs/path/to/value/checkpoint \
+#   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_advantages.sh aloha_sandwich_recap_compute_advantages --nproc 1
+
+defaults:
+  - model/recap_value_model@advantage.model
+
+advantage:
+  value_checkpoint: ${oc.env:ALOHA_SANDWICH_VALUE_CHECKPOINT}
+  batch_size: 1024
+  flush_interval: 256
+  num_dataloader_workers_per_gpu: 12
+  prefetch_factor: 2
+  discount_next_value: true
+  positive_quantile: 0.3
+  tag: sandwich_fail300_N10_q30_teleop
+  returns_tag: sandwich_fail300
+
+  model:
+    critic_expert_variant: "gemma_1m"
+    tokenizer_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m
+    siglip_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/siglip2-so400m-patch14-224
+    gemma3_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m
+
+data:
+  model_type: pi05
+
+  train_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      robot_type: aloha
+      type: rollout
+      weight: 1.0
+
+  advantage_lookahead_step: 10
+  gamma: 1.0
+
+distributed:
+  enabled: true
+  backend: "nccl"
+  timeout: 3600
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/offline_rl/config/
+  job:
+    chdir: false

--- a/examples/offline_rl/config/aloha_sandwich_recap_compute_returns.yaml
+++ b/examples/offline_rl/config/aloha_sandwich_recap_compute_returns.yaml
@@ -1,0 +1,22 @@
+# Usage:
+#   bash examples/offline_rl/advantage_labeling/recap/process/run_compute_returns.sh aloha_sandwich_recap_compute_returns
+
+data:
+  data_root: null
+  train_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      type: rollout
+
+  dataset_type: rollout
+  gamma: 1.0
+  failure_reward: -300.0
+  hitl_aware_returns: true
+  tag: sandwich_fail300
+  num_workers: 128
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  job:
+    chdir: false

--- a/examples/offline_rl/config/aloha_sandwich_recap_value_model_sft.yaml
+++ b/examples/offline_rl/config/aloha_sandwich_recap_value_model_sft.yaml
@@ -1,0 +1,112 @@
+# Usage:
+#   bash examples/offline_rl/advantage_labeling/recap/run_value_sft.sh aloha_sandwich_recap_value_model_sft
+
+defaults:
+  - model/recap_value_model@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - _self_
+  - override hydra/job_logging: stdout
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:REPO_PATH}/examples/offline_rl/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: all
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "../results/aloha_sandwich_value"
+    project_name: rlinf
+    experiment_name: "aloha_sandwich_value"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: 30000
+  max_steps: -1
+  val_check_interval: 500
+  save_interval: 3000
+
+data:
+  tag: sandwich_fail300
+
+  train_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      type: rollout
+      weight: 1.0
+      robot_type: aloha
+      model_type: pi05
+
+  eval_data_paths:
+    - dataset_path: /inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/aloha-data/sandwich_lerobot_v21
+      max_samples: 4096
+      robot_type: aloha
+      model_type: pi05
+
+  train_num_workers: 8
+  eval_num_workers: 4
+  prefetch_factor: 4
+  persistent_workers: false
+  pin_memory: false
+  include_state: true
+  gamma: 1.0
+  action_horizon: 10
+  normalize_to_minus_one_zero: true
+  include_next_obs: false
+  action_dim: 14
+  robot_type: aloha
+  model_type: pi05
+  balance_weights: true
+  seed: 42
+
+algorithm:
+  adv_type: gae
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 32
+  global_batch_size: 256
+  seed: 0
+
+  model:
+    precision: bf16
+    siglip_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/siglip2-so400m-patch14-224
+    gemma3_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m
+    tokenizer_path: /inspire/hdd/project/robot-reasoning/public/shared/hf-models/google/gemma-3-270m
+    freeze_vlm: false
+    action_dim: 14
+    action_horizon: 10
+
+  optim:
+    lr: 5.0e-5
+    value_lr: 1.0e-4
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 1e-10
+    clip_grad: 1.0
+    lr_scheduler: "constant"
+    lr_warmup_steps: 500
+    total_training_steps: 8000
+
+  fsdp_config:
+    strategy: "fsdp"
+    sharding_strategy: "no_shard"
+    use_orig_params: false
+    gradient_checkpointing: false
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}
+
+reward:
+  use_reward_model: false
+
+critic:
+  use_critic_model: false

--- a/examples/offline_rl/config/recap_compute_returns.yaml
+++ b/examples/offline_rl/config/recap_compute_returns.yaml
@@ -12,6 +12,7 @@ data:
   dataset_type: "sft"
   gamma: 1.0
   failure_reward: -300.0
+  hitl_aware_returns: false
   tag: null
   num_workers: 128
 

--- a/examples/offline_rl/data/__init__.py
+++ b/examples/offline_rl/data/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline RL data conversion utilities."""

--- a/examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py
+++ b/examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py
@@ -14,12 +14,21 @@
 
 """Convert ALOHA sandwich HITL HDF5 episodes to LeRobot v2.1."""
 
+import argparse
+import json
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import h5py
 import numpy as np
+from tqdm import tqdm
+
+try:
+    from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+except ImportError:  # pragma: no cover - exercised only when converter deps are absent
+    LeRobotDataset = None
 
 ALOHA_CAMERAS = ("cam_high", "cam_left_wrist", "cam_right_wrist")
 DEFAULT_TASK = "Assemble a sandwich."
@@ -289,3 +298,172 @@ def _build_hil_segments_entry(payload: EpisodePayload) -> dict[str, Any]:
         "is_success": bool(payload.is_success),
         "teleop_segments": payload.teleop_segments.astype(np.int64).tolist(),
     }
+
+
+def _discover_hdf5_files(raw_dir: Path) -> list[Path]:
+    """Return sorted ALOHA HDF5 episode files under ``raw_dir``."""
+    files = sorted([*raw_dir.glob("*.hdf5"), *raw_dir.glob("*.h5")])
+    if not files:
+        raise FileNotFoundError(f"No .hdf5 or .h5 episodes found under {raw_dir}")
+    return files
+
+
+def _is_relative_to(path: Path, other: Path) -> bool:
+    """Return whether ``path`` is equal to or nested under ``other``."""
+    try:
+        path.relative_to(other)
+    except ValueError:
+        return False
+    return True
+
+
+def _validate_output_path(raw_dir: Path, output_dir: Path) -> None:
+    """Reject output paths that overlap the raw input tree."""
+    if (
+        raw_dir == output_dir
+        or _is_relative_to(raw_dir, output_dir)
+        or _is_relative_to(output_dir, raw_dir)
+    ):
+        raise ValueError("output_dir must not overlap raw_dir")
+
+
+def _first_image_shape(first_episode: Path) -> tuple[int, int, int]:
+    """Read the first camera image shape from an episode."""
+    with h5py.File(first_episode, "r") as ep:
+        images = _read_images(ep, first_episode.name)
+    first = images[ALOHA_CAMERAS[0]]
+    return tuple(int(v) for v in first.shape[1:])
+
+
+def _episode_optional_fields(path: Path) -> dict[str, bool]:
+    """Return optional observation fields present in one episode."""
+    with h5py.File(path, "r") as ep:
+        return {
+            "observations/qvel": "observations/qvel" in ep,
+            "observations/effort": "observations/effort" in ep,
+        }
+
+
+def _infer_optional_fields(hdf5_files: list[Path]) -> tuple[bool, bool]:
+    """Infer optional observation fields, requiring consistency across episodes."""
+    field_sets = [_episode_optional_fields(path) for path in hdf5_files]
+    inferred: dict[str, bool] = {}
+    for key in ("observations/qvel", "observations/effort"):
+        values = {fields[key] for fields in field_sets}
+        if len(values) != 1:
+            raise ValueError(f"{key} inconsistent across ALOHA episodes")
+        inferred[key] = values.pop()
+    return inferred["observations/qvel"], inferred["observations/effort"]
+
+
+def _write_hil_segments(output_dir: Path, entries: list[dict[str, Any]]) -> None:
+    """Write JSON metadata for human-in-the-loop segments."""
+    total_frames = sum(int(entry["num_frames"]) for entry in entries)
+    successful = sum(1 for entry in entries if bool(entry["is_success"]))
+    data = {
+        "total_episodes": len(entries),
+        "total_frames": total_frames,
+        "successful_episodes": successful,
+        "failed_episodes": len(entries) - successful,
+        "episodes": entries,
+    }
+    meta_dir = output_dir / "meta"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    (meta_dir / "hil_segments.json").write_text(
+        json.dumps(data, indent=2),
+        encoding="utf-8",
+    )
+
+
+def convert_dataset(
+    raw_dir: Path,
+    output_dir: Path,
+    repo_id: str,
+    task: str = DEFAULT_TASK,
+    fps: int = 25,
+    overwrite: bool = False,
+    image_writer_threads: int = 5,
+    image_writer_processes: int = 10,
+) -> Any:
+    """Convert ALOHA sandwich HDF5 episodes into a LeRobot dataset."""
+    if LeRobotDataset is None:
+        raise ImportError("lerobot is required to run ALOHA HDF5 conversion")
+
+    raw_dir = raw_dir.resolve()
+    output_dir = output_dir.resolve()
+    _validate_output_path(raw_dir, output_dir)
+    hdf5_files = _discover_hdf5_files(raw_dir)
+    include_velocity, include_effort = _infer_optional_fields(hdf5_files)
+
+    if output_dir.exists():
+        if not overwrite:
+            raise FileExistsError(
+                f"Output directory exists: {output_dir}. "
+                "Pass --overwrite to replace it."
+            )
+        shutil.rmtree(output_dir)
+
+    features = _aloha_features(
+        image_shape=_first_image_shape(hdf5_files[0]),
+        include_velocity=include_velocity,
+        include_effort=include_effort,
+    )
+    dataset = LeRobotDataset.create(
+        repo_id=repo_id,
+        root=output_dir,
+        robot_type="aloha",
+        fps=fps,
+        features=features,
+        image_writer_threads=image_writer_threads,
+        image_writer_processes=image_writer_processes,
+    )
+
+    metadata_entries: list[dict[str, Any]] = []
+    for episode_index, episode_path in enumerate(
+        tqdm(hdf5_files, desc="Converting ALOHA episodes")
+    ):
+        payload = _load_episode_payload(
+            episode_path,
+            task=task,
+            episode_index=episode_index,
+        )
+        for frame in payload.frames:
+            dataset.add_frame(frame)
+        dataset.save_episode()
+        metadata_entries.append(_build_hil_segments_entry(payload))
+
+    _write_hil_segments(output_dir, metadata_entries)
+    return dataset
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--repo-id", type=str, default="local/aloha_sandwich")
+    parser.add_argument("--task", type=str, default=DEFAULT_TASK)
+    parser.add_argument("--fps", type=int, default=25)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--image-writer-threads", type=int, default=5)
+    parser.add_argument("--image-writer-processes", type=int, default=10)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the ALOHA HDF5 to LeRobot converter CLI."""
+    args = _parse_args()
+    convert_dataset(
+        raw_dir=args.raw_dir,
+        output_dir=args.output_dir,
+        repo_id=args.repo_id,
+        task=args.task,
+        fps=args.fps,
+        overwrite=args.overwrite,
+        image_writer_threads=args.image_writer_threads,
+        image_writer_processes=args.image_writer_processes,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py
+++ b/examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py
@@ -18,11 +18,13 @@ import argparse
 import json
 import shutil
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 
 import h5py
 import numpy as np
+from PIL import Image
 from tqdm import tqdm
 
 try:
@@ -166,6 +168,62 @@ def _read_teleop_segments(ep: h5py.File) -> np.ndarray:
     return segments
 
 
+def _decode_image_frame(
+    encoded: Any,
+    episode_name: str,
+    camera: str,
+    frame_idx: int,
+) -> np.ndarray:
+    """Decode one encoded RGB camera frame into a uint8 image array."""
+    if isinstance(encoded, np.ndarray):
+        if encoded.shape == ():
+            encoded = encoded.item()
+        else:
+            encoded = encoded.tobytes()
+    elif isinstance(encoded, np.void):
+        encoded = encoded.tobytes()
+
+    encoded_bytes = bytes(encoded).rstrip(b"\x00")
+    try:
+        with Image.open(BytesIO(encoded_bytes)) as image:
+            frame = np.asarray(image.convert("RGB"), dtype=np.uint8)
+    except Exception as exc:
+        raise ValueError(
+            f"{episode_name}: failed to decode camera {camera} frame {frame_idx}"
+        ) from exc
+
+    if frame.ndim != 3 or frame.shape[-1] != 3:
+        raise ValueError(
+            f"{episode_name}: decoded camera {camera} frame {frame_idx} must have "
+            f"shape (H, W, 3), got {frame.shape}"
+        )
+    return frame
+
+
+def _read_encoded_camera_stream(
+    camera_stream: h5py.Dataset,
+    episode_name: str,
+    camera: str,
+) -> np.ndarray:
+    """Decode a one-dimensional stream of encoded camera frames."""
+    frames = [
+        _decode_image_frame(encoded, episode_name, camera, frame_idx)
+        for frame_idx, encoded in enumerate(camera_stream)
+    ]
+    if not frames:
+        raise ValueError(f"{episode_name}: camera {camera} has no frames")
+
+    reference_shape = frames[0].shape
+    for frame_idx, frame in enumerate(frames[1:], start=1):
+        if frame.shape != reference_shape:
+            raise ValueError(
+                f"{episode_name}: decoded camera {camera} frame {frame_idx} "
+                f"shape {frame.shape} does not match {reference_shape}"
+            )
+
+    return np.stack(frames, axis=0)
+
+
 def _read_images(ep: h5py.File, episode_name: str) -> dict[str, np.ndarray]:
     """Read all required ALOHA camera streams from an episode."""
     if "observations" not in ep or "images" not in ep["observations"]:
@@ -177,7 +235,15 @@ def _read_images(ep: h5py.File, episode_name: str) -> dict[str, np.ndarray]:
     for camera in ALOHA_CAMERAS:
         if camera not in images_group:
             raise ValueError(f"{episode_name}: missing camera {camera}")
-        camera_images = np.asarray(images_group[camera])
+        camera_stream = images_group[camera]
+        if camera_stream.ndim == 1 and camera_stream.dtype.kind in {"O", "S"}:
+            camera_images = _read_encoded_camera_stream(
+                camera_stream,
+                episode_name,
+                camera,
+            )
+        else:
+            camera_images = np.asarray(camera_stream)
         if camera_images.ndim != 4 or camera_images.shape[-1] != 3:
             raise ValueError(
                 f"{episode_name}: camera {camera} must have shape (T, H, W, 3), "

--- a/examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py
+++ b/examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py
@@ -1,0 +1,291 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert ALOHA sandwich HITL HDF5 episodes to LeRobot v2.1."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+ALOHA_CAMERAS = ("cam_high", "cam_left_wrist", "cam_right_wrist")
+DEFAULT_TASK = "Assemble a sandwich."
+
+
+@dataclass(frozen=True)
+class EpisodePayload:
+    """In-memory representation of one ALOHA HDF5 episode."""
+
+    episode_index: int
+    episode_name: str
+    raw_reward: float
+    teleop_segments: np.ndarray
+    frames: list[dict[str, Any]]
+
+    @property
+    def num_frames(self) -> int:
+        """Return the number of frames in the episode."""
+        return len(self.frames)
+
+    @property
+    def is_success(self) -> bool:
+        """Return whether the episode reward indicates task success."""
+        return bool(self.raw_reward > 0.0)
+
+
+def _aloha_features(
+    image_shape: tuple[int, int, int],
+    include_velocity: bool,
+    include_effort: bool,
+) -> dict[str, dict[str, Any]]:
+    """Build LeRobot feature metadata for ALOHA sandwich episodes."""
+    features: dict[str, dict[str, Any]] = {
+        "observation.state": {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": ["state"],
+        },
+        "action": {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": ["action"],
+        },
+        "is_success": {
+            "dtype": "bool",
+            "shape": (1,),
+            "names": ["is_success"],
+        },
+        "teleop_mask": {
+            "dtype": "int64",
+            "shape": (1,),
+            "names": ["teleop_mask"],
+        },
+    }
+
+    for camera in ALOHA_CAMERAS:
+        features[f"observation.images.{camera}"] = {
+            "dtype": "image",
+            "shape": tuple(image_shape),
+            "names": ["height", "width", "channel"],
+        }
+
+    if include_velocity:
+        features["observation.velocity"] = {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": ["velocity"],
+        }
+    if include_effort:
+        features["observation.effort"] = {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": ["effort"],
+        }
+
+    return features
+
+
+def _episode_success_array(raw_reward: float, num_frames: int) -> np.ndarray:
+    """Return a per-frame success flag derived from an episode reward."""
+    return np.full(num_frames, raw_reward > 0.0, dtype=bool)
+
+
+def _teleop_mask(
+    segments: np.ndarray,
+    num_frames: int,
+    episode_name: str,
+) -> np.ndarray:
+    """Convert half-open teleoperation segments into a per-frame mask."""
+    segments = np.asarray(segments, dtype=np.int64)
+    if segments.size == 0:
+        segments = segments.reshape(0, 2)
+    if segments.ndim != 2 or segments.shape[1] != 2:
+        raise ValueError(
+            f"{episode_name}: invalid teleop segment array shape {segments.shape}"
+        )
+
+    mask = np.zeros(num_frames, dtype=np.int64)
+    for start, end in segments:
+        if start < 0 or end <= start or end > num_frames:
+            raise ValueError(
+                f"{episode_name}: invalid teleop segment [{start}, {end}) "
+                f"for {num_frames} frames"
+            )
+        mask[start:end] = 1
+    return mask
+
+
+def _read_scalar_reward(ep: h5py.File, episode_name: str) -> float:
+    """Read the scalar reward from an ALOHA HDF5 episode."""
+    if "reward" not in ep:
+        raise ValueError(f"{episode_name}: missing reward dataset")
+
+    reward = np.asarray(ep["reward"][()])
+    if reward.shape == ():
+        return float(reward)
+    if reward.shape == (1,):
+        return float(reward[0])
+
+    raise ValueError(
+        f"{episode_name}: reward must be scalar or shape (1,), got {reward.shape}"
+    )
+
+
+def _read_teleop_segments(ep: h5py.File) -> np.ndarray:
+    """Read teleoperation segments as an ``(N, 2)`` int64 array."""
+    if "teleop_segments" not in ep:
+        return np.empty((0, 2), dtype=np.int64)
+
+    segments = np.asarray(ep["teleop_segments"], dtype=np.int64)
+    if segments.size == 0:
+        return segments.reshape(0, 2)
+    if segments.ndim == 1 and segments.shape == (2,):
+        return segments.reshape(1, 2)
+    return segments
+
+
+def _read_images(ep: h5py.File, episode_name: str) -> dict[str, np.ndarray]:
+    """Read all required ALOHA camera streams from an episode."""
+    if "observations" not in ep or "images" not in ep["observations"]:
+        raise ValueError(f"{episode_name}: missing observations/images group")
+
+    images_group = ep["observations"]["images"]
+    images: dict[str, np.ndarray] = {}
+    reference_shape: tuple[int, int, int, int] | None = None
+    for camera in ALOHA_CAMERAS:
+        if camera not in images_group:
+            raise ValueError(f"{episode_name}: missing camera {camera}")
+        camera_images = np.asarray(images_group[camera])
+        if camera_images.ndim != 4 or camera_images.shape[-1] != 3:
+            raise ValueError(
+                f"{episode_name}: camera {camera} must have shape (T, H, W, 3), "
+                f"got {camera_images.shape}"
+            )
+        if reference_shape is None:
+            reference_shape = camera_images.shape
+        elif camera_images.shape != reference_shape:
+            raise ValueError(
+                f"{episode_name}: camera {camera} shape {camera_images.shape} "
+                f"does not match {reference_shape}"
+            )
+        images[camera] = camera_images
+
+    return images
+
+
+def _load_episode_payload(
+    episode_path: Path,
+    task: str,
+    episode_index: int = 0,
+) -> EpisodePayload:
+    """Load one ALOHA sandwich HDF5 episode into frame dictionaries."""
+    episode_path = Path(episode_path)
+    episode_name = episode_path.name
+
+    with h5py.File(episode_path, "r") as ep:
+        if "observations" not in ep:
+            raise ValueError(f"{episode_name}: missing observations group")
+        if "action" not in ep:
+            raise ValueError(f"{episode_name}: missing action dataset")
+
+        observations = ep["observations"]
+        if "qpos" not in observations:
+            raise ValueError(f"{episode_name}: missing observations/qpos dataset")
+
+        state = np.asarray(observations["qpos"], dtype=np.float32)
+        action = np.asarray(ep["action"], dtype=np.float32)
+        velocity = (
+            np.asarray(observations["qvel"], dtype=np.float32)
+            if "qvel" in observations
+            else None
+        )
+        effort = (
+            np.asarray(observations["effort"], dtype=np.float32)
+            if "effort" in observations
+            else None
+        )
+        raw_reward = _read_scalar_reward(ep, episode_name)
+        teleop_segments = _read_teleop_segments(ep)
+        images = _read_images(ep, episode_name)
+
+    if state.ndim != 2 or state.shape[1] != 14:
+        raise ValueError(
+            f"{episode_name}: observations/qpos must have shape (T, 14), "
+            f"got {state.shape}"
+        )
+    if action.shape != state.shape:
+        raise ValueError(
+            f"{episode_name}: action shape {action.shape} does not match "
+            f"state shape {state.shape}"
+        )
+
+    num_frames = state.shape[0]
+    for name, optional_array in (
+        ("observations/qvel", velocity),
+        ("observations/effort", effort),
+    ):
+        if optional_array is not None and optional_array.shape != state.shape:
+            raise ValueError(
+                f"{episode_name}: {name} shape {optional_array.shape} does not "
+                f"match state shape {state.shape}"
+            )
+
+    for camera, camera_images in images.items():
+        if camera_images.shape[0] != num_frames:
+            raise ValueError(
+                f"{episode_name}: camera {camera} has {camera_images.shape[0]} "
+                f"frames, expected {num_frames}"
+            )
+
+    success = _episode_success_array(raw_reward, num_frames)
+    teleop = _teleop_mask(teleop_segments, num_frames, episode_name)
+
+    frames: list[dict[str, Any]] = []
+    for frame_idx in range(num_frames):
+        frame: dict[str, Any] = {
+            "task": task,
+            "is_success": np.asarray([success[frame_idx]], dtype=bool),
+            "teleop_mask": np.asarray([teleop[frame_idx]], dtype=np.int64),
+            "observation.state": state[frame_idx],
+            "action": action[frame_idx],
+        }
+        if velocity is not None:
+            frame["observation.velocity"] = velocity[frame_idx]
+        if effort is not None:
+            frame["observation.effort"] = effort[frame_idx]
+        for camera, camera_images in images.items():
+            frame[f"observation.images.{camera}"] = camera_images[frame_idx]
+        frames.append(frame)
+
+    return EpisodePayload(
+        episode_index=episode_index,
+        episode_name=episode_name,
+        raw_reward=raw_reward,
+        teleop_segments=teleop_segments,
+        frames=frames,
+    )
+
+
+def _build_hil_segments_entry(payload: EpisodePayload) -> dict[str, Any]:
+    """Build a JSON-serializable HIL segment metadata entry."""
+    return {
+        "episode_index": int(payload.episode_index),
+        "episode_name": payload.episode_name,
+        "num_frames": int(payload.num_frames),
+        "raw_reward": float(payload.raw_reward),
+        "is_success": bool(payload.is_success),
+        "teleop_segments": payload.teleop_segments.astype(np.int64).tolist(),
+    }

--- a/examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py
+++ b/examples/offline_rl/data/convert_aloha_hdf5_to_lerobot_v21.py
@@ -206,22 +206,30 @@ def _read_encoded_camera_stream(
     camera: str,
 ) -> np.ndarray:
     """Decode a one-dimensional stream of encoded camera frames."""
-    frames = [
-        _decode_image_frame(encoded, episode_name, camera, frame_idx)
-        for frame_idx, encoded in enumerate(camera_stream)
-    ]
-    if not frames:
+    num_frames = int(camera_stream.shape[0])
+    if num_frames == 0:
         raise ValueError(f"{episode_name}: camera {camera} has no frames")
 
-    reference_shape = frames[0].shape
-    for frame_idx, frame in enumerate(frames[1:], start=1):
+    first_frame = _decode_image_frame(camera_stream[0], episode_name, camera, 0)
+    reference_shape = first_frame.shape
+    frames = np.empty((num_frames, *reference_shape), dtype=first_frame.dtype)
+    frames[0] = first_frame
+
+    for frame_idx in range(1, num_frames):
+        frame = _decode_image_frame(
+            camera_stream[frame_idx],
+            episode_name,
+            camera,
+            frame_idx,
+        )
         if frame.shape != reference_shape:
             raise ValueError(
                 f"{episode_name}: decoded camera {camera} frame {frame_idx} "
                 f"shape {frame.shape} does not match {reference_shape}"
             )
+        frames[frame_idx] = frame
 
-    return np.stack(frames, axis=0)
+    return frames
 
 
 def _read_images(ep: h5py.File, episode_name: str) -> dict[str, np.ndarray]:
@@ -236,7 +244,7 @@ def _read_images(ep: h5py.File, episode_name: str) -> dict[str, np.ndarray]:
         if camera not in images_group:
             raise ValueError(f"{episode_name}: missing camera {camera}")
         camera_stream = images_group[camera]
-        if camera_stream.ndim == 1 and camera_stream.dtype.kind in {"O", "S"}:
+        if camera_stream.ndim == 1 and camera_stream.dtype.kind in {"O", "S", "V"}:
             camera_images = _read_encoded_camera_stream(
                 camera_stream,
                 episode_name,

--- a/examples/sft/config/sandwich_new_all_sft_openpi_pi05.yaml
+++ b/examples/sft/config/sandwich_new_all_sft_openpi_pi05.yaml
@@ -1,0 +1,79 @@
+defaults:
+  - model/pi0_5@actor.model
+  - training_backend/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+  - _self_
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor: 0
+
+runner:
+  task_type: sft
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "sandwich_new_all_pi05_sft"
+    logger_backends: ["tensorboard"]
+
+  max_epochs: -1
+  max_steps: 20000
+  val_check_interval: -1
+  save_interval: 5000
+
+data:
+  train_data_paths: "/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/RLinf/ocl-data/lerobot-data/sandwich_new_all"
+
+actor:
+  group_name: "ActorGroup"
+  training_backend: "fsdp"
+  micro_batch_size: 1
+  global_batch_size: 8
+  seed: 0
+  openpi_data:
+    repo_id: "pi05_sandwich_new_all"
+
+  model:
+    precision: null
+    model_path: "/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi/checkpoints/torch/pi05_sandwich_new_all_rlinf_base"
+    num_action_chunks: 50
+    action_dim: 14
+    add_value_head: False
+    openpi:
+      config_name: "pi05_aloha_robotwin"
+      detach_critic_input: True
+      num_images_in_input: 3
+      train_expert_only: True
+    openpi_data:
+      repo_id: "pi05_sandwich_new_all"
+
+  optim:
+    lr: 2.5e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-08
+    weight_decay: 1e-10
+    clip_grad: 1.0
+    total_training_steps: 20000
+    lr_warmup_steps: 1000
+    lr_scheduler: "cosine"
+    num_cycles: 0.5
+    min_lr: 2.5e-6
+
+  fsdp_config:
+    strategy: "fsdp"
+    sharding_strategy: "no_shard"
+    use_orig_params: False
+    gradient_checkpointing: False
+    mixed_precision:
+      param_dtype: ${actor.model.precision}
+      reduce_dtype: ${actor.model.precision}
+      buffer_dtype: ${actor.model.precision}

--- a/examples/sft/run_sandwich_new_all_pi05_sft.sh
+++ b/examples/sft/run_sandwich_new_all_pi05_sft.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproduce the pi0.5 SFT flow for ocl-data/lerobot-data/sandwich_new_all.
+#
+# Common usage:
+#   bash examples/sft/run_sandwich_new_all_pi05_sft.sh
+#   SMOKE=1 bash examples/sft/run_sandwich_new_all_pi05_sft.sh
+#   RUN_STEPS=5000 SAVE_INTERVAL=1000 bash examples/sft/run_sandwich_new_all_pi05_sft.sh
+#   RESTART=1 bash examples/sft/run_sandwich_new_all_pi05_sft.sh
+#   DRY_RUN=1 bash examples/sft/run_sandwich_new_all_pi05_sft.sh
+
+EMBODIED_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_PATH="$(cd "${EMBODIED_PATH}/../.." && pwd)"
+SRC_FILE="${EMBODIED_PATH}/train_vla_sft.py"
+
+CONFIG_NAME="${CONFIG_NAME:-sandwich_new_all_sft_openpi_pi05}"
+PYTHON_BIN="${PYTHON_BIN:-${REPO_PATH}/.venv/bin/python}"
+RAY_BIN="${RAY_BIN:-${REPO_PATH}/.venv/bin/ray}"
+
+DATASET_PATH="${DATASET_PATH:-${REPO_PATH}/ocl-data/lerobot-data/sandwich_new_all}"
+OPENPI_ROOT="${OPENPI_ROOT:-/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun/openpi}"
+JAX_PI05_CKPT="${JAX_PI05_CKPT:-${OPENPI_ROOT}/models/pi05_base}"
+TORCH_PI05_CKPT="${TORCH_PI05_CKPT:-${OPENPI_ROOT}/checkpoints/torch/pi05_sandwich_new_all_rlinf_base}"
+ASSET_ID="${ASSET_ID:-pi05_sandwich_new_all}"
+NORM_STATS_SRC="${NORM_STATS_SRC:-${OPENPI_ROOT}/assets/${ASSET_ID}/${ASSET_ID}/norm_stats.json}"
+
+# The ffmpeg used successfully for this run is in this conda env. Only PATH is
+# prepended to avoid leaking conda shared libraries into the RLinf venv.
+CONDA_FFMPEG_ENV="${CONDA_FFMPEG_ENV:-/inspire/qb-ilm/project/robot-reasoning/czxs253130583/yushun-home/miniforge3/envs/yushun-openpi}"
+
+RAY_SESSION="${RAY_SESSION:-rlinf_ray_sft}"
+TRAIN_SESSION="${TRAIN_SESSION:-rlinf_sandwich_pi05_sft}"
+RAY_ADDRESS="${RAY_ADDRESS:-127.0.0.1:6379}"
+RAY_NODE_IP="${RAY_NODE_IP:-127.0.0.1}"
+RAY_NUM_GPUS="${RAY_NUM_GPUS:-1}"
+
+RUN_STEPS="${RUN_STEPS:-20000}"
+SAVE_INTERVAL="${SAVE_INTERVAL:-5000}"
+EXPERIMENT_NAME="${EXPERIMENT_NAME:-sandwich_new_all_pi05_sft}"
+INSTALL_DEPS="${INSTALL_DEPS:-0}"
+RESTART="${RESTART:-0}"
+DRY_RUN="${DRY_RUN:-0}"
+SMOKE="${SMOKE:-0}"
+SMOKE_STEPS="${SMOKE_STEPS:-1}"
+
+if [[ "${SMOKE}" == "1" ]]; then
+  RUN_STEPS="${SMOKE_STEPS}"
+  SAVE_INTERVAL="1"
+  EXPERIMENT_NAME="${EXPERIMENT_NAME}_smoke"
+  TRAIN_SESSION="${TRAIN_SESSION}_smoke"
+fi
+
+RUN_LOG_DIR="${RUN_LOG_DIR:-${REPO_PATH}/logs/${CONFIG_NAME}_$(date +%Y%m%d-%H%M%S)}"
+RUN_LOG_FILE="${RUN_LOG_FILE:-${RUN_LOG_DIR}/run.log}"
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+quote_args() {
+  printf "%q " "$@"
+}
+
+ray_status() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 10 env RAY_ADDRESS="${RAY_ADDRESS}" "${RAY_BIN}" status >/dev/null 2>&1
+  else
+    env RAY_ADDRESS="${RAY_ADDRESS}" "${RAY_BIN}" status >/dev/null 2>&1
+  fi
+}
+
+configure_env() {
+  if [[ -d "${CONDA_FFMPEG_ENV}/bin" ]]; then
+    export PATH="${CONDA_FFMPEG_ENV}/bin:${PATH}"
+  fi
+
+  export EMBODIED_PATH
+  export REPO_PATH
+  export SRC_FILE
+  export RAY_ADDRESS
+  export MUJOCO_GL="${MUJOCO_GL:-egl}"
+  export PYOPENGL_PLATFORM="${PYOPENGL_PLATFORM:-egl}"
+  export HYDRA_FULL_ERROR="${HYDRA_FULL_ERROR:-1}"
+
+  if [[ -n "${PYTHONPATH:-}" ]]; then
+    export PYTHONPATH="${REPO_PATH}:${PYTHONPATH}"
+  else
+    export PYTHONPATH="${REPO_PATH}"
+  fi
+}
+
+ensure_prereqs() {
+  if [[ "${INSTALL_DEPS}" == "1" ]]; then
+    bash "${REPO_PATH}/requirements/install.sh" embodied \
+      --model openpi \
+      --env maniskill_libero \
+      --no-root \
+      --no-flash-attn
+  fi
+
+  [[ -x "${PYTHON_BIN}" ]] || die "missing ${PYTHON_BIN}; run INSTALL_DEPS=1 $0 first, or run requirements/install.sh manually"
+  [[ -x "${RAY_BIN}" ]] || die "missing ${RAY_BIN}; check the RLinf .venv install"
+  [[ -f "${SRC_FILE}" ]] || die "missing ${SRC_FILE}"
+  [[ -d "${DATASET_PATH}" ]] || die "missing dataset: ${DATASET_PATH}"
+  command -v tmux >/dev/null 2>&1 || die "tmux is required for Ray/training sessions"
+}
+
+ensure_huggingface_hub_pin() {
+  local current_version
+  current_version="$("${PYTHON_BIN}" - <<'PY'
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    print(version("huggingface-hub"))
+except PackageNotFoundError:
+    print("")
+PY
+)"
+
+  if [[ "${current_version}" == "0.36.2" ]]; then
+    return
+  fi
+
+  echo "Pinning huggingface-hub to 0.36.2 for transformers compatibility (current: ${current_version:-missing})"
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install --python "${PYTHON_BIN}" "huggingface-hub==0.36.2"
+  else
+    "${PYTHON_BIN}" -m pip install "huggingface-hub==0.36.2"
+  fi
+}
+
+ensure_checkpoint() {
+  if [[ ! -f "${TORCH_PI05_CKPT}/model.safetensors" ]]; then
+    [[ -d "${JAX_PI05_CKPT}" ]] || die "missing JAX pi0.5 checkpoint: ${JAX_PI05_CKPT}"
+    mkdir -p "$(dirname "${TORCH_PI05_CKPT}")"
+    echo "Converting JAX pi0.5 checkpoint to RLinf PyTorch checkpoint: ${TORCH_PI05_CKPT}"
+    JAX_PLATFORMS=cpu CUDA_VISIBLE_DEVICES= \
+      "${PYTHON_BIN}" "${REPO_PATH}/rlinf/utils/ckpt_convertor/convert_openpi_jax_to_python.py" \
+        --checkpoint-dir "${JAX_PI05_CKPT}" \
+        --config-name pi05_aloha \
+        --output-path "${TORCH_PI05_CKPT}" \
+        --precision bfloat16
+  fi
+
+  local norm_stats_dst="${TORCH_PI05_CKPT}/${ASSET_ID}/norm_stats.json"
+  if [[ ! -f "${norm_stats_dst}" ]]; then
+    [[ -f "${NORM_STATS_SRC}" ]] || die "missing norm stats: ${NORM_STATS_SRC}"
+    mkdir -p "$(dirname "${norm_stats_dst}")"
+    cp "${NORM_STATS_SRC}" "${norm_stats_dst}"
+  fi
+}
+
+start_ray() {
+  if ray_status; then
+    echo "Ray is already available at ${RAY_ADDRESS}"
+    return
+  fi
+
+  if tmux has-session -t "${RAY_SESSION}" 2>/dev/null; then
+    die "tmux session ${RAY_SESSION} exists but Ray is not ready; inspect it with: tmux attach -t ${RAY_SESSION}"
+  fi
+
+  mkdir -p "${REPO_PATH}/logs"
+  local ray_log="${REPO_PATH}/logs/ray_sft_$(date +%Y%m%d-%H%M%S).log"
+  local ray_cmd
+  ray_cmd="cd $(printf "%q" "${REPO_PATH}") && $(printf "%q" "${RAY_BIN}") start --head --node-ip-address=$(printf "%q" "${RAY_NODE_IP}") --num-gpus=$(printf "%q" "${RAY_NUM_GPUS}") --include-dashboard=false --block 2>&1 | tee $(printf "%q" "${ray_log}")"
+
+  echo "Starting Ray in tmux session ${RAY_SESSION}"
+  tmux new-session -d -s "${RAY_SESSION}" "${ray_cmd}"
+
+  for _ in $(seq 1 60); do
+    if ray_status; then
+      echo "Ray is ready at ${RAY_ADDRESS}"
+      return
+    fi
+    sleep 1
+  done
+
+  die "Ray did not become ready; inspect logs with: tmux attach -t ${RAY_SESSION}"
+}
+
+build_train_cmd() {
+  TRAIN_CMD=(
+    "${PYTHON_BIN}"
+    "${SRC_FILE}"
+    --config-name
+    "${CONFIG_NAME}"
+    "runner.logger.log_path=${RUN_LOG_DIR}"
+    "runner.logger.experiment_name=${EXPERIMENT_NAME}"
+    "runner.max_steps=${RUN_STEPS}"
+    "runner.save_interval=${SAVE_INTERVAL}"
+    "actor.optim.total_training_steps=${RUN_STEPS}"
+    "data.train_data_paths=${DATASET_PATH}"
+    "actor.model.model_path=${TORCH_PI05_CKPT}"
+    "actor.openpi_data.repo_id=${ASSET_ID}"
+    "actor.model.openpi_data.repo_id=${ASSET_ID}"
+  )
+}
+
+start_training() {
+  mkdir -p "${RUN_LOG_DIR}"
+
+  local quoted_cmd
+  quoted_cmd="$(quote_args "${TRAIN_CMD[@]}")"
+
+  {
+    echo "# started: $(date -Is)"
+    echo "# repo: ${REPO_PATH}"
+    echo "# command:"
+    echo "${quoted_cmd}"
+  } >"${RUN_LOG_FILE}"
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    echo "DRY_RUN=1; no process was started."
+    echo "Training command:"
+    echo "${quoted_cmd}"
+    return
+  fi
+
+  if tmux has-session -t "${TRAIN_SESSION}" 2>/dev/null; then
+    if [[ "${RESTART}" == "1" ]]; then
+      tmux kill-session -t "${TRAIN_SESSION}"
+    else
+      echo "Training tmux session already exists: ${TRAIN_SESSION}"
+      echo "Attach with: tmux attach -t ${TRAIN_SESSION}"
+      echo "Use RESTART=1 to kill that session and start a new run."
+      return
+    fi
+  fi
+
+  local tmux_cmd
+  tmux_cmd="cd $(printf "%q" "${REPO_PATH}") && export PATH=$(printf "%q" "${PATH}") PYTHONPATH=$(printf "%q" "${PYTHONPATH}") EMBODIED_PATH=$(printf "%q" "${EMBODIED_PATH}") REPO_PATH=$(printf "%q" "${REPO_PATH}") SRC_FILE=$(printf "%q" "${SRC_FILE}") RAY_ADDRESS=$(printf "%q" "${RAY_ADDRESS}") MUJOCO_GL=$(printf "%q" "${MUJOCO_GL}") PYOPENGL_PLATFORM=$(printf "%q" "${PYOPENGL_PLATFORM}") HYDRA_FULL_ERROR=$(printf "%q" "${HYDRA_FULL_ERROR}") && ${quoted_cmd} 2>&1 | tee -a $(printf "%q" "${RUN_LOG_FILE}")"
+
+  tmux new-session -d -s "${TRAIN_SESSION}" "${tmux_cmd}"
+
+  echo "Started training in tmux session: ${TRAIN_SESSION}"
+  echo "Attach: tmux attach -t ${TRAIN_SESSION}"
+  echo "Log: ${RUN_LOG_FILE}"
+  echo "TensorBoard log root: ${RUN_LOG_DIR}"
+}
+
+main() {
+  configure_env
+  build_train_cmd
+
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    start_training
+    return
+  fi
+
+  ensure_prereqs
+  ensure_huggingface_hub_pin
+  ensure_checkpoint
+  start_ray
+  start_training
+}
+
+main "$@"

--- a/rlinf/data/datasets/recap/utils.py
+++ b/rlinf/data/datasets/recap/utils.py
@@ -99,16 +99,22 @@ def load_returns_sidecar(
     frame_col = table.column("frame_index").to_numpy()
     ret_col = table.column("return").to_numpy()
     rew_col = table.column("reward").to_numpy()
+    done_col = None
+    if "done" in table.column_names:
+        done_col = np.asarray(table.column("done").to_pylist(), dtype=bool)
 
     sidecar: dict[int, dict[str, np.ndarray]] = {}
     for ep in np.unique(ep_col):
         mask = ep_col == ep
         frames = frame_col[mask]
         order = np.argsort(frames)
-        sidecar[int(ep)] = {
+        ep_data = {
             "return": ret_col[mask][order].astype(np.float32),
             "reward": rew_col[mask][order].astype(np.float32),
         }
+        if done_col is not None:
+            ep_data["done"] = done_col[mask][order].astype(bool, copy=False)
+        sidecar[int(ep)] = ep_data
 
     logger.info(f"Loaded returns sidecar: {sidecar_path} ({len(sidecar)} episodes)")
     return sidecar

--- a/rlinf/data/datasets/recap/value_dataset.py
+++ b/rlinf/data/datasets/recap/value_dataset.py
@@ -33,7 +33,11 @@ from lerobot.common.datasets.lerobot_dataset import (
 from openpi.transforms import DataTransformFn
 from torch.utils.data import Dataset
 
-from rlinf.models.embodiment.openpi.policies import franka_policy, libero_policy
+from rlinf.models.embodiment.openpi.policies import (
+    aloha_policy,
+    franka_policy,
+    libero_policy,
+)
 
 from .common import BaseDataLoaderImpl, ReCapMixtureDataset
 from .utils import (
@@ -62,6 +66,16 @@ _REPACK_KEYS = {
         "observation/image": "observation.images.image",
         "observation/wrist_image": "observation.images.wrist_image",
         "observation/state": "observation.state",
+        "actions": "action",
+        "prompt": "prompt",
+    },
+    "aloha": {
+        "images": {
+            "cam_high": "observation.images.cam_high",
+            "cam_left_wrist": "observation.images.cam_left_wrist",
+            "cam_right_wrist": "observation.images.cam_right_wrist",
+        },
+        "state": "observation.state",
         "actions": "action",
         "prompt": "prompt",
     },
@@ -318,6 +332,8 @@ class ValueDataset(Dataset):
             transforms_list.append(
                 libero_policy.LiberoInputs(model_type=model_type_enum)
             )
+        elif robot == "aloha":
+            transforms_list.append(aloha_policy.AlohaInputs(adapt_to_pi=True))
         elif robot in ("franka", "franka_co_train"):
             transforms_list.append(
                 franka_policy.FrankaEEInputs(

--- a/rlinf/models/embodiment/value_model/recap/checkpoint_utils.py
+++ b/rlinf/models/embodiment/value_model/recap/checkpoint_utils.py
@@ -151,7 +151,11 @@ def build_input_transforms(
     import openpi.models.model as _openpi_model
     import openpi.transforms as _openpi_transforms
 
-    from rlinf.models.embodiment.openpi.policies import franka_policy, libero_policy
+    from rlinf.models.embodiment.openpi.policies import (
+        aloha_policy,
+        franka_policy,
+        libero_policy,
+    )
 
     _mt_map = {
         "pi0": _openpi_model.ModelType.PI0,
@@ -165,6 +169,10 @@ def build_input_transforms(
     if env_type == "libero":
         input_transforms.append(_openpi_transforms.InjectDefaultPrompt(default_prompt))
         input_transforms.append(libero_policy.LiberoInputs(model_type=model_type_enum))
+
+    elif env_type == "aloha":
+        input_transforms.append(_openpi_transforms.InjectDefaultPrompt(default_prompt))
+        input_transforms.append(aloha_policy.AlohaInputs(adapt_to_pi=True))
 
     elif env_type in ("franka", "franka_co_train"):
         input_transforms.append(_openpi_transforms.InjectDefaultPrompt(default_prompt))

--- a/tests/unit_tests/test_aloha_recap_converter.py
+++ b/tests/unit_tests/test_aloha_recap_converter.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 import json
+from io import BytesIO
 from pathlib import Path
 
 import h5py
 import numpy as np
 import pytest
+from PIL import Image
 
 from examples.offline_rl.data.convert_aloha_hdf5_to_lerobot_v21 import (
     _aloha_features,
@@ -58,6 +60,13 @@ def _write_episode(
                 name,
                 data=np.zeros((4, 8, 8, 3), dtype=np.uint8),
             )
+
+
+def _jpeg_bytes(color: tuple[int, int, int]) -> bytes:
+    image = Image.new("RGB", (5, 4), color=color)
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
 
 
 def test_teleop_mask_maps_half_open_segments() -> None:
@@ -179,6 +188,30 @@ def test_read_images_rejects_invalid_camera_shape(tmp_path: Path) -> None:
     with h5py.File(episode_path, "r") as ep:
         with pytest.raises(ValueError, match=r"shape \(T, H, W, 3\)"):
             _read_images(ep, "bad_camera_shape.hdf5")
+
+
+def test_read_images_decodes_fixed_width_jpeg_camera_streams(
+    tmp_path: Path,
+) -> None:
+    episode_path = tmp_path / "encoded_camera_images.hdf5"
+    _write_episode(episode_path)
+    encoded_frames = np.asarray(
+        [_jpeg_bytes((20, 40, 60)), _jpeg_bytes((80, 100, 120))],
+        dtype="S",
+    )
+
+    with h5py.File(episode_path, "a") as ep:
+        images = ep["observations"]["images"]
+        for camera in ("cam_high", "cam_left_wrist", "cam_right_wrist"):
+            del images[camera]
+            images.create_dataset(camera, data=encoded_frames)
+
+    with h5py.File(episode_path, "r") as ep:
+        images = _read_images(ep, "encoded_camera_images.hdf5")
+
+    assert set(images) == {"cam_high", "cam_left_wrist", "cam_right_wrist"}
+    assert images["cam_high"].shape == (2, 4, 5, 3)
+    assert images["cam_high"].dtype == np.uint8
 
 
 def test_load_episode_payload_reads_sandwich_hdf5(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_aloha_recap_converter.py
+++ b/tests/unit_tests/test_aloha_recap_converter.py
@@ -22,6 +22,7 @@ import pytest
 from examples.offline_rl.data.convert_aloha_hdf5_to_lerobot_v21 import (
     _aloha_features,
     _build_hil_segments_entry,
+    _discover_hdf5_files,
     _episode_success_array,
     _load_episode_payload,
     _read_images,
@@ -289,3 +290,149 @@ def test_build_hil_segments_entry_is_json_serializable(tmp_path: Path) -> None:
         "teleop_segments": [[1, 3]],
     }
     json.dumps(entry)
+
+
+class _FakeLeRobotDataset:
+    created_kwargs: dict | None = None
+
+    def __init__(self) -> None:
+        self.frames: list[dict] = []
+        self.episode_lengths: list[int] = []
+
+    @classmethod
+    def create(cls, **kwargs):
+        cls.created_kwargs = kwargs
+        return cls()
+
+    def add_frame(self, frame: dict) -> None:
+        self.frames.append(frame)
+
+    def save_episode(self) -> None:
+        self.episode_lengths.append(len(self.frames) - sum(self.episode_lengths))
+
+
+def test_convert_dataset_writes_frames_and_hil_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from examples.offline_rl.data import convert_aloha_hdf5_to_lerobot_v21 as converter
+
+    _FakeLeRobotDataset.created_kwargs = None
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_episode(raw_dir / "episode_0.hdf5", reward=1.0)
+    _write_episode(raw_dir / "episode_1.hdf5", reward=0.0)
+    output_dir = tmp_path / "lerobot"
+
+    monkeypatch.setattr(converter, "LeRobotDataset", _FakeLeRobotDataset)
+
+    dataset = converter.convert_dataset(
+        raw_dir=raw_dir,
+        output_dir=output_dir,
+        repo_id="local/aloha_sandwich",
+        task="Assemble a sandwich.",
+        fps=25,
+        overwrite=True,
+        image_writer_threads=1,
+        image_writer_processes=1,
+    )
+
+    assert dataset.episode_lengths == [4, 4]
+    assert _FakeLeRobotDataset.created_kwargs["repo_id"] == "local/aloha_sandwich"
+    assert _FakeLeRobotDataset.created_kwargs["root"] == output_dir
+    assert _FakeLeRobotDataset.created_kwargs["robot_type"] == "aloha"
+    assert _FakeLeRobotDataset.created_kwargs["fps"] == 25
+    assert _FakeLeRobotDataset.created_kwargs["image_writer_threads"] == 1
+    assert _FakeLeRobotDataset.created_kwargs["image_writer_processes"] == 1
+    assert _FakeLeRobotDataset.created_kwargs["features"]["is_success"]["shape"] == (1,)
+    assert _FakeLeRobotDataset.created_kwargs["features"]["teleop_mask"]["shape"] == (
+        1,
+    )
+    assert _FakeLeRobotDataset.created_kwargs["features"][
+        "observation.images.cam_high"
+    ]["shape"] == (8, 8, 3)
+
+    metadata_path = output_dir / "meta" / "hil_segments.json"
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["total_episodes"] == 2
+    assert metadata["total_frames"] == 8
+    assert metadata["successful_episodes"] == 1
+    assert metadata["failed_episodes"] == 1
+    assert metadata["episodes"][0]["teleop_segments"] == [[1, 3]]
+
+
+def test_discover_hdf5_files_returns_hdf5_and_h5_union(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    h5_path = raw_dir / "episode_0.h5"
+    hdf5_path = raw_dir / "episode_1.hdf5"
+    h5_path.touch()
+    hdf5_path.touch()
+
+    assert _discover_hdf5_files(raw_dir) == [h5_path, hdf5_path]
+
+
+@pytest.mark.parametrize(
+    "output_kind",
+    ("same", "parent", "child"),
+)
+def test_convert_dataset_rejects_overlapping_output_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output_kind: str,
+) -> None:
+    from examples.offline_rl.data import convert_aloha_hdf5_to_lerobot_v21 as converter
+
+    _FakeLeRobotDataset.created_kwargs = None
+    if output_kind == "parent":
+        output_dir = tmp_path / "raw_parent"
+        raw_dir = output_dir / "raw"
+    else:
+        raw_dir = tmp_path / "raw"
+        output_dir = raw_dir if output_kind == "same" else raw_dir / "lerobot"
+    raw_dir.mkdir(parents=True)
+    _write_episode(raw_dir / "episode_0.hdf5", reward=1.0)
+
+    monkeypatch.setattr(converter, "LeRobotDataset", _FakeLeRobotDataset)
+
+    with pytest.raises(ValueError, match="output_dir must not overlap raw_dir"):
+        converter.convert_dataset(
+            raw_dir=raw_dir,
+            output_dir=output_dir,
+            repo_id="local/aloha_sandwich",
+            overwrite=True,
+        )
+    assert _FakeLeRobotDataset.created_kwargs is None
+    assert raw_dir.exists()
+
+
+def test_convert_dataset_rejects_inconsistent_optional_fields_before_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from examples.offline_rl.data import convert_aloha_hdf5_to_lerobot_v21 as converter
+
+    _FakeLeRobotDataset.created_kwargs = None
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    _write_episode(raw_dir / "episode_0.hdf5", reward=1.0)
+    second_episode = raw_dir / "episode_1.hdf5"
+    _write_episode(second_episode, reward=0.0)
+    with h5py.File(second_episode, "a") as ep:
+        del ep["observations"]["qvel"]
+    output_dir = tmp_path / "lerobot"
+    output_dir.mkdir()
+    marker = output_dir / "keep.txt"
+    marker.write_text("existing", encoding="utf-8")
+
+    monkeypatch.setattr(converter, "LeRobotDataset", _FakeLeRobotDataset)
+
+    with pytest.raises(ValueError, match=r"observations/qvel.*inconsistent"):
+        converter.convert_dataset(
+            raw_dir=raw_dir,
+            output_dir=output_dir,
+            repo_id="local/aloha_sandwich",
+            overwrite=True,
+        )
+    assert _FakeLeRobotDataset.created_kwargs is None
+    assert marker.exists()

--- a/tests/unit_tests/test_aloha_recap_converter.py
+++ b/tests/unit_tests/test_aloha_recap_converter.py
@@ -69,6 +69,15 @@ def _jpeg_bytes(color: tuple[int, int, int]) -> bytes:
     return buffer.getvalue()
 
 
+def _fixed_width_void_frames(colors: list[tuple[int, int, int]]) -> np.ndarray:
+    encoded_frames = [_jpeg_bytes(color) for color in colors]
+    max_size = max(len(frame) for frame in encoded_frames)
+    return np.asarray(
+        [np.void(frame) for frame in encoded_frames],
+        dtype=f"V{max_size}",
+    )
+
+
 def test_teleop_mask_maps_half_open_segments() -> None:
     segments = np.asarray([[1, 3], [4, 5]], dtype=np.int64)
     mask = _teleop_mask(segments, num_frames=6, episode_name="episode_0.hdf5")
@@ -212,6 +221,37 @@ def test_read_images_decodes_fixed_width_jpeg_camera_streams(
     assert set(images) == {"cam_high", "cam_left_wrist", "cam_right_wrist"}
     assert images["cam_high"].shape == (2, 4, 5, 3)
     assert images["cam_high"].dtype == np.uint8
+    np.testing.assert_allclose(
+        images["cam_high"].mean(axis=(1, 2)),
+        np.asarray([[20, 40, 60], [80, 100, 120]], dtype=np.float64),
+        atol=3.0,
+    )
+
+
+def test_read_images_decodes_opaque_jpeg_camera_streams(tmp_path: Path) -> None:
+    episode_path = tmp_path / "opaque_camera_images.hdf5"
+    _write_episode(episode_path)
+    encoded_frames = _fixed_width_void_frames(
+        [(30, 50, 70), (90, 110, 130)],
+    )
+
+    with h5py.File(episode_path, "a") as ep:
+        images = ep["observations"]["images"]
+        for camera in ("cam_high", "cam_left_wrist", "cam_right_wrist"):
+            del images[camera]
+            images.create_dataset(camera, data=encoded_frames)
+
+    with h5py.File(episode_path, "r") as ep:
+        images = _read_images(ep, "opaque_camera_images.hdf5")
+
+    assert set(images) == {"cam_high", "cam_left_wrist", "cam_right_wrist"}
+    assert images["cam_high"].shape == (2, 4, 5, 3)
+    assert images["cam_high"].dtype == np.uint8
+    np.testing.assert_allclose(
+        images["cam_high"].mean(axis=(1, 2)),
+        np.asarray([[30, 50, 70], [90, 110, 130]], dtype=np.float64),
+        atol=3.0,
+    )
 
 
 def test_load_episode_payload_reads_sandwich_hdf5(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_aloha_recap_converter.py
+++ b/tests/unit_tests/test_aloha_recap_converter.py
@@ -1,0 +1,291 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from examples.offline_rl.data.convert_aloha_hdf5_to_lerobot_v21 import (
+    _aloha_features,
+    _build_hil_segments_entry,
+    _episode_success_array,
+    _load_episode_payload,
+    _read_images,
+    _read_scalar_reward,
+    _teleop_mask,
+)
+
+
+def _write_episode(
+    path: Path,
+    reward: float | np.ndarray = 1.0,
+    width: int = 14,
+) -> None:
+    with h5py.File(path, "w") as f:
+        f.create_dataset(
+            "action",
+            data=np.arange(4 * width, dtype=np.float32).reshape(4, width),
+        )
+        f.create_dataset("reward", data=np.asarray(reward, dtype=np.float32))
+        f.create_dataset(
+            "teleop_segments",
+            data=np.asarray([[1, 3]], dtype=np.int64),
+        )
+
+        obs = f.create_group("observations")
+        obs.create_dataset("qpos", data=np.ones((4, width), dtype=np.float32))
+        obs.create_dataset("qvel", data=np.full((4, width), 2.0, dtype=np.float32))
+        obs.create_dataset("effort", data=np.full((4, width), 3.0, dtype=np.float32))
+
+        images = obs.create_group("images")
+        for name in ("cam_high", "cam_left_wrist", "cam_right_wrist"):
+            images.create_dataset(
+                name,
+                data=np.zeros((4, 8, 8, 3), dtype=np.uint8),
+            )
+
+
+def test_teleop_mask_maps_half_open_segments() -> None:
+    segments = np.asarray([[1, 3], [4, 5]], dtype=np.int64)
+    mask = _teleop_mask(segments, num_frames=6, episode_name="episode_0.hdf5")
+
+    np.testing.assert_array_equal(mask, np.asarray([0, 1, 1, 0, 1, 0], dtype=np.int64))
+
+
+def test_teleop_mask_rejects_invalid_segment() -> None:
+    with pytest.raises(ValueError, match="invalid teleop segment"):
+        _teleop_mask(
+            np.asarray([[2, 7]], dtype=np.int64),
+            num_frames=6,
+            episode_name="episode_bad.hdf5",
+        )
+
+
+def test_episode_success_array_uses_scalar_reward() -> None:
+    np.testing.assert_array_equal(
+        _episode_success_array(1.0, num_frames=3),
+        np.asarray([True, True, True], dtype=bool),
+    )
+    np.testing.assert_array_equal(
+        _episode_success_array(0.0, num_frames=3),
+        np.asarray([False, False, False], dtype=bool),
+    )
+
+
+def test_aloha_features_include_required_recap_columns() -> None:
+    features = _aloha_features(
+        image_shape=(8, 8, 3),
+        include_velocity=True,
+        include_effort=True,
+    )
+
+    assert features["observation.images.cam_high"]["dtype"] == "image"
+    assert features["observation.images.cam_left_wrist"]["dtype"] == "image"
+    assert features["observation.images.cam_right_wrist"]["dtype"] == "image"
+    assert features["observation.state"]["shape"] == (14,)
+    assert features["observation.state"]["names"] == ["state"]
+    assert features["observation.velocity"]["shape"] == (14,)
+    assert features["observation.velocity"]["names"] == ["velocity"]
+    assert features["observation.effort"]["shape"] == (14,)
+    assert features["observation.effort"]["names"] == ["effort"]
+    assert features["action"]["shape"] == (14,)
+    assert features["action"]["names"] == ["action"]
+    assert features["is_success"]["dtype"] == "bool"
+    assert features["is_success"]["shape"] == (1,)
+    assert features["is_success"]["names"] == ["is_success"]
+    assert features["teleop_mask"]["dtype"] == "int64"
+    assert features["teleop_mask"]["shape"] == (1,)
+    assert features["teleop_mask"]["names"] == ["teleop_mask"]
+    assert features["observation.images.cam_high"]["shape"] == (8, 8, 3)
+    assert features["observation.images.cam_high"]["names"] == [
+        "height",
+        "width",
+        "channel",
+    ]
+    assert "task" not in features
+
+
+def test_read_scalar_reward_accepts_scalar_and_singleton(tmp_path: Path) -> None:
+    scalar_path = tmp_path / "scalar_reward.hdf5"
+    singleton_path = tmp_path / "singleton_reward.hdf5"
+    _write_episode(scalar_path, reward=1.0)
+    _write_episode(singleton_path, reward=np.asarray([0.5], dtype=np.float32))
+
+    with h5py.File(scalar_path, "r") as ep:
+        assert _read_scalar_reward(ep, "scalar_reward.hdf5") == 1.0
+    with h5py.File(singleton_path, "r") as ep:
+        assert _read_scalar_reward(ep, "singleton_reward.hdf5") == pytest.approx(0.5)
+
+
+def test_read_scalar_reward_rejects_non_scalar(tmp_path: Path) -> None:
+    episode_path = tmp_path / "bad_reward.hdf5"
+    _write_episode(episode_path, reward=np.asarray([0.0, 1.0], dtype=np.float32))
+
+    with h5py.File(episode_path, "r") as ep:
+        with pytest.raises(ValueError, match="reward must be scalar"):
+            _read_scalar_reward(ep, "bad_reward.hdf5")
+
+
+def test_read_images_rejects_missing_images_group(tmp_path: Path) -> None:
+    episode_path = tmp_path / "missing_images.hdf5"
+    _write_episode(episode_path)
+
+    with h5py.File(episode_path, "a") as ep:
+        del ep["observations"]["images"]
+
+    with h5py.File(episode_path, "r") as ep:
+        with pytest.raises(ValueError, match="missing observations/images group"):
+            _read_images(ep, "missing_images.hdf5")
+
+
+def test_read_images_rejects_missing_camera(tmp_path: Path) -> None:
+    episode_path = tmp_path / "missing_camera.hdf5"
+    _write_episode(episode_path)
+
+    with h5py.File(episode_path, "a") as ep:
+        del ep["observations"]["images"]["cam_left_wrist"]
+
+    with h5py.File(episode_path, "r") as ep:
+        with pytest.raises(ValueError, match="missing camera cam_left_wrist"):
+            _read_images(ep, "missing_camera.hdf5")
+
+
+def test_read_images_rejects_invalid_camera_shape(tmp_path: Path) -> None:
+    episode_path = tmp_path / "bad_camera_shape.hdf5"
+    _write_episode(episode_path)
+
+    with h5py.File(episode_path, "a") as ep:
+        del ep["observations"]["images"]["cam_high"]
+        ep["observations"]["images"].create_dataset(
+            "cam_high",
+            data=np.zeros((4, 8, 8, 1), dtype=np.uint8),
+        )
+
+    with h5py.File(episode_path, "r") as ep:
+        with pytest.raises(ValueError, match=r"shape \(T, H, W, 3\)"):
+            _read_images(ep, "bad_camera_shape.hdf5")
+
+
+def test_load_episode_payload_reads_sandwich_hdf5(tmp_path: Path) -> None:
+    episode_path = tmp_path / "episode_0.hdf5"
+    _write_episode(episode_path, reward=1.0)
+
+    payload = _load_episode_payload(episode_path, task="Assemble a sandwich.")
+
+    assert payload.episode_name == "episode_0.hdf5"
+    assert payload.raw_reward == 1.0
+    assert payload.num_frames == 4
+    assert payload.frames[0]["task"] == "Assemble a sandwich."
+    assert payload.frames[0]["observation.state"].shape == (14,)
+    assert payload.frames[0]["action"].shape == (14,)
+    np.testing.assert_array_equal(
+        payload.frames[1]["teleop_mask"],
+        np.asarray([1], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(
+        payload.frames[3]["teleop_mask"],
+        np.asarray([0], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(
+        payload.frames[0]["is_success"],
+        np.asarray([True], dtype=bool),
+    )
+
+
+def test_load_episode_payload_scalar_fields_match_feature_schema(
+    tmp_path: Path,
+) -> None:
+    episode_path = tmp_path / "episode_0.hdf5"
+    _write_episode(episode_path, reward=1.0)
+    features = _aloha_features(
+        image_shape=(8, 8, 3),
+        include_velocity=True,
+        include_effort=True,
+    )
+
+    payload = _load_episode_payload(episode_path, task="Assemble a sandwich.")
+
+    for field, expected in (
+        ("is_success", np.asarray([True], dtype=bool)),
+        ("teleop_mask", np.asarray([0], dtype=np.int64)),
+    ):
+        value = payload.frames[0][field]
+        assert value.shape == features[field]["shape"]
+        assert value.dtype == np.dtype(features[field]["dtype"])
+        np.testing.assert_array_equal(value, expected)
+
+
+def test_load_episode_payload_casts_numeric_arrays_to_float32(
+    tmp_path: Path,
+) -> None:
+    episode_path = tmp_path / "episode_float64.hdf5"
+    _write_episode(episode_path)
+
+    with h5py.File(episode_path, "a") as ep:
+        del ep["action"]
+        del ep["observations"]["qpos"]
+        del ep["observations"]["qvel"]
+        del ep["observations"]["effort"]
+        ep.create_dataset(
+            "action",
+            data=np.arange(56, dtype=np.float64).reshape(4, 14),
+        )
+        ep["observations"].create_dataset(
+            "qpos",
+            data=np.ones((4, 14), dtype=np.float64),
+        )
+        ep["observations"].create_dataset(
+            "qvel",
+            data=np.full((4, 14), 2.0, dtype=np.float64),
+        )
+        ep["observations"].create_dataset(
+            "effort",
+            data=np.full((4, 14), 3.0, dtype=np.float64),
+        )
+
+    payload = _load_episode_payload(episode_path, task="Assemble a sandwich.")
+
+    assert payload.frames[0]["observation.state"].dtype == np.float32
+    assert payload.frames[0]["action"].dtype == np.float32
+    assert payload.frames[0]["observation.velocity"].dtype == np.float32
+    assert payload.frames[0]["observation.effort"].dtype == np.float32
+
+
+def test_load_episode_payload_rejects_non_aloha_state_width(tmp_path: Path) -> None:
+    episode_path = tmp_path / "episode_bad_width.hdf5"
+    _write_episode(episode_path, width=13)
+
+    with pytest.raises(ValueError, match=r"\(T, 14\)"):
+        _load_episode_payload(episode_path, task="Assemble a sandwich.")
+
+
+def test_build_hil_segments_entry_is_json_serializable(tmp_path: Path) -> None:
+    episode_path = tmp_path / "episode_0.hdf5"
+    _write_episode(episode_path, reward=0.0)
+
+    payload = _load_episode_payload(episode_path, task="Assemble a sandwich.")
+    entry = _build_hil_segments_entry(payload)
+
+    assert entry == {
+        "episode_index": 0,
+        "episode_name": "episode_0.hdf5",
+        "num_frames": 4,
+        "raw_reward": 0.0,
+        "is_success": False,
+        "teleop_segments": [[1, 3]],
+    }
+    json.dumps(entry)

--- a/tests/unit_tests/test_aloha_recap_returns.py
+++ b/tests/unit_tests/test_aloha_recap_returns.py
@@ -1,0 +1,237 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from omegaconf import OmegaConf
+
+import examples.offline_rl.advantage_labeling.recap.process.compute_returns as returns_module
+from examples.offline_rl.advantage_labeling.recap.process.compute_returns import (
+    _process_single_parquet,
+    compute_hitl_aware_returns_for_episode,
+    compute_returns_for_episode,
+)
+
+
+def test_successful_episode_split_at_first_teleop_frame() -> None:
+    returns, rewards = compute_hitl_aware_returns_for_episode(
+        episode_length=6,
+        is_success=True,
+        teleop_mask=np.asarray([0, 0, 0, 1, 1, 0], dtype=np.int64),
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+
+    np.testing.assert_array_equal(
+        rewards,
+        np.asarray([-1.0, -1.0, -300.0, -1.0, -1.0, 0.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        returns,
+        np.asarray([-302.0, -301.0, -300.0, -2.0, -1.0, 0.0], dtype=np.float32),
+    )
+
+
+def test_successful_episode_without_teleop_uses_standard_returns() -> None:
+    hitl_returns, hitl_rewards = compute_hitl_aware_returns_for_episode(
+        episode_length=4,
+        is_success=True,
+        teleop_mask=np.zeros(4, dtype=np.int64),
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+    normal_returns, normal_rewards = compute_returns_for_episode(
+        episode_length=4,
+        is_success=True,
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+
+    np.testing.assert_array_equal(hitl_returns, normal_returns)
+    np.testing.assert_array_equal(hitl_rewards, normal_rewards)
+
+
+def test_successful_episode_split_at_zero_uses_standard_returns() -> None:
+    hitl_returns, hitl_rewards = compute_hitl_aware_returns_for_episode(
+        episode_length=3,
+        is_success=True,
+        teleop_mask=np.asarray([1, 1, 0], dtype=np.int64),
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+    normal_returns, normal_rewards = compute_returns_for_episode(
+        episode_length=3,
+        is_success=True,
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+
+    np.testing.assert_array_equal(hitl_returns, normal_returns)
+    np.testing.assert_array_equal(hitl_rewards, normal_rewards)
+
+
+def test_failed_episode_with_teleop_remains_failed() -> None:
+    hitl_returns, hitl_rewards = compute_hitl_aware_returns_for_episode(
+        episode_length=4,
+        is_success=False,
+        teleop_mask=np.asarray([0, 1, 1, 0], dtype=np.int64),
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+    normal_returns, normal_rewards = compute_returns_for_episode(
+        episode_length=4,
+        is_success=False,
+        gamma=1.0,
+        failure_reward=-300.0,
+    )
+
+    np.testing.assert_array_equal(hitl_returns, normal_returns)
+    np.testing.assert_array_equal(hitl_rewards, normal_rewards)
+
+
+def test_teleop_mask_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="does not match episode length"):
+        compute_hitl_aware_returns_for_episode(
+            episode_length=4,
+            is_success=True,
+            teleop_mask=np.asarray([0, 1], dtype=np.int64),
+            gamma=1.0,
+            failure_reward=-300.0,
+        )
+
+
+def test_invalid_teleop_mask_shape_raises() -> None:
+    with pytest.raises(ValueError, match=r"1-D or shape \(N, 1\)"):
+        compute_hitl_aware_returns_for_episode(
+            episode_length=2,
+            is_success=True,
+            teleop_mask=np.ones((2, 2), dtype=np.int64),
+            gamma=1.0,
+            failure_reward=-300.0,
+        )
+
+
+def test_process_single_parquet_accepts_lerobot_column_teleop_mask(tmp_path) -> None:
+    pq_file = tmp_path / "episode.parquet"
+    table = pa.table(
+        {
+            "episode_index": pa.array([0, 0, 0, 0, 0, 0], type=pa.int64()),
+            "frame_index": pa.array([0, 1, 2, 3, 4, 5], type=pa.int64()),
+            "is_success": pa.array([True, True, True, True, True, True]),
+            "teleop_mask": pa.array([[0], [0], [0], [1], [1], [0]]),
+            "task_index": pa.array([0, 0, 0, 0, 0, 0], type=pa.int64()),
+            "task": pa.array(["pick"] * 6),
+        }
+    )
+    pq.write_table(table, pq_file)
+
+    result = _process_single_parquet(
+        str(pq_file),
+        dataset_type="rollout",
+        gamma=1.0,
+        failure_reward=-300.0,
+        tasks={},
+        hitl_aware_returns=True,
+    )
+
+    np.testing.assert_array_equal(
+        result.column("reward").to_numpy(),
+        np.asarray([-1.0, -1.0, -300.0, -1.0, -1.0, 0.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        result.column("return").to_numpy(),
+        np.asarray([-302.0, -301.0, -300.0, -2.0, -1.0, 0.0], dtype=np.float32),
+    )
+
+
+def test_process_single_parquet_missing_teleop_mask_warns_and_falls_back(
+    tmp_path, caplog
+) -> None:
+    pq_file = tmp_path / "episode.parquet"
+    table = pa.table(
+        {
+            "episode_index": pa.array([0, 0, 0, 0], type=pa.int64()),
+            "frame_index": pa.array([0, 1, 2, 3], type=pa.int64()),
+            "is_success": pa.array([True, True, True, True]),
+            "task_index": pa.array([0, 0, 0, 0], type=pa.int64()),
+            "task": pa.array(["pick"] * 4),
+        }
+    )
+    pq.write_table(table, pq_file)
+
+    with caplog.at_level("WARNING"):
+        result = _process_single_parquet(
+            str(pq_file),
+            dataset_type="rollout",
+            gamma=1.0,
+            failure_reward=-300.0,
+            tasks={},
+            hitl_aware_returns=True,
+        )
+
+    assert "teleop_mask is missing" in caplog.text
+    np.testing.assert_array_equal(
+        result.column("reward").to_numpy(),
+        np.asarray([-1.0, -1.0, -1.0, 0.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        result.column("return").to_numpy(),
+        np.asarray([-3.0, -2.0, -1.0, 0.0], dtype=np.float32),
+    )
+
+
+def test_compute_returns_uses_per_entry_hitl_aware_override(
+    tmp_path, monkeypatch
+) -> None:
+    first_dataset = tmp_path / "first"
+    second_dataset = tmp_path / "second"
+    first_dataset.mkdir()
+    second_dataset.mkdir()
+    captured_hitl_values = []
+
+    def fake_process_dataset(**kwargs):
+        captured_hitl_values.append(kwargs["hitl_aware_returns"])
+        return {"return": {"min": 0.0, "max": 0.0}, "reward": {}}
+
+    monkeypatch.setattr(returns_module, "process_dataset", fake_process_dataset)
+    cfg = OmegaConf.create(
+        {
+            "data": {
+                "data_root": None,
+                "train_data_paths": [
+                    {
+                        "dataset_path": str(first_dataset),
+                        "type": "rollout",
+                        "hitl_aware_returns": True,
+                    },
+                    {
+                        "dataset_path": str(second_dataset),
+                        "type": "rollout",
+                    },
+                ],
+                "dataset_type": "rollout",
+                "gamma": 1.0,
+                "failure_reward": -300.0,
+                "hitl_aware_returns": False,
+                "num_workers": 1,
+                "tag": None,
+            }
+        }
+    )
+
+    returns_module.compute_returns(cfg)
+
+    assert captured_hitl_values == [True, False]

--- a/tests/unit_tests/test_aloha_recap_returns.py
+++ b/tests/unit_tests/test_aloha_recap_returns.py
@@ -155,6 +155,49 @@ def test_process_single_parquet_accepts_lerobot_column_teleop_mask(tmp_path) -> 
         result.column("return").to_numpy(),
         np.asarray([-302.0, -301.0, -300.0, -2.0, -1.0, 0.0], dtype=np.float32),
     )
+    assert result.column("done").to_pylist() == [
+        False,
+        False,
+        True,
+        False,
+        False,
+        True,
+    ]
+
+
+def test_process_single_parquet_normalizes_singleton_list_is_success(
+    tmp_path,
+) -> None:
+    pq_file = tmp_path / "episode.parquet"
+    table = pa.table(
+        {
+            "episode_index": pa.array([0, 0, 0], type=pa.int64()),
+            "frame_index": pa.array([0, 1, 2], type=pa.int64()),
+            "is_success": pa.array([[False], [False], [False]]),
+            "task_index": pa.array([0, 0, 0], type=pa.int64()),
+            "task": pa.array(["pick"] * 3),
+        }
+    )
+    pq.write_table(table, pq_file)
+
+    result = _process_single_parquet(
+        str(pq_file),
+        dataset_type="rollout",
+        gamma=1.0,
+        failure_reward=-300.0,
+        tasks={},
+        hitl_aware_returns=False,
+    )
+
+    np.testing.assert_array_equal(
+        result.column("reward").to_numpy(),
+        np.asarray([-1.0, -1.0, -300.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        result.column("return").to_numpy(),
+        np.asarray([-302.0, -301.0, -300.0], dtype=np.float32),
+    )
+    assert result.column("done").to_pylist() == [False, False, True]
 
 
 def test_process_single_parquet_missing_teleop_mask_warns_and_falls_back(

--- a/tests/unit_tests/test_aloha_recap_transforms.py
+++ b/tests/unit_tests/test_aloha_recap_transforms.py
@@ -14,6 +14,8 @@
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 
@@ -120,3 +122,72 @@ def test_save_advantages_teleop_override_preserves_continuous_values(
     assert saved["advantage_continuous"].tolist() == [-0.5, 0.2, -0.4]
     assert saved["advantage"].tolist() == [False, True, True]
     assert saved["teleop_positive"].tolist() == [False, False, True]
+
+
+def test_load_returns_sidecar_reads_optional_done(tmp_path) -> None:
+    from rlinf.data.datasets.recap.utils import load_returns_sidecar
+
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": pa.array([0, 0, 0], type=pa.int64()),
+                "frame_index": pa.array([0, 1, 2], type=pa.int64()),
+                "return": pa.array([-2.0, -1.0, 0.0], type=pa.float32()),
+                "reward": pa.array([-1.0, -1.0, 0.0], type=pa.float32()),
+                "done": pa.array([False, False, True]),
+            }
+        ),
+        meta_dir / "returns_test.parquet",
+    )
+
+    sidecar = load_returns_sidecar(tmp_path, returns_tag="test")
+
+    assert sidecar is not None
+    np.testing.assert_array_equal(
+        sidecar[0]["done"],
+        np.asarray([False, False, True], dtype=bool),
+    )
+
+
+def test_load_returns_sidecar_accepts_legacy_sidecar_without_done(tmp_path) -> None:
+    from rlinf.data.datasets.recap.utils import load_returns_sidecar
+
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    pq.write_table(
+        pa.table(
+            {
+                "episode_index": pa.array([0, 0], type=pa.int64()),
+                "frame_index": pa.array([0, 1], type=pa.int64()),
+                "return": pa.array([-1.0, 0.0], type=pa.float32()),
+                "reward": pa.array([-1.0, 0.0], type=pa.float32()),
+            }
+        ),
+        meta_dir / "returns.parquet",
+    )
+
+    sidecar = load_returns_sidecar(tmp_path)
+
+    assert sidecar is not None
+    assert "done" not in sidecar[0]
+
+
+def test_resolve_lookahead_clamps_at_done_boundary() -> None:
+    from examples.offline_rl.advantage_labeling.recap.process.compute_advantages import (
+        _resolve_lookahead,
+    )
+
+    lookahead = _resolve_lookahead(
+        local_idx=1,
+        global_idx=1,
+        shard_start=0,
+        episode_end=6,
+        action_horizon=3,
+        done_flags=np.asarray([False, False, True, False, False, True]),
+    )
+
+    assert lookahead.num_valid == 2
+    assert lookahead.is_next_pad is True
+    assert lookahead.next_local_idx is None

--- a/tests/unit_tests/test_aloha_recap_transforms.py
+++ b/tests/unit_tests/test_aloha_recap_transforms.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import numpy as np
+import pandas as pd
 import pytest
 
 
@@ -66,3 +67,56 @@ def test_checkpoint_utils_builds_aloha_input_transforms() -> None:
 
     names = [type(transform).__name__ for transform in transforms]
     assert names == ["InjectDefaultPrompt", "AlohaInputs", "PadStatesAndActions"]
+
+
+def test_compute_advantages_build_obs_supports_aloha() -> None:
+    from examples.offline_rl.advantage_labeling.recap.process.compute_advantages import (
+        build_obs,
+    )
+
+    sample = {
+        "observation.images.cam_high": np.zeros((3, 8, 8), dtype=np.uint8),
+        "observation.images.cam_left_wrist": np.ones((3, 8, 8), dtype=np.uint8),
+        "observation.images.cam_right_wrist": np.full((3, 8, 8), 2, dtype=np.uint8),
+        "observation.state": np.arange(14, dtype=np.float32),
+        "task_index": np.asarray(0),
+    }
+
+    obs = build_obs(sample, robot_type="aloha", tasks={0: "Assemble a sandwich."})
+
+    assert set(obs["images"]) == {"cam_high", "cam_left_wrist", "cam_right_wrist"}
+    assert obs["images"]["cam_high"].shape == (3, 8, 8)
+    np.testing.assert_array_equal(obs["state"], np.arange(14, dtype=np.float32))
+    assert obs["prompt"] == "Assemble a sandwich."
+
+
+def test_save_advantages_teleop_override_preserves_continuous_values(
+    tmp_path,
+) -> None:
+    from examples.offline_rl.advantage_labeling.recap.process.compute_advantages import (
+        save_advantages_to_dataset,
+    )
+
+    dataset_path = tmp_path / "dataset"
+    (dataset_path / "meta").mkdir(parents=True)
+    df = pd.DataFrame(
+        {
+            "episode_index": [0, 0, 0],
+            "frame_index": [0, 1, 2],
+            "advantage": [-0.5, 0.2, -0.4],
+            "teleop_mask": [0, 1, 1],
+        }
+    )
+
+    save_advantages_to_dataset(
+        dataset_path=dataset_path,
+        advantages_df=df,
+        threshold=0.0,
+        dataset_type="rollout",
+        tag="teleop",
+    )
+
+    saved = pd.read_parquet(dataset_path / "meta" / "advantages_teleop.parquet")
+    assert saved["advantage_continuous"].tolist() == [-0.5, 0.2, -0.4]
+    assert saved["advantage"].tolist() == [False, True, True]
+    assert saved["teleop_positive"].tolist() == [False, False, True]

--- a/tests/unit_tests/test_aloha_recap_transforms.py
+++ b/tests/unit_tests/test_aloha_recap_transforms.py
@@ -1,0 +1,68 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+
+def test_value_dataset_builds_aloha_transform() -> None:
+    pytest.importorskip("openpi")
+
+    from rlinf.data.datasets.recap.value_dataset import ValueDataset
+
+    transform = ValueDataset._build_transform(
+        robot_type="aloha",
+        model_type="pi05",
+        action_dim=14,
+        default_prompt="Assemble a sandwich.",
+    )
+    sample = {
+        "observation.images.cam_high": np.zeros((3, 8, 8), dtype=np.uint8),
+        "observation.images.cam_left_wrist": np.ones((3, 8, 8), dtype=np.uint8),
+        "observation.images.cam_right_wrist": np.full((3, 8, 8), 2, dtype=np.uint8),
+        "observation.state": np.zeros((14,), dtype=np.float32),
+        "action": np.zeros((10, 14), dtype=np.float32),
+        "prompt": "Assemble a sandwich.",
+    }
+
+    transformed = transform(sample)
+
+    assert set(transformed["image"]) == {
+        "base_0_rgb",
+        "left_wrist_0_rgb",
+        "right_wrist_0_rgb",
+    }
+    assert transformed["state"].shape == (14,)
+    assert transformed["actions"].shape[-1] == 14
+    assert transformed["prompt"] == "Assemble a sandwich."
+
+
+def test_checkpoint_utils_builds_aloha_input_transforms() -> None:
+    pytest.importorskip("openpi")
+
+    from rlinf.models.embodiment.value_model.recap.checkpoint_utils import (
+        build_input_transforms,
+    )
+
+    transforms = build_input_transforms(
+        env_type="aloha",
+        model_type="pi05",
+        action_dim=14,
+        default_prompt="Assemble a sandwich.",
+        norm_stats=None,
+        use_quantile_norm=True,
+    )
+
+    names = [type(transform).__name__ for transform in transforms]
+    assert names == ["InjectDefaultPrompt", "AlohaInputs", "PadStatesAndActions"]


### PR DESCRIPTION
## Summary

- Add ALOHA sandwich RECAP planning docs, configs, and data conversion utilities.
- Add HITL-aware RECAP return and advantage processing updates.
- Add sandwich pi0.5 SFT recipe wiring and focused unit tests for the new converter and RECAP transforms.

## Validation

Not run in this session. This was a publish-only request; the local worktree was clean before pushing.
