### PR TITLE
fix: sort para in bucket syncer to prevent hang

### DIFF
--- a/rlinf/hybrid_engines/weight_syncer/bucket_syncer.py
+++ b/rlinf/hybrid_engines/weight_syncer/bucket_syncer.py
@@ -248,7 +248,7 @@ class BucketWeightSyncer(WeightSyncer):
         """
 
         del state_dict, send, recv
-        self.param_names_need_sync = set(param_names_need_sync)
+        self.param_names_need_sync = sorted(set(param_names_need_sync))
         if not self.param_names_need_sync:
             raise ValueError("param_names_need_sync must not be empty")
         self._sender_initialized = True


### PR DESCRIPTION
BucketWeightSyncer stored param_names_need_sync as a plain set, so the iteration/sync order was nondeterministic across ranks. The mismatched ordering between sender and receiver could cause the bucketed allgather to hang. Sort the set so the sync order is deterministic and stable.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.