### PR TITLE
perf(openpi): batch all camera views into one SigLIP call in embed_prefix

### DIFF
--- a/rlinf/models/embodiment/openpi/openpi_action_model.py
+++ b/rlinf/models/embodiment/openpi/openpi_action_model.py
@@ -1208,6 +1208,73 @@ class OpenPi0ForRLActionPrediction(PI0Pytorch, BasePolicy):
         v_t = self.action_out_proj(suffix_out)
         return v_t, suffix_out
 
+    def embed_prefix(
+        self, images, img_masks, lang_tokens, lang_masks
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Embed prefix images and language tokens for PaliGemma processing.
+
+        Overrides ``PI0Pytorch.embed_prefix`` to embed all camera views in a
+        single SigLIP forward (views stacked on the batch dim) instead of a
+        per-view Python loop. Batch entries are independent inside the ViT, so
+        the outputs match the loop path, while small batches fill the GPU much
+        better (batch = num_views x bsize per call instead of bsize). At bs=1
+        with 3 views and torch.compile max-autotune, prefix image embedding
+        drops from 9.5 ms to 6.4 ms per inference on an RTX PRO 5000.
+
+        Args:
+            images: Sequence of per-view image tensors, each ``[B, C, H, W]``
+                with identical shapes across views.
+            img_masks: Sequence of per-view validity masks, each ``[B]``.
+            lang_tokens: Tokenized language prompt of shape ``[B, L]``.
+            lang_masks: Language padding mask of shape ``[B, L]``.
+
+        Returns:
+            Tuple of concatenated prefix embeddings ``[B, T, D]``, padding
+            masks ``[B, T]``, and attention masks ``[B, T]``.
+        """
+        assert len(images) == len(img_masks), (
+            f"Expected one mask per image view, got {len(images)} views "
+            f"and {len(img_masks)} masks."
+        )
+        embs = []
+        pad_masks = []
+        att_masks = []
+
+        bsize = images[0].shape[0]
+
+        def image_embed_func(img):
+            return self.paligemma_with_expert.embed_image(img)
+
+        all_img_embs = self._apply_checkpoint(
+            image_embed_func, torch.cat(images, dim=0) if len(images) > 1 else images[0]
+        )
+        num_img_embs = all_img_embs.shape[1]
+
+        for view_idx, img_mask in enumerate(img_masks):
+            embs.append(all_img_embs[view_idx * bsize : (view_idx + 1) * bsize])
+            pad_masks.append(img_mask[:, None].expand(bsize, num_img_embs))
+            # Image tokens attend to each other within the prefix.
+            att_masks += [0] * num_img_embs
+
+        def lang_embed_func(lang_tokens):
+            lang_emb = self.paligemma_with_expert.embed_language_tokens(lang_tokens)
+            return lang_emb * math.sqrt(lang_emb.shape[-1])
+
+        lang_emb = self._apply_checkpoint(lang_embed_func, lang_tokens)
+
+        embs.append(lang_emb)
+        pad_masks.append(lang_masks)
+
+        # Full attention between image and language inputs.
+        att_masks += [0] * lang_emb.shape[1]
+
+        embs = torch.cat(embs, dim=1)
+        pad_masks = torch.cat(pad_masks, dim=1)
+        att_masks = torch.tensor(att_masks, dtype=torch.bool, device=pad_masks.device)
+        att_masks = att_masks[None, :].expand(pad_masks.shape[0], len(att_masks))
+
+        return embs, pad_masks, att_masks
+
     def _build_prefix_cache(self, images, img_masks, lang_tokens, lang_masks):
         """Embed prefix tokens and compute KV cache for efficient suffix generation."""
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(


### PR DESCRIPTION
### Description
Override `PI0Pytorch.embed_prefix` in `OpenPi0ForRLActionPrediction` to embed all prefix camera views in a **single SigLIP ViT forward** (views stacked on the batch dim) instead of a per-view Python loop. Batch entries are independent inside the ViT, so the outputs match the loop path, while small batches fill the GPU much better: the vision forward sees `num_views x bsize` rows per call instead of `bsize`. The override is picked up by both the rollout inference path (`predict_action_batch` → `_build_prefix_cache`) and the training forward, which share `embed_prefix`.

### Motivation and Context
Real-robot pi0.5 rollout runs at bs=1 (one observation per control step), where the per-view loop badly underfills the GPU. Profiling the production inference path (`torch.compile max-autotune`, #968) on an RTX PRO 5000 (sm_120) with 3 camera views showed `embed_prefix`'s image embedding taking 9.5 ms of the ~65 ms e2e predict.

With this change, prefix image embedding drops **9.5 ms → 6.4 ms** per inference, contributing to an e2e `predict_action_batch` improvement of **65.8 ms → 58.9 ms** (bs=1, 10 denoise steps, 3 views, compiled) in our real-robot rollout measurements.

### How has this been tested?
Environment: H20 / RTX PRO 5000, torch 2.6/2.7, `RLinf/RLinf-Pi05-LIBERO-SFT` weights, `pi05` config.

1. **ViT-output equivalence** (real weights, bf16): batched vs loop embeddings are **bit-exact at bs=4**; at bs=1 the only differences are cuBLAS kernel-selection rounding (max diff ~1.2e-2 relative to the tensor max after the full 27-layer ViT) — the same class of numerical noise as enabling `torch.compile`.
2. **Action-level equivalence**: same-seed `predict_action_batch` (eval, 10 denoise steps) with loop vs batched embedding: max abs action diff **4.9e-3**, mean **9.0e-4** (unnormalized action range ≈ 0.3).
3. **Peak GPU memory**: the vision-embed transient grows ~×2.4 (bs=1: 10.7 → 20.3 MiB; bs=8: 69 → 163 MiB; bs=32: 272 → 648 MiB), but the **whole-predict peak is unchanged** at every batch size tested (bs=1: 14.11 GiB, bs=8: 22.07 GiB, bs=32: 32.43 GiB for both variants) — the global peak sits in the VLM prefill, and the caching allocator reuses the freed embed blocks. With `train_expert_only=True` (default RL configs) the VLM is frozen, so the training path behaves identically; with full-VLM training the *stored* activations are the same set in both variants (all views are needed for backward), only the checkpoint-recompute transient scales with `num_views`, which stays below the prefill activations.
4. **e2e smoke** on this branch: `predict_action_batch` with `pi05_libero` (2 views + language) produces sane actions; bs=1 latency benchmarked at 76.7 ms e2e on H20 (compiled, 3 views, unpatched container reference ~73 ms — structure and MFU conclusions identical across GPUs, absolute ms differ per part).

### Additional information (optional, e.g., figures and logs):
Measured with a standalone bs=1 inference benchmark plus nsys (NVTX range `prefix/vision_siglip` before/after). Happy to share the benchmark script, equivalence-check scripts, and nsys reps. Related: #968 (torch.compile predict path), #1325 (typecheck overhead on the same rollout path).

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Note on tests: `pytest tests/unit_tests` in my container gives 201 passed / 3 skipped, with failures confined to the Ray/scheduler comm suites (`test_channel`, `test_comm`, `test_worker`, ...) that behave the same on a clean `upstream/main` checkout in this environment — no overlap with the changed file (the only openpi-related unit test, `test_value_model_embedding_scale`, is skipped by default). Please trigger CI for an authoritative run. The equivalence checks above need GPU + the released checkpoint, so they are not committed as CI unit tests; if maintainers prefer, I can add a GPU-marked e2e test mirroring check 1/2.
