### PR TITLE
fix(embodiment): apply SFT loss in co-training

### DIFF
--- a/rlinf/workers/actor/fsdp_actor_worker.py
+++ b/rlinf/workers/actor/fsdp_actor_worker.py
@@ -1306,7 +1306,7 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
 
     def _train_sft_epoch(
         self, metrics_data: dict[str, torch.Tensor], loss: torch.Tensor
-    ):
+    ) -> torch.Tensor:
         """
         Train one epoch of SFT.
         """
@@ -1342,6 +1342,7 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
                 f"ppo_loss={metrics_data['ppo_loss']:.6f}, "
                 f"sft_loss_weight={self.sft_loss_weight:.6f}"
             )
+        return loss
 
     @Worker.timer("run_training")
     def run_training(self) -> None:
@@ -1532,7 +1533,7 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
         metrics_data["actor/entropy_loss"] = entropy_loss.detach().item()
 
         if self.enable_sft_co_train:
-            self._train_sft_epoch(metrics_data, loss)
+            loss = self._train_sft_epoch(metrics_data, loss)
 
         loss /= self.gradient_accumulation
         with backward_ctx:

--- a/rlinf/workers/actor/fsdp_nft_policy_worker.py
+++ b/rlinf/workers/actor/fsdp_nft_policy_worker.py
@@ -189,7 +189,7 @@ class EmbodiedNFTFSDPPolicy(EmbodiedFSDPActor):
                     loss, metrics_data = self.nft_forward_and_loss(batch)
 
                     if self.enable_sft_co_train:
-                        self._train_sft_epoch(metrics_data, loss)
+                        loss = self._train_sft_epoch(metrics_data, loss)
 
                     loss /= self.gradient_accumulation
                     with backward_ctx:


### PR DESCRIPTION
### Description

This PR fixes the SFT co-training loss path for embodied FSDP actor workers.

When `enable_sft_co_train` is enabled, `_train_sft_epoch()` computes:

```python
loss + sft_loss_weight * sft_loss
```

but the combined loss was only assigned to a local variable inside the helper. The caller then continued to backpropagate the original PPO/NFT loss, so the SFT loss was logged but did not contribute gradients.

This change makes `_train_sft_epoch()` return the combined loss and updates both co-training callers to use it.

### Motivation and Context

The sim-real co-training path should optimize both the RL loss and the weighted SFT loss. Without returning the combined loss from `_train_sft_epoch()`, co-training effectively ignores the SFT objective during backpropagation.

This is a minimal bug fix for the existing co-training implementation.

### How has this been tested?

Ran targeted style checks on the changed files:

```bash
python -m ruff check rlinf/workers/actor/fsdp_actor_worker.py rlinf/workers/actor/fsdp_nft_policy_worker.py
python -m ruff format --check rlinf/workers/actor/fsdp_actor_worker.py rlinf/workers/actor/fsdp_nft_policy_worker.py
```

Both checks passed.

No full test suite or training job was run.

### Additional information (optional, e.g., figures and logs):

N/A

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
