### PR TITLE
docs: fix OpenVLA-OFT model repo link in vla quickstart

### DIFF
--- a/docs/source-en/rst_source/start/vla.rst
+++ b/docs/source-en/rst_source/start/vla.rst
@@ -35,8 +35,8 @@ If using the **OpenVLA-OFT** model, run the following command:
 .. code-block:: bash
 
    # Download OpenVLA-OFT pre-trained model
-   hf download RLinf/Openvla-oft-SFT-libero10-trajall \
-   --local-dir /path/to/model/Openvla-oft-SFT-libero10-trajall/
+   hf download RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Main \
+   --local-dir /path/to/model/RLinf-OpenVLAOFT-ManiSkill-Base-Main/
    
    # Download LoRA fine-tuned checkpoint on maniskill
    hf download RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Lora \
@@ -63,7 +63,7 @@ Before running the script, you need to modify the ``./examples/embodiment/config
 
 
 
-For **OpenVLA-OFT**, modify the ``maniskill_ppo_openvlaoft_quickstart.yaml`` file. Set the following model configuration items to the path where the `RLinf/Openvla-oft-SFT-libero10-trajall` checkpoint is located. At the same time, set the LoRA path to the path where the `RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Lora` checkpoint is located.
+For **OpenVLA-OFT**, modify the ``maniskill_ppo_openvlaoft_quickstart.yaml`` file. Set the following model configuration items to the path where the `RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Main` checkpoint is located. At the same time, set the LoRA path to the path where the `RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Lora` checkpoint is located.
 
 - ``rollout.model.model_path``  
 - ``actor.model.model_path``  

--- a/docs/source-zh/rst_source/start/vla.rst
+++ b/docs/source-zh/rst_source/start/vla.rst
@@ -36,8 +36,8 @@ ManiSkill3 是一个基于 GPU 加速的机器人研究仿真平台，
 .. code-block:: bash
 
    # 下载 OpenVLA-OFT 预训练模型
-   hf download RLinf/Openvla-oft-SFT-libero10-trajall \
-   --local-dir /path/to/model/Openvla-oft-SFT-libero10-trajall/
+   hf download RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Main \
+   --local-dir /path/to/model/RLinf-OpenVLAOFT-ManiSkill-Base-Main/
    
    # 下载在maniskill上lora微调过的检查点
    hf download RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Lora \
@@ -64,7 +64,7 @@ ManiSkill3 是一个基于 GPU 加速的机器人研究仿真平台，
 
 
 
-对于 **OpenVLA-OFT**，修改 ``maniskill_ppo_openvlaoft_quickstart.yaml`` 文件。将下列模型配置项设置为 `RLinf/Openvla-oft-SFT-libero10-trajall` 检查点所在的路径。同时，将 LoRA 路径设置为 `RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Lora` 检查点所在的路径。
+对于 **OpenVLA-OFT**，修改 ``maniskill_ppo_openvlaoft_quickstart.yaml`` 文件。将下列模型配置项设置为 `RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Main` 检查点所在的路径。同时，将 LoRA 路径设置为 `RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Lora` 检查点所在的路径。
 
 - ``rollout.model.model_path``  
 - ``actor.model.model_path``  


### PR DESCRIPTION
The OpenVLA-OFT pre-trained model download command and prose referenced the wrong repo (RLinf/Openvla-oft-SFT-libero10-trajall). Correct it to RLinf/RLinf-OpenVLAOFT-ManiSkill-Base-Main in both EN and ZH vla.rst.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- how your change affects other areas of the code, etc. -->

### Additional information (optional, e.g. figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
