### PR TITLE
feat: camera depth and metadata retrieval for LIBERO

### DIFF
--- a/rlinf/envs/libero/libero_env.py
+++ b/rlinf/envs/libero/libero_env.py
@@ -661,6 +661,14 @@ class LiberoEnv(gym.Env):
         infos = {}
         return obs, infos
 
+    def get_camera_meta(self, camera_name: str = "agentview",
+                        height: int = 256, width: int = 256) -> dict:
+        """Static camera calibration (intrinsics K, cam->world extrinsics,
+        depth near/far) for the named camera, from worker 0's robosuite sim.
+        Agentview is a fixed world camera, so this is constant per episode."""
+        return self.env.workers[0].get_camera_meta(
+            camera_name=camera_name, height=height, width=width)
+
     def step(self, actions=None, auto_reset=True):
         """Step the environment with the given actions."""
         if isinstance(actions, torch.Tensor):

--- a/rlinf/envs/libero/libero_env.py
+++ b/rlinf/envs/libero/libero_env.py
@@ -669,6 +669,21 @@ class LiberoEnv(gym.Env):
         return self.env.workers[0].get_camera_meta(
             camera_name=camera_name, height=height, width=width)
 
+    def render_camera(
+        self,
+        camera_name: str = "agentview",
+        height: int = 1024,
+        width: int = 1024,
+        depth: bool = False,
+    ):
+        """Render an arbitrary camera at the requested resolution."""
+        return self.env.workers[0].render_camera(
+            camera_name=camera_name,
+            height=height,
+            width=width,
+            depth=depth,
+        )
+
     def step(self, actions=None, auto_reset=True):
         """Step the environment with the given actions."""
         if isinstance(actions, torch.Tensor):

--- a/rlinf/envs/libero/libero_env.py
+++ b/rlinf/envs/libero/libero_env.py
@@ -661,13 +661,15 @@ class LiberoEnv(gym.Env):
         infos = {}
         return obs, infos
 
-    def get_camera_meta(self, camera_name: str = "agentview",
-                        height: int = 256, width: int = 256) -> dict:
+    def get_camera_meta(
+        self, camera_name: str = "agentview", height: int = 256, width: int = 256
+    ) -> dict:
         """Static camera calibration (intrinsics K, cam->world extrinsics,
         depth near/far) for the named camera, from worker 0's robosuite sim.
         Agentview is a fixed world camera, so this is constant per episode."""
         return self.env.workers[0].get_camera_meta(
-            camera_name=camera_name, height=height, width=width)
+            camera_name=camera_name, height=height, width=width
+        )
 
     def render_camera(
         self,

--- a/rlinf/envs/libero/venv.py
+++ b/rlinf/envs/libero/venv.py
@@ -134,6 +134,23 @@ def _worker(
                 break
             elif cmd == "render":
                 p.send(env.render(**data) if hasattr(env, "render") else None)
+            elif cmd == "render_camera":
+                rob = getattr(env, "env", env)
+                while hasattr(rob, "env"):
+                    rob = rob.env
+                sim = rob.sim
+                cam = data.get("camera_name", "agentview")
+                h = int(data.get("height", 1024))
+                w = int(data.get("width", 1024))
+                depth = bool(data.get("depth", False))
+                p.send(
+                    sim.render(
+                        width=w,
+                        height=h,
+                        camera_name=cam,
+                        depth=depth,
+                    )
+                )
             elif cmd == "seed":
                 if hasattr(env, "seed"):
                     p.send(env.seed(data))
@@ -234,6 +251,25 @@ class ReconfigureSubprocEnvWorker(SubprocEnvWorker):
 
     def reconfigure_env_fn(self, env_fn_param):
         self.parent_remote.send(["reconfigure", env_fn_param])
+        return self.parent_remote.recv()
+
+    def render_camera(
+        self,
+        camera_name: str = "agentview",
+        height: int = 1024,
+        width: int = 1024,
+        depth: bool = False,
+    ) -> Any:
+        """Render an arbitrary LIBERO camera from the worker subprocess."""
+        self.parent_remote.send([
+            "render_camera",
+            {
+                "camera_name": camera_name,
+                "height": height,
+                "width": width,
+                "depth": depth,
+            },
+        ])
         return self.parent_remote.recv()
 
 

--- a/rlinf/envs/libero/venv.py
+++ b/rlinf/envs/libero/venv.py
@@ -191,8 +191,9 @@ def _worker(
                         obj = obj.env
                 else:
                     obj = env
-                ret = getattr(obj, data["method"])(*data.get("args", []),
-                                                   **data.get("kwargs", {}))
+                ret = getattr(obj, data["method"])(
+                    *data.get("args", []), **data.get("kwargs", {})
+                )
                 p.send(ret)
             elif cmd == "get_camera_meta":
                 # Compute static camera calibration (intrinsics + cam->world
@@ -201,6 +202,7 @@ def _worker(
                 # Returns plain lists/floats (picklable) so the driver can
                 # back-project pixels to world without GT object poses.
                 from robosuite.utils import camera_utils as _cu
+
                 rob = getattr(env, "env", env)
                 while hasattr(rob, "env"):
                     rob = rob.env
@@ -213,12 +215,17 @@ def _worker(
                 extent = float(sim.model.stat.extent)
                 near = float(sim.model.vis.map.znear) * extent
                 far = float(sim.model.vis.map.zfar) * extent
-                p.send({
-                    "camera_name": cam, "height": h, "width": w,
-                    "intrinsic_K": K.tolist(),
-                    "extrinsic_cam2world": E.tolist(),
-                    "depth_near": near, "depth_far": far,
-                })
+                p.send(
+                    {
+                        "camera_name": cam,
+                        "height": h,
+                        "width": w,
+                        "intrinsic_K": K.tolist(),
+                        "extrinsic_cam2world": E.tolist(),
+                        "depth_near": near,
+                        "depth_far": far,
+                    }
+                )
             else:
                 p.close()
                 raise NotImplementedError
@@ -261,15 +268,17 @@ class ReconfigureSubprocEnvWorker(SubprocEnvWorker):
         depth: bool = False,
     ) -> Any:
         """Render an arbitrary LIBERO camera from the worker subprocess."""
-        self.parent_remote.send([
-            "render_camera",
-            {
-                "camera_name": camera_name,
-                "height": height,
-                "width": width,
-                "depth": depth,
-            },
-        ])
+        self.parent_remote.send(
+            [
+                "render_camera",
+                {
+                    "camera_name": camera_name,
+                    "height": height,
+                    "width": width,
+                    "depth": depth,
+                },
+            ]
+        )
         return self.parent_remote.recv()
 
 

--- a/rlinf/envs/libero/venv.py
+++ b/rlinf/envs/libero/venv.py
@@ -159,6 +159,49 @@ def _worker(
                 env = OffScreenRenderEnv(**data)
                 env.seed(seed)
                 p.send(None)
+            elif cmd == "env_call":
+                # Generic method dispatcher (mirror of the base SubprocEnvWorker
+                # impl). Used by LiberoEnv.set_image_render_enabled to toggle
+                # robosuite observables without touching env.step.
+                target = data.get("target", "robosuite")
+                if target == "self":
+                    obj = env
+                elif target == "env":
+                    obj = env.env
+                elif target == "robosuite":
+                    obj = getattr(env, "env", env)
+                    while hasattr(obj, "env"):
+                        obj = obj.env
+                else:
+                    obj = env
+                ret = getattr(obj, data["method"])(*data.get("args", []),
+                                                   **data.get("kwargs", {}))
+                p.send(ret)
+            elif cmd == "get_camera_meta":
+                # Compute static camera calibration (intrinsics + cam->world
+                # extrinsics) + depth near/far planes for the named camera,
+                # using the robosuite sim (only reachable in this subprocess).
+                # Returns plain lists/floats (picklable) so the driver can
+                # back-project pixels to world without GT object poses.
+                from robosuite.utils import camera_utils as _cu
+                rob = getattr(env, "env", env)
+                while hasattr(rob, "env"):
+                    rob = rob.env
+                sim = rob.sim
+                cam = data.get("camera_name", "agentview")
+                h = int(data.get("height", 256))
+                w = int(data.get("width", 256))
+                K = _cu.get_camera_intrinsic_matrix(sim, cam, h, w)
+                E = _cu.get_camera_extrinsic_matrix(sim, cam)  # cam->world 4x4
+                extent = float(sim.model.stat.extent)
+                near = float(sim.model.vis.map.znear) * extent
+                far = float(sim.model.vis.map.zfar) * extent
+                p.send({
+                    "camera_name": cam, "height": h, "width": w,
+                    "intrinsic_K": K.tolist(),
+                    "extrinsic_cam2world": E.tolist(),
+                    "depth_near": near, "depth_far": far,
+                })
             else:
                 p.close()
                 raise NotImplementedError

--- a/rlinf/envs/venv/venv.py
+++ b/rlinf/envs/venv/venv.py
@@ -289,6 +289,25 @@ def _worker(
                 p.send(getattr(env, data) if hasattr(env, data) else None)
             elif cmd == "setattr":
                 setattr(env.unwrapped, data["key"], data["value"])
+            elif cmd == "env_call":
+                # data: {"target": "env" | "self" | "robosuite", "method": str,
+                #        "args": list, "kwargs": dict}
+                target = data.get("target", "robosuite")
+                if target == "self":
+                    obj = env
+                elif target == "env":
+                    obj = env.env
+                elif target == "robosuite":
+                    obj = getattr(env, "env", env)
+                    while hasattr(obj, "env"):
+                        obj = obj.env
+                else:
+                    obj = env
+                method_name = data["method"]
+                args = data.get("args", [])
+                kwargs = data.get("kwargs", {})
+                ret = getattr(obj, method_name)(*args, **kwargs)
+                p.send(ret)
             elif cmd == "check_success":
                 p.send(env.check_success())
             elif cmd == "get_segmentation_of_interest":
@@ -395,6 +414,35 @@ class SubprocEnvWorker(EnvWorker):
 
     def set_env_attr(self, key: str, value: Any) -> None:
         self.parent_remote.send(["setattr", {"key": key, "value": value}])
+
+    def env_call(self, method: str, args: list = None, kwargs: dict = None,
+                 target: str = "robosuite") -> Any:
+        """Invoke a method on the worker's env (or one of its unwrapped layers).
+
+        target='robosuite' walks env.env.env... down to the deepest robosuite
+        MujocoEnv; 'env' uses one-level unwrap; 'self' uses the outermost env.
+        """
+        self.parent_remote.send([
+            "env_call",
+            {
+                "target": target,
+                "method": method,
+                "args": args or [],
+                "kwargs": kwargs or {},
+            },
+        ])
+        return self.parent_remote.recv()
+
+    def get_camera_meta(self, camera_name: str = "agentview",
+                        height: int = 256, width: int = 256) -> Any:
+        """Fetch static camera calibration (intrinsics, cam->world extrinsics,
+        depth near/far) for the named camera. Handled by the libero worker
+        loop, which has access to the robosuite sim."""
+        self.parent_remote.send([
+            "get_camera_meta",
+            {"camera_name": camera_name, "height": height, "width": width},
+        ])
+        return self.parent_remote.recv()
 
     def _decode_obs(self) -> Union[dict, tuple, np.ndarray]:
         def decode_obs(


### PR DESCRIPTION
This pull request adds new utilities for rendering and camera calibration to the LIBERO environment wrappers and their underlying vectorized environments. It introduces generic remote method invocation for more flexible interaction with nested environments, and exposes camera rendering and calibration metadata retrieval through both the main and vectorized environment APIs.

**New camera utilities:**

* Added `get_camera_meta` and `render_camera` methods to `libero_env.py` to fetch static camera calibration data and render arbitrary cameras, respectively. These methods delegate to the underlying worker environment.
* Added corresponding `render_camera` and `get_camera_meta` methods to the vectorized environment (`venv.py`), enabling camera rendering and metadata retrieval from the worker subprocess. [[1]](diffhunk://#diff-433086d92d73a951a0a8a6e957cba5d19a240f9317bd6157258c8b835892dca5R256-R274) [[2]](diffhunk://#diff-03b37d5bf070978551967feb7567f4e316b5237761233e24a0f78d06ad03d7caR418-R446)

**Generic environment method dispatch:**

* Implemented a generic `env_call` mechanism in both LIBERO and base vectorized environment workers, allowing arbitrary method calls on nested environments (including deep access into robosuite environments). This supports more flexible and extensible environment control. [[1]](diffhunk://#diff-433086d92d73a951a0a8a6e957cba5d19a240f9317bd6157258c8b835892dca5R179-R221) [[2]](diffhunk://#diff-03b37d5bf070978551967feb7567f4e316b5237761233e24a0f78d06ad03d7caR292-R310) [[3]](diffhunk://#diff-03b37d5bf070978551967feb7567f4e316b5237761233e24a0f78d06ad03d7caR418-R446)

**Worker command handling:**

* Updated the LIBERO worker loop to handle the new `render_camera`, `get_camera_meta`, and `env_call` commands, including logic to traverse environment wrappers and interact with the underlying robosuite simulation for camera operations and calibration. [[1]](diffhunk://#diff-433086d92d73a951a0a8a6e957cba5d19a240f9317bd6157258c8b835892dca5R137-R153) [[2]](diffhunk://#diff-433086d92d73a951a0a8a6e957cba5d19a240f9317bd6157258c8b835892dca5R179-R221)

These changes make it easier to access camera data and control environment internals for RPent downstream tasks.<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Additional information (optional, e.g., figures and logs):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.