### PR TITLE
feat: adapt rlinf to sgl 0.5.12, cu13 and tf 5.6

### DIFF
--- a/rlinf/data/datasets/reasoning.py
+++ b/rlinf/data/datasets/reasoning.py
@@ -209,7 +209,11 @@ class ReasoningDataset(Dataset):
         """
         Use tokenizer to encode the texts and return the token ids and length.
         """
-        text_ids = self.tokenizer.batch_encode_plus(list(texts))["input_ids"]
+        # transformers >= 5.0 renamed the tiktoken-backed tokenizer class to TokenizersBackend
+        try:
+            text_ids = self.tokenizer.batch_encode_plus(list(texts))["input_ids"]
+        except AttributeError:
+            text_ids = self.tokenizer(list(texts))["input_ids"]
         return text_ids
 
     def __getitem__(self, idx):

--- a/rlinf/data/datasets/rstar2.py
+++ b/rlinf/data/datasets/rstar2.py
@@ -94,7 +94,13 @@ class Rstar2Dataset(ReasoningDataset):
         """
         Use tokenizer to encode the texts and return the token ids and length.
         """
-        text_ids = self.tokenizer.batch_encode_plus(
-            list(texts), add_special_tokens=False
-        )["input_ids"]
+        # transformers >= 5.0 TokenizersBackend removed batch_encode_plus
+        try:
+            text_ids = self.tokenizer.batch_encode_plus(
+                list(texts), add_special_tokens=False
+            )["input_ids"]
+        except AttributeError:
+            text_ids = self.tokenizer(list(texts), add_special_tokens=False)[
+                "input_ids"
+            ]
         return text_ids

--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -23,7 +23,16 @@ from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
 from torch.distributed.tensor import DTensor
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
-from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForVision2Seq
+from transformers import AutoConfig, AutoModelForCausalLM
+
+# AutoModelForVision2Seq was renamed to AutoModelForImageTextToText in transformers >= 5.0
+try:
+    from transformers import AutoModelForVision2Seq
+except ImportError:
+    try:
+        from transformers import AutoModelForImageTextToText as AutoModelForVision2Seq
+    except ImportError:
+        AutoModelForVision2Seq = None
 
 from rlinf.config import SupportedModel, torch_dtype_from_precision
 from rlinf.data.tokenizers import hf_tokenizer
@@ -173,7 +182,10 @@ class FSDPModelManager:
                 load_in_8bit=True,
             )
         else:
-            if type(model_config) in AutoModelForVision2Seq._model_mapping.keys():
+            if (
+                AutoModelForVision2Seq is not None
+                and type(model_config) in AutoModelForVision2Seq._model_mapping.keys()
+            ):
                 auto_model_class = AutoModelForVision2Seq
             else:
                 auto_model_class = AutoModelForCausalLM

--- a/rlinf/hybrid_engines/sglang/common/sgl_scheduler.py
+++ b/rlinf/hybrid_engines/sglang/common/sgl_scheduler.py
@@ -63,13 +63,17 @@ class Scheduler(_Scheduler):
         if not hasattr(self.tp_worker, "worker"):
             self.tp_worker.worker = self.tp_worker
 
-        self._request_dispatcher._mapping.extend(
-            [
-                (TaskMethodInput, self.run_task_method),
-                (SyncHFWeightInput, self.sync_hf_weight),
-                (AbortGenerationInput, self.abort_generation),
-            ]
-        )
+        # In sglang 0.4.x `_mapping` was a list; in 0.5.x it's an OrderedDict
+        _extra_req_mapping = [
+            (TaskMethodInput, self.run_task_method),
+            (SyncHFWeightInput, self.sync_hf_weight),
+            (AbortGenerationInput, self.abort_generation),
+        ]
+        if isinstance(self._request_dispatcher._mapping, dict):
+            for _ty, _fn in _extra_req_mapping:
+                self._request_dispatcher._mapping[_ty] = _fn
+        else:
+            self._request_dispatcher._mapping.extend(_extra_req_mapping)
 
         self.is_weight_offloaded = False
         self.weight_norm_dict = None

--- a/rlinf/hybrid_engines/sglang/common/tokenizer_manager.py
+++ b/rlinf/hybrid_engines/sglang/common/tokenizer_manager.py
@@ -19,10 +19,17 @@ import fastapi
 from packaging.version import parse
 from sglang.srt.managers.tokenizer_manager import TokenizerManager as _TokenizerManager
 
+# sglang renamed/moved the internal `_Communicator` across versions:
+#   0.4.x: sglang.srt.managers.tokenizer_manager._Communicator
+#   0.5.x (brief): sglang.srt.managers.tokenizer_communicator_mixin._Communicator
+#   0.5.12: sglang.srt.managers.communicator.FanOutCommunicator (renamed)
 try:
     from sglang.srt.managers.tokenizer_manager import _Communicator
 except ImportError:
-    from sglang.srt.managers.tokenizer_communicator_mixin import _Communicator
+    try:
+        from sglang.srt.managers.tokenizer_communicator_mixin import _Communicator
+    except ImportError:
+        from sglang.srt.managers.communicator import FanOutCommunicator as _Communicator
 from sglang.srt.server_args import PortArgs, ServerArgs
 
 from .io_struct import (
@@ -58,22 +65,16 @@ class TokenizerManager(_TokenizerManager):
             self.send_to_scheduler, server_args.dp_size
         )
 
-        self._result_dispatcher._mapping.extend(
-            [
-                (
-                    TaskMethodOutput,
-                    self.run_task_method_communicator.handle_recv,
-                ),
-                (
-                    SyncHFWeightOutput,
-                    self.sync_hf_weight_communicator.handle_recv,
-                ),
-                (
-                    AbortGenerationOutput,
-                    self.abort_generation_communicator.handle_recv,
-                ),
-            ]
-        )
+        _extra_mapping = [
+            (TaskMethodOutput, self.run_task_method_communicator.handle_recv),
+            (SyncHFWeightOutput, self.sync_hf_weight_communicator.handle_recv),
+            (AbortGenerationOutput, self.abort_generation_communicator.handle_recv),
+        ]
+        if isinstance(self._result_dispatcher._mapping, dict):
+            for _ty, _fn in _extra_mapping:
+                self._result_dispatcher._mapping[_ty] = _fn
+        else:
+            self._result_dispatcher._mapping.extend(_extra_mapping)
 
         try:
             sglang_version = parse(version("sglang"))
@@ -126,13 +127,31 @@ class TokenizerManager(_TokenizerManager):
         if not self.patch_return_output_ids:
             return super()._handle_batch_output(recv_obj)
 
-        from sglang.srt.managers.tokenizer_manager import (
-            BatchEmbeddingOut,
-            BatchMultimodalOut,
-            BatchStrOut,
-            BatchTokenIDOut,
-            logger,
-        )
+        # sglang renamed Batch*Out -> Batch*Output (moved to io_struct) in 0.5.x;
+        try:
+            from sglang.srt.managers.io_struct import (
+                BatchEmbeddingOutput as BatchEmbeddingOut,
+            )
+            from sglang.srt.managers.io_struct import (
+                BatchMultimodalOutput as BatchMultimodalOut,
+            )
+            from sglang.srt.managers.io_struct import (
+                BatchStrOutput as BatchStrOut,
+            )
+            from sglang.srt.managers.io_struct import (
+                BatchTokenIDOutput as BatchTokenIDOut,
+            )
+        except ImportError:
+            from sglang.srt.managers.tokenizer_manager import (
+                BatchEmbeddingOut,
+                BatchMultimodalOut,
+                BatchStrOut,
+                BatchTokenIDOut,
+            )
+        try:
+            from sglang.srt.managers.tokenizer_manager import logger
+        except ImportError:
+            from sglang.srt.managers.scheduler import logger
 
         for i, rid in enumerate(recv_obj.rids):
             state = self.rid_to_state.get(rid, None)

--- a/rlinf/models/embodiment/reward/vlm_reward_model.py
+++ b/rlinf/models/embodiment/reward/vlm_reward_model.py
@@ -26,7 +26,15 @@ from peft import (
     get_peft_model,
     set_peft_model_state_dict,
 )
-from transformers import AutoModelForVision2Seq
+
+# AutoModelForVision2Seq was renamed to AutoModelForImageTextToText in transformers >= 5.0
+try:
+    from transformers import AutoModelForVision2Seq
+except ImportError:
+    try:
+        from transformers import AutoModelForImageTextToText as AutoModelForVision2Seq
+    except ImportError:
+        AutoModelForVision2Seq = None
 
 from rlinf.config import torch_dtype_from_precision
 from rlinf.models.embodiment.reward.base_reward_model import BaseRewardModel

--- a/rlinf/utils/patcher.py
+++ b/rlinf/utils/patcher.py
@@ -193,9 +193,9 @@ class _Patcher:
 
     def _apply_to_class(self, cls):
         # patch member functions and member classes in classes
-        if cls in self._traced_cls:
+        if id(cls) in self._traced_cls:
             return
-        self._traced_cls.add(cls)
+        self._traced_cls.add(id(cls))
 
         for k, v in cls.__dict__.items():
             # most function with prefix '__' means it's an inner operator or variable

--- a/rlinf/workers/rollout/sglang/__init__.py
+++ b/rlinf/workers/rollout/sglang/__init__.py
@@ -31,7 +31,7 @@ sglang_version = None
 
 if package_version is None:
     raise ValueError(f"sglang version {package_version} not supported")
-elif package_version >= parse("0.4.4") and package_version <= parse("0.5.4"):
+elif package_version >= parse("0.4.4") and package_version <= parse("0.5.13"):
     sglang_version = package_version
     from rlinf.hybrid_engines.sglang.common import io_struct
     from rlinf.hybrid_engines.sglang.common.sgl_engine import (

--- a/rlinf/workers/rollout/sglang/sglang_worker.py
+++ b/rlinf/workers/rollout/sglang/sglang_worker.py
@@ -169,6 +169,12 @@ class SGLangWorker(Worker):
                 self._cfg_rollout.max_running_requests,
             ),
             tp_size=self._cfg_rollout.tensor_parallel_size,
+            # sglang >=0.5.11 drops the `enable_ep_moe` flag and enables EP via ep_size > 1.
+            ep_size=(
+                self._cfg_rollout.tensor_parallel_size
+                if self._cfg_rollout.sglang.get("enable_ep_moe", False)
+                else 1
+            ),
             mem_fraction_static=self._cfg_rollout.gpu_memory_utilization,
             enable_memory_saver=use_cudagraph,
             enable_torch_compile=self._cfg_rollout.sglang.use_torch_compile,


### PR DESCRIPTION
### Description

Companion to #1413 (which makes the sglang 0.5.12 + cu13 stack installable). This PR makes RLinf's sglang rollout, tokenizer, dataset and patcher code load and run on that stack. Each change is a dual-version fallback for one upstream API break; the 0.4.6 / cu12 / transformers 4.x path is unchanged.

- **sglang_worker.py** — sglang >=0.5.11 dropped the `enable_ep_moe` ServerArgs flag; EP is now enabled by `ep_size > 1`. Keep the `rollout.sglang.enable_ep_moe` config as the EP switch and translate it to `ep_size`.
- **fsdp_model_manager.py**, **vlm_reward_model.py** — transformers >=5.0 renamed `AutoModelForVision2Seq` to `AutoModelForImageTextToText` (old name removed); import with try/except for both versions.
- **workers/rollout/sglang/__init__.py** — raise the supported-sglang cap from 0.5.4 to 0.5.13 so 0.5.12.post1 is accepted.
- **tokenizer_manager.py** — `_Communicator` moved across sglang versions (0.4.x `tokenizer_manager` -> 0.5.x `tokenizer_communicator_mixin` -> 0.5.12 `communicator.FanOutCommunicator`); three-layer import fallback.
- **tokenizer_manager.py** — sglang 0.5.x renamed `Batch*Out` to `Batch*Output` (moved to `io_struct`) and relocated `logger`; import with fallback to the 0.4.x names.
- **tokenizer_manager.py**, **sgl_scheduler.py** — sglang 0.5.x made `TypeBasedDispatcher._mapping` an OrderedDict (was a list), so `.extend(...)` breaks; use dict assignment when it is a dict, else `.extend` for 0.4.x.
- **utils/patcher.py** — on the cu13 stack, nvidia-cutlass-dsl's `align` class raises in `__hash__` (references a missing `_value`), breaking the `cls in set` dedup; dedup traced classes by `id(cls)`.
- **data/datasets/reasoning.py**, **rstar2.py** — transformers >=5.0 (`TokenizersBackend`) removed `batch_encode_plus`; fall back to `tokenizer(...)` (`__call__`), which works on 4.x and 5.x.

### Motivation and Context

The sglang 0.5.11+ / torch 2.11+cu130 / TE 2.17 / transformers 5.6 stack is needed for newer models and the cu13 driver path (install side: #1413). RLinf's runtime code called sglang/transformers internals that were renamed, moved or removed in that stack, so it failed to import or run. This PR ports those call sites with dual-version fallbacks so one code base supports both the 0.4.6 / cu12 / transformers 4.x baseline and the 0.5.12 / cu13 / transformers 5.6 stack.

No linked issue.

### How has this been tested?

Verified in the Moonlight-16B RL e2e on sglang 0.5.12.post1 + torch 2.11+cu130 + TE 2.17 + transformers 5.6: rollout forward succeeds, training runs, checkpoint saved, clean exit.

The full Moonlight/MoE e2e additionally depends on the megatron-bridge provider-override whitelist and the DeepseekV3 weight convertor, which are model-line work (not version-compat shims) and tracked separately — out of scope here. A CI install/e2e test for the 0.5.12 cu13 path needs GPUs and a cu13 docker image; happy to coordinate with maintainers (per CONTRIBUTING, large-dependency tests may need maintainer help).

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] My code follows the code style of this project. (Google Python style; `ruff` is the configured linter.)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (Version-compat fallbacks; e2e needs GPUs/docker — manual verification above. Can add a CI test with maintainer help.)
- [ ] All new and existing tests passed. (Manual e2e passed; CI runs via the `run-ci` label.)
