### PR TITLE
fix(embodiment): avoid DAgger bootstrap mask mismatch

### DIFF
--- a/rlinf/data/embodied_io_struct.py
+++ b/rlinf/data/embodied_io_struct.py
@@ -290,6 +290,7 @@ class RolloutResult:
 
     bootstrap_values: torch.Tensor = None  # [B, 1]
     intervene_flags: torch.Tensor = None  # [B, num_action_chunks]
+    save_flags: torch.Tensor = None  # [B, num_action_chunks]
     forward_inputs: dict[str, torch.Tensor] = field(default_factory=dict)
     versions: torch.Tensor = None  # [B, 1]
 
@@ -304,6 +305,8 @@ class RolloutResult:
             self.bootstrap_values = self.bootstrap_values.cpu().contiguous()
         if self.intervene_flags is not None:
             self.intervene_flags = self.intervene_flags.cpu().contiguous()
+        if self.save_flags is not None:
+            self.save_flags = self.save_flags.cpu().contiguous()
         if self.forward_inputs:
             self.forward_inputs = put_tensor_device(self.forward_inputs, "cpu")
         if self.versions is not None:
@@ -331,6 +334,7 @@ class RolloutResult:
         merged_prev_values = _merge_optional_tensor("prev_values")
         merged_bootstrap_values = _merge_optional_tensor("bootstrap_values")
         merged_intervene_flags = _merge_optional_tensor("intervene_flags")
+        merged_save_flags = _merge_optional_tensor("save_flags")
         merged_versions = _merge_optional_tensor("versions")
 
         forward_inputs_list = [
@@ -347,6 +351,7 @@ class RolloutResult:
             prev_values=merged_prev_values,
             bootstrap_values=merged_bootstrap_values,
             intervene_flags=merged_intervene_flags,
+            save_flags=merged_save_flags,
             forward_inputs=merged_forward_inputs,
             versions=merged_versions,
         )
@@ -592,6 +597,21 @@ class EmbodiedRolloutResult:
         last_action = self.actions[-1]
         bsz, num_action_chunks = intervene_flags.shape
         expanded_flags = intervene_flags.reshape(bsz, num_action_chunks, 1).expand_as(
+            last_action.reshape(bsz, num_action_chunks, -1)
+        )
+        self.intervene_flags[-1] = expanded_flags.reshape(bsz, -1).to(torch.bool)
+
+    def mark_last_step_with_flags(self, save_flags: torch.Tensor):
+        if not self.intervene_flags:
+            return
+
+        if save_flags.dim() == 1:
+            save_flags = save_flags[:, None]
+        assert save_flags.dim() == 2, f"Expected 2D tensor, got {save_flags.shape=}"
+
+        last_action = self.actions[-1]
+        bsz, num_action_chunks = save_flags.shape
+        expanded_flags = save_flags.reshape(bsz, num_action_chunks, 1).expand_as(
             last_action.reshape(bsz, num_action_chunks, -1)
         )
         self.intervene_flags[-1] = expanded_flags.reshape(bsz, -1).to(torch.bool)
@@ -859,7 +879,7 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
 
     1. Auto-reset envs: ``final_observation`` is attributed to the finished
        episode; post-reset observations are carried via ``_pending_obs``.
-    2. DAgger intervention: ``RolloutResult.intervene_flags`` and expert actions
+    2. DAgger intervention: ``RolloutResult.save_flags`` and expert actions
        override recorded actions and set ``intervene_flag``.
     3. Real-world hooks: ``record_reset``, ``pre_record``, and
        ``segment_advance`` info flags are honored.
@@ -1116,7 +1136,7 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
     def _inject_expert_into_step_info(
         step_info: dict,
         expert_actions: np.ndarray,
-        intervene_flags,
+        save_flags,
         *,
         step_idx: int,
         step_term,
@@ -1125,22 +1145,22 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
         """Port of pre-refactor ``CollectEpisode.chunk_step`` expert injection."""
         if (
             expert_actions is None
-            or intervene_flags is None
+            or save_flags is None
             or "intervene_action" in step_info
         ):
             return
-        step_intervene_flags = intervene_flags[:, step_idx]
+        step_save_flags = save_flags[:, step_idx]
         step_expert = expert_actions[:, step_idx]
         if "final_info" in step_info:
             step_info["final_info"]["intervene_action"] = expert_actions
-            step_info["final_info"]["intervene_flag"] = intervene_flags
+            step_info["final_info"]["intervene_flag"] = save_flags
             step_info["intervene_action"] = step_expert
             term = EmbodiedLerobotRolloutResult._to_numpy(step_term)
             trunc = EmbodiedLerobotRolloutResult._to_numpy(step_trunc)
-            step_info["intervene_flag"] = step_intervene_flags & ~(term | trunc)
+            step_info["intervene_flag"] = step_save_flags & ~(term | trunc)
         else:
             step_info["intervene_action"] = step_expert
-            step_info["intervene_flag"] = step_intervene_flags
+            step_info["intervene_flag"] = step_save_flags
 
     def _update_episode_success(self, env_idx: int, env_info: Any) -> None:
         success = self._extract_success_from_info(env_info)
@@ -1265,11 +1285,9 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
             num_chunks=num_chunks,
             action_dim=action_dim,
         )
-        intervene_flags = rollout_result.intervene_flags
-        if intervene_flags is not None:
-            intervene_flags = self._to_numpy(intervene_flags).reshape(
-                num_envs, num_chunks
-            )
+        save_flags = rollout_result.save_flags
+        if save_flags is not None:
+            save_flags = self._to_numpy(save_flags).reshape(num_envs, num_chunks)
         expert_actions = rollout_result.forward_inputs.get("action", None)
         if expert_actions is not None:
             expert_actions = self._reshape_chunk_actions(
@@ -1302,7 +1320,7 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
                 self._inject_expert_into_step_info(
                     step_info,
                     expert_actions,
-                    intervene_flags,
+                    save_flags,
                     step_idx=step_idx,
                     step_term=step_term,
                     step_trunc=step_trunc,

--- a/rlinf/data/embodied_io_struct.py
+++ b/rlinf/data/embodied_io_struct.py
@@ -324,7 +324,6 @@ class RolloutResult:
 
     bootstrap_values: torch.Tensor = None  # [B, 1]
     intervene_flags: torch.Tensor = None  # [B, num_action_chunks]
-    save_flags: torch.Tensor = None  # [B, num_action_chunks]
     forward_inputs: dict[str, torch.Tensor] = field(default_factory=dict)
     versions: torch.Tensor = None  # [B, 1]
 
@@ -339,8 +338,6 @@ class RolloutResult:
             self.bootstrap_values = self.bootstrap_values.cpu().contiguous()
         if self.intervene_flags is not None:
             self.intervene_flags = self.intervene_flags.cpu().contiguous()
-        if self.save_flags is not None:
-            self.save_flags = self.save_flags.cpu().contiguous()
         if self.forward_inputs:
             self.forward_inputs = put_tensor_device(self.forward_inputs, "cpu")
         if self.versions is not None:
@@ -368,7 +365,6 @@ class RolloutResult:
         merged_prev_values = _merge_optional_tensor("prev_values")
         merged_bootstrap_values = _merge_optional_tensor("bootstrap_values")
         merged_intervene_flags = _merge_optional_tensor("intervene_flags")
-        merged_save_flags = _merge_optional_tensor("save_flags")
         merged_versions = _merge_optional_tensor("versions")
 
         forward_inputs_list = [
@@ -385,7 +381,6 @@ class RolloutResult:
             prev_values=merged_prev_values,
             bootstrap_values=merged_bootstrap_values,
             intervene_flags=merged_intervene_flags,
-            save_flags=merged_save_flags,
             forward_inputs=merged_forward_inputs,
             versions=merged_versions,
         )
@@ -631,21 +626,6 @@ class EmbodiedRolloutResult:
         last_action = self.actions[-1]
         bsz, num_action_chunks = intervene_flags.shape
         expanded_flags = intervene_flags.reshape(bsz, num_action_chunks, 1).expand_as(
-            last_action.reshape(bsz, num_action_chunks, -1)
-        )
-        self.intervene_flags[-1] = expanded_flags.reshape(bsz, -1).to(torch.bool)
-
-    def mark_last_step_with_flags(self, save_flags: torch.Tensor):
-        if not self.intervene_flags:
-            return
-
-        if save_flags.dim() == 1:
-            save_flags = save_flags[:, None]
-        assert save_flags.dim() == 2, f"Expected 2D tensor, got {save_flags.shape=}"
-
-        last_action = self.actions[-1]
-        bsz, num_action_chunks = save_flags.shape
-        expanded_flags = save_flags.reshape(bsz, num_action_chunks, 1).expand_as(
             last_action.reshape(bsz, num_action_chunks, -1)
         )
         self.intervene_flags[-1] = expanded_flags.reshape(bsz, -1).to(torch.bool)
@@ -913,7 +893,7 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
 
     1. Auto-reset envs: ``final_observation`` is attributed to the finished
        episode; post-reset observations are carried via ``_pending_obs``.
-    2. DAgger intervention: ``RolloutResult.save_flags`` and expert actions
+    2. DAgger intervention: ``RolloutResult.intervene_flags`` and expert actions
        override recorded actions and set ``intervene_flag``.
     3. Real-world hooks: ``record_reset``, ``pre_record``, and
        ``segment_advance`` info flags are honored.
@@ -1170,7 +1150,7 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
     def _inject_expert_into_step_info(
         step_info: dict,
         expert_actions: np.ndarray,
-        save_flags,
+        intervene_flags,
         *,
         step_idx: int,
         step_term,
@@ -1179,22 +1159,22 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
         """Port of pre-refactor ``CollectEpisode.chunk_step`` expert injection."""
         if (
             expert_actions is None
-            or save_flags is None
+            or intervene_flags is None
             or "intervene_action" in step_info
         ):
             return
-        step_save_flags = save_flags[:, step_idx]
+        step_intervene_flags = intervene_flags[:, step_idx]
         step_expert = expert_actions[:, step_idx]
         if "final_info" in step_info:
             step_info["final_info"]["intervene_action"] = expert_actions
-            step_info["final_info"]["intervene_flag"] = save_flags
+            step_info["final_info"]["intervene_flag"] = intervene_flags
             step_info["intervene_action"] = step_expert
             term = EmbodiedLerobotRolloutResult._to_numpy(step_term)
             trunc = EmbodiedLerobotRolloutResult._to_numpy(step_trunc)
-            step_info["intervene_flag"] = step_save_flags & ~(term | trunc)
+            step_info["intervene_flag"] = step_intervene_flags & ~(term | trunc)
         else:
             step_info["intervene_action"] = step_expert
-            step_info["intervene_flag"] = step_save_flags
+            step_info["intervene_flag"] = step_intervene_flags
 
     def _update_episode_success(self, env_idx: int, env_info: Any) -> None:
         success = self._extract_success_from_info(env_info)
@@ -1319,9 +1299,11 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
             num_chunks=num_chunks,
             action_dim=action_dim,
         )
-        save_flags = rollout_result.save_flags
-        if save_flags is not None:
-            save_flags = self._to_numpy(save_flags).reshape(num_envs, num_chunks)
+        intervene_flags = rollout_result.intervene_flags
+        if intervene_flags is not None:
+            intervene_flags = self._to_numpy(intervene_flags).reshape(
+                num_envs, num_chunks
+            )
         expert_actions = rollout_result.forward_inputs.get("action", None)
         if expert_actions is not None:
             expert_actions = self._reshape_chunk_actions(
@@ -1354,7 +1336,7 @@ class EmbodiedLerobotRolloutResult(EmbodiedRolloutResult):
                 self._inject_expert_into_step_info(
                     step_info,
                     expert_actions,
-                    save_flags,
+                    intervene_flags,
                     step_idx=step_idx,
                     step_term=step_term,
                     step_trunc=step_trunc,

--- a/rlinf/workers/env/env_worker.py
+++ b/rlinf/workers/env/env_worker.py
@@ -1104,6 +1104,10 @@ class EnvWorker(Worker):
                         ].mark_last_step_with_intervene_flags(
                             rollout_result.intervene_flags
                         )
+                    if rollout_result.save_flags is not None:
+                        self.rollout_results[stage_id].mark_last_step_with_flags(
+                            rollout_result.save_flags
+                        )
                     if self.enable_rlt and self.collect_transitions:
                         update_rlt_transitions(
                             stage_id,
@@ -1186,8 +1190,14 @@ class EnvWorker(Worker):
                 rewards = self.compute_bootstrap_rewards(
                     env_output, rollout_result.bootstrap_values, reward_model_output
                 )
+                final_actions = rollout_result.forward_inputs.get("action", None)
+                final_forward_inputs = rollout_result.forward_inputs
+                if self.cfg.algorithm.loss_type == "embodied_dagger":
+                    final_actions = None
+                    final_forward_inputs = {}
+
                 chunk_step_result = ChunkStepResult(
-                    actions=rollout_result.forward_inputs.get("action", None),
+                    actions=final_actions,
                     prev_logprobs=(
                         rollout_result.prev_logprobs
                         if self.collect_prev_infos
@@ -1196,7 +1206,7 @@ class EnvWorker(Worker):
                     prev_values=(
                         rollout_result.prev_values if self.collect_prev_infos else None
                     ),
-                    forward_inputs=rollout_result.forward_inputs,
+                    forward_inputs=final_forward_inputs,
                     versions=rollout_result.versions,
                     dones=env_output.dones,
                     truncations=env_output.truncations,

--- a/rlinf/workers/env/env_worker.py
+++ b/rlinf/workers/env/env_worker.py
@@ -1104,10 +1104,6 @@ class EnvWorker(Worker):
                         ].mark_last_step_with_intervene_flags(
                             rollout_result.intervene_flags
                         )
-                    if rollout_result.save_flags is not None:
-                        self.rollout_results[stage_id].mark_last_step_with_flags(
-                            rollout_result.save_flags
-                        )
                     if self.enable_rlt and self.collect_transitions:
                         update_rlt_transitions(
                             stage_id,

--- a/rlinf/workers/env/env_worker.py
+++ b/rlinf/workers/env/env_worker.py
@@ -1188,7 +1188,10 @@ class EnvWorker(Worker):
                 )
                 final_actions = rollout_result.forward_inputs.get("action", None)
                 final_forward_inputs = rollout_result.forward_inputs
-                if self.cfg.algorithm.loss_type == "embodied_dagger":
+                if (
+                    OmegaConf.select(self.cfg, "algorithm.loss_type", default="")
+                    == "embodied_dagger"
+                ):
                     final_actions = None
                     final_forward_inputs = {}
 

--- a/rlinf/workers/rollout/hf/huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/huggingface_worker.py
@@ -583,8 +583,9 @@ class MultiStepRolloutWorker(Worker):
         final_obs: dict[str, Any] | None = None,
     ) -> RolloutResult:
         intervene_flags = result.get("intervene_flags")
-        if intervene_flags is None and result.get("expert_label_flag", False):
-            intervene_flags = torch.full(
+        save_flags = None
+        if self.enable_dagger and result.get("expert_label_flag", False):
+            save_flags = torch.full(
                 (actions.shape[0], self.model_cfg.num_action_chunks),
                 True,
                 dtype=torch.bool,
@@ -596,6 +597,7 @@ class MultiStepRolloutWorker(Worker):
             prev_values=result["prev_values"] if self.collect_prev_infos else None,
             bootstrap_values=self.get_bootstrap_values(final_obs),
             intervene_flags=intervene_flags,
+            save_flags=save_flags,
             forward_inputs=result["forward_inputs"],
             versions=torch.full_like(
                 result["prev_logprobs"],
@@ -969,6 +971,7 @@ class MultiStepRolloutWorker(Worker):
         split_prev_values = _split_optional_tensor(rollout_result.prev_values)
         split_bootstrap_values = _split_optional_tensor(rollout_result.bootstrap_values)
         split_intervene_flags = _split_optional_tensor(rollout_result.intervene_flags)
+        split_save_flags = _split_optional_tensor(rollout_result.save_flags)
         split_versions = _split_optional_tensor(rollout_result.versions)
         split_forward_inputs = (
             [{} for _ in sizes]
@@ -990,6 +993,7 @@ class MultiStepRolloutWorker(Worker):
                 prev_values=split_prev_values[idx],
                 bootstrap_values=split_bootstrap_values[idx],
                 intervene_flags=split_intervene_flags[idx],
+                save_flags=split_save_flags[idx],
                 forward_inputs=split_forward_inputs[idx],
                 versions=split_versions[idx],
             )

--- a/rlinf/workers/rollout/hf/huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/huggingface_worker.py
@@ -583,9 +583,12 @@ class MultiStepRolloutWorker(Worker):
         final_obs: dict[str, Any] | None = None,
     ) -> RolloutResult:
         intervene_flags = result.get("intervene_flags")
-        save_flags = None
-        if self.enable_dagger and result.get("expert_label_flag", False):
-            save_flags = torch.full(
+        if (
+            intervene_flags is None
+            and self.enable_dagger
+            and result.get("expert_label_flag", False)
+        ):
+            intervene_flags = torch.full(
                 (actions.shape[0], self.model_cfg.num_action_chunks),
                 True,
                 dtype=torch.bool,
@@ -597,7 +600,6 @@ class MultiStepRolloutWorker(Worker):
             prev_values=result["prev_values"] if self.collect_prev_infos else None,
             bootstrap_values=self.get_bootstrap_values(final_obs),
             intervene_flags=intervene_flags,
-            save_flags=save_flags,
             forward_inputs=result["forward_inputs"],
             versions=torch.full_like(
                 result["prev_logprobs"],
@@ -971,7 +973,6 @@ class MultiStepRolloutWorker(Worker):
         split_prev_values = _split_optional_tensor(rollout_result.prev_values)
         split_bootstrap_values = _split_optional_tensor(rollout_result.bootstrap_values)
         split_intervene_flags = _split_optional_tensor(rollout_result.intervene_flags)
-        split_save_flags = _split_optional_tensor(rollout_result.save_flags)
         split_versions = _split_optional_tensor(rollout_result.versions)
         split_forward_inputs = (
             [{} for _ in sizes]
@@ -993,7 +994,6 @@ class MultiStepRolloutWorker(Worker):
                 prev_values=split_prev_values[idx],
                 bootstrap_values=split_bootstrap_values[idx],
                 intervene_flags=split_intervene_flags[idx],
-                save_flags=split_save_flags[idx],
                 forward_inputs=split_forward_inputs[idx],
                 versions=split_versions[idx],
             )


### PR DESCRIPTION
### Description

This PR fixes a DAgger rollout regression introduced after the RLT integration.

Before PR #1352, DAgger used `RolloutResult.save_flags` to mark expert-labeled chunks that should be saved and used for training. Later, when trajectories were built, those `save_flags` were mapped into `Trajectory.intervene_flags` only because the existing DAgger actor still consumes trajectories through `extract_intervene_traj(mode="all")`.

After the RLT changes, this DAgger save/train mask was routed through `RolloutResult.intervene_flags` instead. That mixed two different meanings in the same field:

- For RLT, `intervene_flags` means actual expert intervention/takeover.
- For DAgger, the flag is a save/train mask for expert-labeled data.

This PR restores the old DAgger data path by:
- Restoring `RolloutResult.save_flags` for DAgger expert-label save masks.
- Keeping `RolloutResult.intervene_flags` for actual intervention semantics.
- Passing `save_flags` through rollout result merge/split.
- Mapping `save_flags` back into final `Trajectory.intervene_flags` only for the legacy DAgger extraction path.
- Skipping final bootstrap `actions` and `forward_inputs` append for DAgger.

### Motivation and Context

`robotwin_adjust_bottle_dagger_openpi` can fail with:

```text
IndexError: The shape of the mask [5] at index 0 does not match the shape of the indexed tensor [4, 50] at index 0
```

The direct cause is a trajectory length mismatch. DAgger can produce a `trajectory.intervene_flags` mask with one more timestep than `trajectory.rewards`.

That extra mask row comes from the final bootstrap rollout result. The final bootstrap result is needed to compute bootstrap values/rewards, but it should not create another normal training action step for DAgger. Previously, it still appended `actions` and `forward_inputs`. Since `EmbodiedRolloutResult.append_step_result()` creates an `intervene_flags` row whenever `actions` exists, this added one extra mask row without a matching reward row.

The deeper issue is the flag semantic regression after RLT was added. DAgger's original `save_flags` path was collapsed into `intervene_flags`, while RLT also uses `intervene_flags` for real expert takeover. This made DAgger depend on a field whose meaning had changed.

This PR restores DAgger behavior close to the pre-PR #1352 implementation while preserving the RLT meaning of `intervene_flags`.

### How has this been tested?

RoboTwin and RLT can be trained as they should be and results is alright.

### Additional information (optional, e.g., figures and logs):

N/A

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
