### PR TITLE
fix(scheduler): introduce serialization for PG

### DIFF
--- a/rlinf/scheduler/cluster/cluster.py
+++ b/rlinf/scheduler/cluster/cluster.py
@@ -100,6 +100,19 @@ class ClusterEnvVar(str, Enum):
     Set explicitly when workers do not share a filesystem with the launch node.
     """
 
+    SERIALIZE_PG_LIFECYCLE = "SERIALIZE_PG_LIFECYCLE"
+    """Serialize ProcessGroup create/destroy within a process.
+
+    Concurrent GLOO rendezvous / TCPStore from multiple threads can abort with
+    ``pybind11_object_dealloc`` on older torch builds. Env FT recovery hits this
+    when many send-queue threads rebuild peer groups at once.
+
+    Values (``RLINF_SERIALIZE_PG_LIFECYCLE``):
+        - Unset: enabled when ``torch < 2.7.0``, disabled when ``torch >= 2.7.0``.
+        - ``1`` / ``true`` / ``on`` / ``yes``: force enable.
+        - ``0`` / ``false`` / ``off`` / ``no``: force disable.
+    """
+
 
 class PathEnvMergeMode(str, Enum):
     """Merge mode for path-like worker env vars."""
@@ -128,6 +141,7 @@ class Cluster:
         ClusterEnvVar.EXT_MODULE: None,
         ClusterEnvVar.PATH_ENV_MERGE_MODE: PathEnvMergeMode.APPEND.value,
         ClusterEnvVar.CODE_WORKING_DIR: "0",
+        ClusterEnvVar.SERIALIZE_PG_LIFECYCLE: None,
     }
     PATH_LIKE_ENV_VARS = {
         "PYTHONPATH",

--- a/rlinf/scheduler/collective/multi_channel_pg.py
+++ b/rlinf/scheduler/collective/multi_channel_pg.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import logging
+import threading
+from contextlib import nullcontext
 from datetime import timedelta
 from typing import Optional
 
 import torch
 import torch.distributed as dist
+from packaging.version import parse as parse_version
 
 from ..hardware import AcceleratorType, AcceleratorUtil
 from .async_work import AsyncCollWork, AsyncWork
@@ -26,6 +29,53 @@ from .collective_group import (
     CollectiveGroupInfo,
     CollectiveGroupOptions,
 )
+
+# Serialize ProcessGroup create/destroy within a process when enabled.
+# Concurrent GLOO rendezvous / TCPStore from multiple threads can abort with:
+#   pybind11_object_dealloc(): Tried to deallocate unregistered instance!
+# (known torch/pybind race). Env FT recovery hits this when many send-queue
+# threads rebuild peer groups at once. Prefer correctness over parallel init.
+#
+# Default: on for torch < 2.7.0, off for torch >= 2.7.0.
+# Override with RLINF_SERIALIZE_PG_LIFECYCLE=0/1 (see ClusterEnvVar).
+# Corresponding issue: https://github.com/pytorch/pytorch/pull/143598
+# and https://github.com/pybind/pybind11/issues/5473
+_PROCESS_GROUP_LIFECYCLE_LOCK = threading.RLock()
+_TORCH_SERIALIZE_PG_LIFECYCLE_CUTOFF = "2.7.0"
+_TRUE_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_ENV_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def is_process_group_lifecycle_lock_enabled() -> bool:
+    """Return whether ProcessGroup create/destroy should be serialized.
+
+    Honors ``RLINF_SERIALIZE_PG_LIFECYCLE`` when set; otherwise defaults to
+    enabled for ``torch < 2.7.0`` and disabled for ``torch >= 2.7.0``.
+    """
+    from ..cluster import Cluster, ClusterEnvVar
+
+    raw = Cluster.get_sys_env_var(ClusterEnvVar.SERIALIZE_PG_LIFECYCLE)
+    if raw is not None and str(raw).strip() != "":
+        lowered = str(raw).strip().lower()
+        if lowered in _TRUE_ENV_VALUES:
+            return True
+        if lowered in _FALSE_ENV_VALUES:
+            return False
+        env_name = Cluster.get_full_env_var_name(ClusterEnvVar.SERIALIZE_PG_LIFECYCLE)
+        raise ValueError(
+            f"Invalid {env_name}={raw!r}; expected one of "
+            f"{sorted(_TRUE_ENV_VALUES | _FALSE_ENV_VALUES)} or unset."
+        )
+    return parse_version(torch.__version__) < parse_version(
+        _TORCH_SERIALIZE_PG_LIFECYCLE_CUTOFF
+    )
+
+
+def _process_group_lifecycle_guard():
+    """Acquire the lifecycle lock when serialization is enabled."""
+    if is_process_group_lifecycle_lock_enabled():
+        return _PROCESS_GROUP_LIFECYCLE_LOCK
+    return nullcontext()
 
 
 class MultiChannelProcessGroup:
@@ -475,6 +525,40 @@ class MultiChannelProcessGroup:
         """Create a new process group.
 
         This function is modified version of dist.init_process_group to allow creating multiple process groups without the default process group and new processes unknown to existing process groups (therefore new_group cannot be used).
+
+        When serialization is enabled (see ``RLINF_SERIALIZE_PG_LIFECYCLE``),
+        creation is locked process-wide to avoid torch/pybind races on
+        concurrent GLOO rendezvous / TCPStore.
+        """
+        with _process_group_lifecycle_guard():
+            return MultiChannelProcessGroup._create_process_group_unlocked(
+                backend=backend,
+                init_method=init_method,
+                timeout=timeout,
+                world_size=world_size,
+                rank=rank,
+                store=store,
+                group_name=group_name,
+                pg_options=pg_options,
+                device_id=device_id,
+            )
+
+    @staticmethod
+    def _create_process_group_unlocked(
+        backend=None,
+        init_method=None,
+        timeout=None,
+        world_size=-1,
+        rank=-1,
+        store=None,
+        group_name=None,
+        pg_options=None,
+        device_id=None,
+    ) -> dist.ProcessGroup:
+        """Create a process group without taking the lifecycle lock.
+
+        Callers must hold ``_PROCESS_GROUP_LIFECYCLE_LOCK`` when serialization
+        is enabled, or accept the concurrent-init risk when it is disabled.
         """
         from torch.distributed.distributed_c10d import (
             Backend,
@@ -543,6 +627,28 @@ class MultiChannelProcessGroup:
 
         This is a modified version of dist.new_group to allow splitting any existing process groups (not only the default group like dist.new_group) into a new one.
         """
+        with _process_group_lifecycle_guard():
+            return MultiChannelProcessGroup._split_process_group_unlocked(
+                base_group=base_group,
+                timeout=timeout,
+                backend=backend,
+                pg_options=pg_options,
+                group_name=group_name,
+            )
+
+    @staticmethod
+    def _split_process_group_unlocked(
+        base_group: dist.ProcessGroup = None,
+        timeout=None,
+        backend=None,
+        pg_options=None,
+        group_name=None,
+    ) -> dist.ProcessGroup:
+        """Split a process group without taking the lifecycle lock.
+
+        Callers must hold ``_PROCESS_GROUP_LIFECYCLE_LOCK`` when serialization
+        is enabled, or accept the concurrent-init risk when it is disabled.
+        """
         dist.new_group
         from torch.distributed.distributed_c10d import (
             Backend,
@@ -590,7 +696,7 @@ class MultiChannelProcessGroup:
             device_id=device_id,
         )
         if result is None:
-            pg = MultiChannelProcessGroup._create_process_group(
+            pg = MultiChannelProcessGroup._create_process_group_unlocked(
                 backend=backend,
                 world_size=group_world_size,
                 rank=group_rank,

--- a/rlinf/scheduler/collective/multi_channel_pg.py
+++ b/rlinf/scheduler/collective/multi_channel_pg.py
@@ -649,7 +649,6 @@ class MultiChannelProcessGroup:
         Callers must hold ``_PROCESS_GROUP_LIFECYCLE_LOCK`` when serialization
         is enabled, or accept the concurrent-init risk when it is disabled.
         """
-        dist.new_group
         from torch.distributed.distributed_c10d import (
             Backend,
             _check_valid_timeout,

--- a/tests/unit_tests/test_concurrent_pg_init_safety.py
+++ b/tests/unit_tests/test_concurrent_pg_init_safety.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The RLinf Authors.
+# Copyright 2026 The RLinf Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -106,9 +106,7 @@ def _run_stress_in_subprocess(timeout_s: float = 180.0) -> dict:
     if proc.is_alive():
         proc.kill()
         proc.join(timeout=10)
-        pytest.fail(
-            f"Concurrent GLOO ProcessGroup stress timed out after {timeout_s}s"
-        )
+        pytest.fail(f"Concurrent GLOO ProcessGroup stress timed out after {timeout_s}s")
     if proc.exitcode != 0:
         # Negative exitcode means killed by signal (-6 == SIGABRT).
         pytest.fail(

--- a/tests/unit_tests/test_concurrent_pg_init_safety.py
+++ b/tests/unit_tests/test_concurrent_pg_init_safety.py
@@ -1,0 +1,133 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import gc
+import multiprocessing as mp
+import socket
+import threading
+from datetime import timedelta
+
+import pytest
+import torch.distributed as dist
+
+from rlinf.scheduler.collective.multi_channel_pg import (
+    MultiChannelProcessGroup,
+    _process_group_lifecycle_guard,
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _stress_concurrent_create_process_group(
+    num_threads: int = 16,
+    trials: int = 4,
+    iters_per_trial: int = 8,
+) -> dict:
+    """Create/destroy GLOO PGs from many threads; must survive without abort."""
+    errors: list[str] = []
+    lock = threading.Lock()
+
+    for trial in range(trials):
+        # Unique ports per thread: mirrors production peer-group rebuilds and
+        # avoids TCP port reuse stalls when create/destroy is serialized.
+        ports = [_free_port() for _ in range(num_threads)]
+        barrier = threading.Barrier(num_threads)
+
+        def worker(thread_id: int) -> None:
+            port = ports[thread_id]
+            for step in range(iters_per_trial):
+                barrier.wait()
+                try:
+                    pg = MultiChannelProcessGroup._create_process_group(
+                        backend="gloo",
+                        init_method=f"tcp://127.0.0.1:{port}",
+                        world_size=1,
+                        rank=0,
+                        group_name=f"safe_gloo_{thread_id}_{trial}_{step}",
+                        timeout=timedelta(seconds=5),
+                    )
+                    try:
+                        with _process_group_lifecycle_guard():
+                            dist.destroy_process_group(pg)
+                    except Exception:
+                        pass
+                    del pg
+                except Exception as exc:
+                    with lock:
+                        errors.append(repr(exc))
+                barrier.wait()
+                gc.collect()
+
+        threads = [
+            threading.Thread(target=worker, args=(tid,)) for tid in range(num_threads)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+    return {
+        "ok": True,
+        "errors": errors[:20],
+        "num_errors": len(errors),
+    }
+
+
+def _stress_child(result_queue: mp.Queue) -> None:
+    """Child entrypoint so SIGABRT cannot tear down the pytest process."""
+    result_queue.put(_stress_concurrent_create_process_group())
+
+
+def _run_stress_in_subprocess(timeout_s: float = 180.0) -> dict:
+    """Run PG stress in a spawned child and surface abort as a pytest failure."""
+    ctx = mp.get_context("spawn")
+    result_queue: mp.Queue = ctx.Queue()
+    proc = ctx.Process(target=_stress_child, args=(result_queue,))
+    proc.start()
+    proc.join(timeout=timeout_s)
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=10)
+        pytest.fail(
+            f"Concurrent GLOO ProcessGroup stress timed out after {timeout_s}s"
+        )
+    if proc.exitcode != 0:
+        # Negative exitcode means killed by signal (-6 == SIGABRT).
+        pytest.fail(
+            "Child aborted during concurrent GLOO ProcessGroup init "
+            f"(exitcode={proc.exitcode}); likely pybind11_object_dealloc SIGABRT."
+        )
+    assert not result_queue.empty(), "Child exited 0 but produced no result"
+    return result_queue.get()
+
+
+class TestConcurrentProcessGroupInitSafety:
+    """Concurrent GLOO PG init must not abort the process when serialization is on."""
+
+    def test_concurrent_gloo_pg_init_does_not_abort_worker(self):
+        # Run in a subprocess so a pybind SIGABRT is reported via exitcode
+        # instead of killing pytest through WorkerGroup's SIGUSR1 failure path.
+        results = _run_stress_in_subprocess()
+        assert results["ok"] is True
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Serialize ProcessGroup create/destroy/split within a process to avoid a known torch/pybind race on concurrent GLOO rendezvous / TCPStore.

Changes:
- Add `RLINF_SERIALIZE_PG_LIFECYCLE` (`ClusterEnvVar.SERIALIZE_PG_LIFECYCLE`):
  - unset: enabled for `torch < 2.7.0`, disabled for `torch >= 2.7.0`
  - `1`/`true`/`on`/`yes`: force enable
  - `0`/`false`/`off`/`no`: force disable
- Wrap `MultiChannelProcessGroup._create_process_group` / `_split_process_group` with a process-wide lifecycle lock when serialization is enabled
- Add a unit test that stresses concurrent GLOO PG create/destroy in a subprocess (so a pybind `SIGABRT` is reported via exit code instead of killing pytest)

### Motivation and Context
Concurrent GLOO ProcessGroup create/destroy from multiple threads can abort with:
```text
pybind11_object_dealloc(): Tried to deallocate unregistered instance!
```
This is a known torch/pybind race (see [pytorch#143598](https://github.com/pytorch/pytorch/pull/143598), [pybind11#5473](https://github.com/pybind/pybind11/issues/5473)). Prefer correctness over parallel PG init on older torch builds; keep the opt-out for newer torch and for explicit overrides.

### How has this been tested?
- Added `tests/unit_tests/test_concurrent_pg_init_safety.py`
- Ran locally with torch `2.6.0+cu124`:
  - default behavior (serialization on): test **PASSED**
  - forced `RLINF_SERIALIZE_PG_LIFECYCLE=0`: child aborts and the harness reports a clear failure (expected)

### Additional information (optional, e.g., figures and logs):
Default policy matches the torch cutoff where the upstream race is expected to be fixed (`>= 2.7.0`).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.