### PR TITLE
fix(scheduler): allocate ports outside the kernel ephemeral range

### DIFF
--- a/docs/source-en/rst_source/resources/faq.rst
+++ b/docs/source-en/rst_source/resources/faq.rst
@@ -166,6 +166,34 @@ interface is chosen).
 - If needed, choose the correct interface's IP address explicitly for the Ray
   head and share that IP with workers.
 
+Random "address already in use" (EADDRINUSE) During Startup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Symptom:** A run fails intermittently while an engine starts, e.g.
+``torch.distributed.DistNetworkError: The server socket has failed to listen on any
+local network address. port: <N>, name: EADDRINUSE``. Checking the port by hand
+afterwards always shows it as free.
+
+**Cause:** RLinf allocates listening ports from the band given by ``RLINF_PORT_RANGE``
+(default ``20000-32767``) precisely so this cannot happen. If that band is exhausted or
+misconfigured, allocation falls back to asking the kernel for an ephemeral port. The
+kernel draws ephemeral ports (``net.ipv4.ip_local_port_range``, typically
+``32768-60999``) for the source ports of *outbound* connections too, so a port that was
+free when it was reserved can be taken by an unrelated outgoing socket in the seconds
+before the server binds it. The port genuinely is free at check time, which is why
+probing it never reproduces the failure.
+
+**Fix:**
+
+- Make sure ``RLINF_PORT_RANGE`` does not overlap ``net.ipv4.ip_local_port_range``
+  (``cat /proc/sys/net/ipv4/ip_local_port_range``), and is wide enough for all workers.
+- If several RLinf runs share one machine, leave ``RLINF_PORT_LOCK_DIR`` on a local
+  filesystem shared by all of them (default ``/tmp/rlinf-port-locks``). The lock is what
+  keeps independent Ray clusters on one host from being handed the same port.
+- Stop leftover processes from a previous run (``ray stop --force``) before starting a
+  new one; orphaned engine subprocesses keep holding ports that the new run's lock
+  manager knows nothing about.
+
 CUDA Issues
 -------------
 

--- a/docs/source-zh/rst_source/resources/faq.rst
+++ b/docs/source-zh/rst_source/resources/faq.rst
@@ -157,8 +157,31 @@ Vulkan Incompatible GPU Driver
 
 **修复：**
 
-- 确认所选 IP 能被其他节点访问（例如使用 ping 测试）。  
+- 确认所选 IP 能被其他节点访问（例如使用 ping 测试）。
 - 如有需要，请显式选择正确网卡对应的 IP 作为 Ray head，并将该 IP 告知各 Worker。
+
+启动过程中偶发 “address already in use”（EADDRINUSE）
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**现象：** 引擎启动过程中偶发失败，例如
+``torch.distributed.DistNetworkError: The server socket has failed to listen on any
+local network address. port: <N>, name: EADDRINUSE``。事后手动检查该端口时，总是显示空闲。
+
+**原因：** RLinf 从 ``RLINF_PORT_RANGE`` 指定的端口段（默认 ``20000-32767``）分配监听端口，
+正是为了避免这一问题。若该端口段被占满或配置有误，分配会退回到向内核申请临时端口。
+内核同样会从临时端口范围（``net.ipv4.ip_local_port_range``，通常为 ``32768-60999``）
+为**出站**连接分配源端口，因此一个在预留时确实空闲的端口，可能在服务真正 bind 之前的
+几秒内被无关的出站套接字占用。检查时该端口确实空闲，这正是事后探测无法复现该故障的原因。
+
+**修复：**
+
+- 确认 ``RLINF_PORT_RANGE`` 与 ``net.ipv4.ip_local_port_range``
+  （``cat /proc/sys/net/ipv4/ip_local_port_range``）不重叠，且范围足够容纳所有 Worker。
+- 若同一台机器上有多个 RLinf 任务并行，请让它们共享同一个本地文件系统上的
+  ``RLINF_PORT_LOCK_DIR``（默认 ``/tmp/rlinf-port-locks``）。该锁用于避免同一主机上相互
+  独立的 Ray 集群拿到相同端口。
+- 启动新任务前，先清理上一次运行残留的进程（``ray stop --force``）；残留的引擎子进程会继续
+  占用端口，而新任务的锁管理器对此一无所知。
 
 CUDA 问题
 ----------

--- a/rlinf/scheduler/cluster/cluster.py
+++ b/rlinf/scheduler/cluster/cluster.py
@@ -79,6 +79,29 @@ class ClusterEnvVar(str, Enum):
         export RLINF_EXT_MODULE=workflows.scripts.rlinf_ext
     """
 
+    PORT_RANGE = "PORT_RANGE"
+    """Inclusive port band that workers allocate listening ports from, as ``<low>-<high>``.
+
+    Ports are allocated from this band instead of asking the kernel for an ephemeral
+    port, because the kernel draws ephemeral ports (``net.ipv4.ip_local_port_range``,
+    typically 32768-60999) for the source ports of *outbound* connections too. A port
+    that was free when it was picked can therefore be handed to an unrelated outgoing
+    socket before the server that reserved it gets around to binding, which surfaces
+    much later as ``EADDRINUSE``.
+
+    Defaults to ``20000-32767``. Set this when the default band overlaps something else
+    on the host. If the band is exhausted, allocation falls back to an ephemeral port.
+    """
+
+    PORT_LOCK_DIR = "PORT_LOCK_DIR"
+    """Directory holding the host-wide port lock files. Defaults to ``/tmp/rlinf-port-locks``.
+
+    Port reservations are recorded both in the cluster's ``PortLockManager`` and as an
+    ``flock`` under this directory. The latter is what keeps two Ray clusters sharing a
+    host -- concurrent CI jobs, most commonly -- from handing out the same port, since
+    each cluster has its own manager but they all share one kernel port space.
+    """
+
     PATH_ENV_MERGE_MODE = "PATH_ENV_MERGE_MODE"
     """How to merge path-like env vars when allocating workers.
 
@@ -126,6 +149,10 @@ class Cluster:
         ClusterEnvVar.NODE_RANK: None,
         ClusterEnvVar.COMM_NET_DEVICES: None,
         ClusterEnvVar.EXT_MODULE: None,
+        # Left unset so the code defaults apply uniformly; propagated to workers only
+        # when the user overrides them, which keeps every worker on the same band.
+        ClusterEnvVar.PORT_RANGE: None,
+        ClusterEnvVar.PORT_LOCK_DIR: None,
         ClusterEnvVar.PATH_ENV_MERGE_MODE: PathEnvMergeMode.APPEND.value,
         ClusterEnvVar.CODE_WORKING_DIR: "0",
     }
@@ -142,16 +169,136 @@ class Cluster:
     class NamespaceConflictError(Exception):
         """Raised when there is a namespace conflict in Ray initialization."""
 
+    DEFAULT_PORT_RANGE = (20000, 32767)
+    """Fallback band for :meth:`find_free_port`. See ``ClusterEnvVar.PORT_RANGE``."""
+
+    DEFAULT_PORT_RANGE_WIDTH = 12768
+    """Width of the auto-derived default band, matching :attr:`DEFAULT_PORT_RANGE`."""
+
+    @classmethod
+    def get_ephemeral_port_range(cls) -> Optional[tuple[int, int]]:
+        """Return the kernel's ephemeral port range, or None if it cannot be read.
+
+        Ports in this range are handed out as the source ports of outbound connections,
+        so allocating a *listening* port from it is inherently racy.
+        """
+        try:
+            with open("/proc/sys/net/ipv4/ip_local_port_range") as handle:
+                low, high = handle.read().split()
+            return int(low), int(high)
+        except (OSError, ValueError):
+            return None
+
+    @classmethod
+    def default_port_range(cls) -> tuple[int, int]:
+        """Return the default band, placed below the kernel's ephemeral range.
+
+        Derived from ``net.ipv4.ip_local_port_range`` so the default stays correct on
+        hosts that have retuned it. Falls back to :attr:`DEFAULT_PORT_RANGE` when the
+        setting is unreadable or leaves no usable window below it.
+        """
+        ephemeral = cls.get_ephemeral_port_range()
+        if ephemeral is None:
+            return cls.DEFAULT_PORT_RANGE
+        high = min(cls.DEFAULT_PORT_RANGE[1], ephemeral[0] - 1)
+        low = max(1024, high - cls.DEFAULT_PORT_RANGE_WIDTH + 1)
+        if low >= high:
+            # The ephemeral range starts too low to leave a usable window below it; the
+            # operator needs to set RLINF_PORT_RANGE (or retune the kernel) explicitly.
+            return cls.DEFAULT_PORT_RANGE
+        return low, high
+
+    @classmethod
+    def get_port_range(cls) -> tuple[int, int]:
+        """Return the inclusive band that :meth:`find_free_port` allocates from.
+
+        Reads ``RLINF_PORT_RANGE`` (``<low>-<high>``), falling back to
+        :meth:`default_port_range`.
+
+        Raises:
+            ValueError: If ``RLINF_PORT_RANGE`` is set but not a valid ``<low>-<high>`` band.
+        """
+        raw = os.getenv(f"{cls.SYS_NAME.upper()}_{ClusterEnvVar.PORT_RANGE.value}")
+        if not raw:
+            return cls.default_port_range()
+        match = re.fullmatch(r"\s*(\d+)\s*-\s*(\d+)\s*", raw)
+        if match is None:
+            raise ValueError(
+                f"Invalid {cls.SYS_NAME.upper()}_{ClusterEnvVar.PORT_RANGE.value}={raw!r}; "
+                "expected '<low>-<high>'."
+            )
+        low, high = int(match.group(1)), int(match.group(2))
+        if not (0 < low <= high <= 65535):
+            raise ValueError(
+                f"Invalid {cls.SYS_NAME.upper()}_{ClusterEnvVar.PORT_RANGE.value}={raw!r}; "
+                "expected 0 < low <= high <= 65535."
+            )
+        return low, high
+
+    @classmethod
+    def _port_is_bindable(cls, port: int) -> bool:
+        """Return whether a listening socket can currently bind ``port`` on all interfaces.
+
+        ``SO_REUSEADDR`` is deliberately *not* set so that this mirrors what a plain
+        server (``TCPStore``, an HTTP server, ...) will experience: a port still held in
+        ``TIME_WAIT`` is reported as unavailable rather than free.
+        """
+        import socket
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", port))
+            except OSError:
+                return False
+        return True
+
     @classmethod
     def find_free_port(cls, max_port_num: Optional[int] = None):
         """Find a free port on the node.
 
+        Ports are drawn from the ``RLINF_PORT_RANGE`` band rather than from the kernel's
+        ephemeral range. Binding to port 0 and closing the socket only reports a port
+        that *was* free: the kernel is then free to hand that same port to any outbound
+        connection's source port, and the caller -- which typically binds seconds later,
+        often from a subprocess -- fails with ``EADDRINUSE``. Ports outside the ephemeral
+        range are never auto-assigned, which removes that race rather than narrowing it.
+
         Args:
             max_port_num (Optional[int]): Largest acceptable port. Use it for servers that
                 derive a second port from this one and would overflow past 65535.
+
+        Returns:
+            int: A port that was bindable at the time of the call.
+
+        Raises:
+            RuntimeError: If neither the configured band nor the ephemeral fallback yields a port.
         """
+        import random
         import socket
 
+        low, high = cls.get_port_range()
+        if max_port_num is not None:
+            if max_port_num < low:
+                # The configured band sits entirely above the caller's cap. Scan below it
+                # instead of falling through to an ephemeral port, which the kernel draws
+                # from a range that is itself above the cap and so can never satisfy it.
+                low, high = 1024, max_port_num
+            else:
+                high = min(high, max_port_num)
+
+        if low <= high:
+            # Probe from a random offset so that concurrently starting workers do not all
+            # walk the band from the same end and collide on every candidate.
+            span = high - low + 1
+            start = random.randrange(span)
+            for offset in range(span):
+                port = low + (start + offset) % span
+                if cls._port_is_bindable(port):
+                    return port
+
+        # Band exhausted or unusable: fall back to an ephemeral port. This restores the
+        # old (racy) behavior rather than failing outright, so a misconfigured band
+        # degrades to what previous releases did instead of breaking the run.
         for _ in range(1000):
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 s.bind(("", 0))

--- a/rlinf/scheduler/manager/lock_manager.py
+++ b/rlinf/scheduler/manager/lock_manager.py
@@ -169,6 +169,22 @@ class PortLockManager(Manager):
             self._port_locks[key] = worker_name
             return True
 
+    def release(self, node_rank: int, worker_name: str, port: int) -> None:
+        """Unlock a port previously acquired by ``worker_name``.
+
+        Releasing a port held by a different worker is a no-op, so a stale caller cannot
+        free someone else's reservation.
+
+        Args:
+            node_rank (int): The rank of the node.
+            worker_name (str): The name of the worker releasing the lock.
+            port (int): The port number to unlock.
+        """
+        with self._lock:
+            key = (node_rank, port)
+            if self._port_locks.get(key, None) == worker_name:
+                self._port_locks.pop(key)
+
     def _release_daemon(self):
         """Daemon thread to periodically clean up released ports when it finds a worker is no longer alive."""
         from ..worker import Worker

--- a/rlinf/scheduler/worker/lock.py
+++ b/rlinf/scheduler/worker/lock.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 
+import errno
+import fcntl
+import os
+import tempfile
 from contextlib import AbstractContextManager
+from typing import Optional
 
 from ..manager import DeviceLockManager, PortLockManager
 from .worker import Worker
@@ -74,12 +79,69 @@ class DeviceLock(AbstractContextManager):
 
 
 class PortLock:
-    """A global lock to manage network port resources."""
+    """A global lock to manage network port resources.
+
+    A reservation is taken in two places:
+
+    1. The cluster's :class:`PortLockManager`, which serializes workers inside one Ray cluster.
+    2. An ``flock`` on a file under ``RLINF_PORT_LOCK_DIR``, which extends the reservation to
+       every RLinf process on the *host*. Two Ray clusters on one machine -- concurrent CI
+       jobs being the common case -- each get their own manager but share a single kernel
+       port space, so the manager alone cannot keep them apart.
+
+    The ``flock`` is held through an open file descriptor for the lifetime of the worker
+    process, so the kernel drops it when the process dies. No stale lock files need
+    reaping, and a crashed worker cannot strand a port.
+    """
 
     def __init__(self, worker: Worker):
         """Initialize the port lock."""
         self._worker = worker
         self._lock_manager = PortLockManager.get_proxy()
+        # Keep the flock fds alive; closing them would release the locks.
+        self._held_fds: dict[int, int] = {}
+
+    @staticmethod
+    def _lock_dir() -> str:
+        from ..cluster import Cluster, ClusterEnvVar
+
+        return os.getenv(
+            f"{Cluster.SYS_NAME.upper()}_{ClusterEnvVar.PORT_LOCK_DIR.value}",
+            os.path.join(tempfile.gettempdir(), "rlinf-port-locks"),
+        )
+
+    def _acquire_host_lock(self, port: int) -> tuple[bool, Optional[int]]:
+        """Take a non-blocking ``flock`` on ``port``'s lock file.
+
+        Args:
+            port (int): The port to lock host-wide.
+
+        Returns:
+            tuple[bool, Optional[int]]: ``(False, None)`` if another process on this host
+            holds the port. ``(True, fd)`` if the lock was taken; the caller owns ``fd``
+            and must keep it open. ``(True, None)`` if the lock directory is unusable, in
+            which case the reservation degrades to the cluster-scoped manager alone.
+        """
+        try:
+            lock_dir = self._lock_dir()
+            os.makedirs(lock_dir, exist_ok=True)
+            fd = os.open(
+                os.path.join(lock_dir, f"{port}.lock"), os.O_CREAT | os.O_RDWR, 0o666
+            )
+        except OSError:
+            # An unwritable or unshared lock dir must not take down the run: degrade to
+            # the cluster-scoped manager, which is what previous releases relied on.
+            return True, None
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as err:
+            os.close(fd)
+            if err.errno in (errno.EACCES, errno.EAGAIN):
+                return False, None
+            # Filesystems without flock support (some network mounts) raise other errnos.
+            return True, None
+        return True, fd
 
     def acquire(self, port: int) -> bool:
         """Lock a network port for the current worker.
@@ -95,9 +157,48 @@ class PortLock:
         Raises:
             RuntimeError: If the worker is not running in a worker context.
         """
-        if self._worker is not None:
-            return self._lock_manager.acquire(
-                self._worker._cluster_node_rank, self._worker._worker_name, port
-            )
-        else:
+        if self._worker is None:
             raise RuntimeError("Cannot lock ports when not running in a worker.")
+
+        if port in self._held_fds:
+            # Already ours. Re-locking would open a second file description and the
+            # non-blocking flock would fail against our own lock, reporting a conflict
+            # with ourselves.
+            return True
+
+        locked, fd = self._acquire_host_lock(port)
+        if not locked:
+            return False
+
+        if not self._lock_manager.acquire(
+            self._worker._cluster_node_rank, self._worker._worker_name, port
+        ):
+            if fd is not None:
+                os.close(fd)
+            return False
+
+        if fd is not None:
+            self._held_fds[port] = fd
+        return True
+
+    def release(self, port: int) -> None:
+        """Unlock a network port held by the current worker.
+
+        Both halves of the reservation are dropped: the ``flock`` (by closing its file
+        descriptor) and the cluster manager's entry.
+
+        Args:
+            port (int): The network port to unlock.
+
+        Raises:
+            RuntimeError: If the worker is not running in a worker context.
+        """
+        if self._worker is None:
+            raise RuntimeError("Cannot unlock ports when not running in a worker.")
+
+        fd = self._held_fds.pop(port, None)
+        if fd is not None:
+            os.close(fd)
+        self._lock_manager.release(
+            self._worker._cluster_node_rank, self._worker._worker_name, port
+        )

--- a/rlinf/scheduler/worker/worker.py
+++ b/rlinf/scheduler/worker/worker.py
@@ -23,6 +23,7 @@ import threading
 import time
 import traceback
 import warnings
+from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
@@ -1254,19 +1255,47 @@ class Worker(metaclass=WorkerMeta):
         """
         return self._worker_address.get_parent_rank()
 
-    def acquire_free_port(self, max_port_num: Optional[int] = None):
+    def acquire_free_port(
+        self,
+        max_port_num: Optional[int] = None,
+        derived_offsets: Sequence[int] = (),
+    ):
         """Safely acquire a free port on the current node without causing conflicts within the node.
 
         Args:
             max_port_num (Optional[int]): Largest acceptable port. Use it for servers that
                 derive a second port from this one and would overflow past 65535.
+            derived_offsets (Sequence[int]): Additional offsets from the returned port that
+                the caller's server will also bind (e.g. sglang derives its gRPC port as
+                ``port + 10000``). Those ports are reserved alongside the returned one, so
+                no other worker can be handed them. Without this they look free to the
+                allocator and are handed out, which surfaces as a late ``EADDRINUSE`` in
+                whichever process binds second.
+
+        Returns:
+            int: The acquired port, with any derived ports reserved as well.
+
+        Raises:
+            RuntimeError: If no free port could be acquired.
         """
         max_tries = 10000  # Retry up to 10000 times to find a free port
         for _ in range(max_tries):
             port = Cluster.find_free_port(max_port_num)
-            success = self._port_lock.acquire(port)
-            if success:
+            if not self._port_lock.acquire(port):
+                continue
+
+            reserved = [port]
+            for offset in derived_offsets:
+                if not self._port_lock.acquire(port + offset):
+                    break
+                reserved.append(port + offset)
+            else:
                 return port
+
+            # A derived port was taken. Hand back everything reserved for this candidate
+            # before retrying, so a repeatedly unlucky loop cannot drain the port band.
+            for reserved_port in reserved:
+                self._port_lock.release(reserved_port)
         raise RuntimeError(f"Failed to acquire a free port after {max_tries} attempts.")
 
     def log_on_first_rank(self, msg):

--- a/rlinf/workers/rollout/sglang_server/server_worker.py
+++ b/rlinf/workers/rollout/sglang_server/server_worker.py
@@ -194,7 +194,10 @@ class SGLangServerWorker(Worker):
         # internal torch.distributed bootstrap. ``acquire_free_port``
         # uses the worker's PortLock so neither port collides with any
         # other worker on this node.
-        http_port = self.acquire_free_port(max_port_num=MAX_SGLANG_HTTP_PORT)
+        http_port = self.acquire_free_port(
+            max_port_num=MAX_SGLANG_HTTP_PORT,
+            derived_offsets=(SGLANG_GRPC_PORT_OFFSET,),
+        )
         dist_port = self.acquire_free_port()
 
         server_kwargs = OmegaConf.to_container(self._sglang_cfg, resolve=True) or {}

--- a/tests/e2e_tests/reasoning/run.sh
+++ b/tests/e2e_tests/reasoning/run.sh
@@ -13,4 +13,18 @@ if [ -z "$1" ]; then
 else
     CONFIG_NAME=$1
 fi
+
+# CI runs these configs back to back on one self-hosted runner. Without an explicit
+# teardown, a previous run's Ray cluster and its sglang scheduler/detokenizer
+# subprocesses can outlive the step and keep holding ports, while the next run starts a
+# fresh PortLockManager that has no record of them -- which shows up as a random
+# EADDRINUSE partway through engine startup.
+cleanup() {
+    status=$?
+    ray stop --force >/dev/null 2>&1 || true
+    exit $status
+}
+ray stop --force >/dev/null 2>&1 || true
+trap cleanup EXIT
+
 python ${REPO_PATH}/examples/reasoning/main_grpo.py --config-path $REPO_PATH/tests/e2e_tests/reasoning/  --config-name $CONFIG_NAME

--- a/tests/unit_tests/test_port_allocation.py
+++ b/tests/unit_tests/test_port_allocation.py
@@ -1,0 +1,341 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for port allocation and the host-wide port lock.
+
+These cover the invariant that makes the allocation safe: a port handed out by
+``find_free_port`` must sit outside the kernel's ephemeral range, so the kernel can
+never assign it to an unrelated outbound connection between reservation and bind.
+"""
+
+import contextlib
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+from rlinf.scheduler.cluster.cluster import Cluster, ClusterEnvVar
+from rlinf.scheduler.worker.lock import PortLock
+
+PORT_RANGE_ENV = f"{Cluster.SYS_NAME.upper()}_{ClusterEnvVar.PORT_RANGE.value}"
+PORT_LOCK_DIR_ENV = f"{Cluster.SYS_NAME.upper()}_{ClusterEnvVar.PORT_LOCK_DIR.value}"
+
+
+def _ephemeral_range() -> tuple[int, int] | None:
+    """Return the kernel's ephemeral port range, or None if it is not readable."""
+    try:
+        with open("/proc/sys/net/ipv4/ip_local_port_range") as handle:
+            low, high = handle.read().split()
+        return int(low), int(high)
+    except (OSError, ValueError):
+        return None
+
+
+@contextlib.contextmanager
+def _bound(port: int):
+    """Hold a real listening socket on ``port`` for the duration of the block."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("", port))
+        sock.listen(1)
+        yield
+    finally:
+        sock.close()
+
+
+class TestPortRangeConfig:
+    """Parsing and validation of ``RLINF_PORT_RANGE``."""
+
+    def test_defaults_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(PORT_RANGE_ENV, raising=False)
+        assert Cluster.get_port_range() == Cluster.default_port_range()
+
+    def test_parses_configured_band(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PORT_RANGE_ENV, "21000-21500")
+        assert Cluster.get_port_range() == (21000, 21500)
+
+    @pytest.mark.parametrize(
+        "raw", ["", "not-a-range", "21000", "21500-21000", "0-100", "1000-70000"]
+    )
+    def test_rejects_invalid_band(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str
+    ) -> None:
+        monkeypatch.setenv(PORT_RANGE_ENV, raw)
+        if raw == "":
+            # An empty value is treated as unset rather than as an error.
+            assert Cluster.get_port_range() == Cluster.default_port_range()
+        else:
+            with pytest.raises(ValueError):
+                Cluster.get_port_range()
+
+    def test_default_band_avoids_ephemeral_range(self) -> None:
+        """The default band must not overlap where the kernel draws source ports."""
+        ephemeral = _ephemeral_range()
+        if ephemeral is None:
+            pytest.skip("Kernel ephemeral port range is not readable on this platform.")
+        eph_low, eph_high = ephemeral
+        if eph_low <= 1024 + Cluster.DEFAULT_PORT_RANGE_WIDTH:
+            pytest.skip("Kernel leaves no usable window below its ephemeral range.")
+        low, high = Cluster.default_port_range()
+        assert high < eph_low or low > eph_high, (
+            f"Default band {low}-{high} overlaps the ephemeral range {eph_low}-{eph_high}; "
+            "allocated ports could be reassigned to outbound connections."
+        )
+
+    def test_default_band_tracks_a_retuned_kernel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A host with a lowered ephemeral range still gets a non-overlapping default."""
+        monkeypatch.setattr(
+            Cluster, "get_ephemeral_port_range", classmethod(lambda cls: (25000, 60999))
+        )
+        low, high = Cluster.default_port_range()
+        assert high < 25000
+        assert low >= 1024
+
+
+class TestFindFreePort:
+    """Allocation behavior of ``Cluster.find_free_port``."""
+
+    def test_allocates_within_configured_band(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PORT_RANGE_ENV, "24000-24999")
+        for _ in range(20):
+            assert 24000 <= Cluster.find_free_port() <= 24999
+
+    def test_allocates_outside_ephemeral_range_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ephemeral = _ephemeral_range()
+        if ephemeral is None:
+            pytest.skip("Kernel ephemeral port range is not readable on this platform.")
+        monkeypatch.delenv(PORT_RANGE_ENV, raising=False)
+        eph_low, eph_high = ephemeral
+        port = Cluster.find_free_port()
+        assert not (eph_low <= port <= eph_high), (
+            f"find_free_port returned {port}, inside the ephemeral range "
+            f"{eph_low}-{eph_high}; the kernel may reassign it before the caller binds."
+        )
+
+    def test_respects_max_port_num(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(PORT_RANGE_ENV, "24000-24999")
+        assert Cluster.find_free_port(max_port_num=24100) <= 24100
+
+    def test_skips_a_port_that_is_actually_bound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PORT_RANGE_ENV, "24000-24999")
+        taken = Cluster.find_free_port()
+        with _bound(taken):
+            # Narrow the band to the single taken port: it cannot be handed out, so
+            # allocation must fall back to an ephemeral port rather than return it.
+            monkeypatch.setenv(PORT_RANGE_ENV, f"{taken}-{taken}")
+            for _ in range(5):
+                assert Cluster.find_free_port() != taken
+
+    def test_falls_back_when_band_is_unusable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A band above ``max_port_num`` leaves nothing to scan; allocation still succeeds."""
+        monkeypatch.setenv(PORT_RANGE_ENV, "30000-30100")
+        port = Cluster.find_free_port(max_port_num=25000)
+        assert 0 < port <= 25000
+
+
+class TestHostWidePortLock:
+    """``PortLock``'s ``flock``, which spans Ray clusters sharing one host."""
+
+    @staticmethod
+    def _make_lock(tmp_path, monkeypatch: pytest.MonkeyPatch) -> PortLock:
+        """Build a PortLock without Ray, since only the host-lock half is under test."""
+        monkeypatch.setenv(PORT_LOCK_DIR_ENV, str(tmp_path))
+        lock = object.__new__(PortLock)
+        lock._worker = object()
+        lock._lock_manager = None
+        lock._held_fds = {}
+        return lock
+
+    def test_second_holder_is_refused(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        first = self._make_lock(tmp_path, monkeypatch)
+        second = self._make_lock(tmp_path, monkeypatch)
+
+        locked, fd = first._acquire_host_lock(24321)
+        assert locked and fd is not None
+        try:
+            # A separate open file description on the same file conflicts, which is
+            # exactly what a second Ray cluster on this host would hit.
+            assert second._acquire_host_lock(24321) == (False, None)
+        finally:
+            import os
+
+            os.close(fd)
+
+    def test_lock_is_released_when_fd_closes(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import os
+
+        first = self._make_lock(tmp_path, monkeypatch)
+        locked, fd = first._acquire_host_lock(24322)
+        assert locked and fd is not None
+        os.close(fd)
+
+        second = self._make_lock(tmp_path, monkeypatch)
+        locked_again, fd_again = second._acquire_host_lock(24322)
+        assert locked_again and fd_again is not None
+        os.close(fd_again)
+
+    def test_degrades_when_lock_dir_is_unusable(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unwritable lock dir must not fail the reservation outright."""
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("")
+        monkeypatch.setenv(PORT_LOCK_DIR_ENV, str(blocker / "locks"))
+        lock = object.__new__(PortLock)
+        lock._worker = object()
+        lock._lock_manager = None
+        lock._held_fds = {}
+
+        assert lock._acquire_host_lock(24323) == (True, None)
+
+    def test_reacquiring_an_owned_port_succeeds(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-locking a port we already hold must not read as a conflict with ourselves."""
+        import os
+
+        lock = self._make_lock(tmp_path, monkeypatch)
+        lock._worker = SimpleNamespace(_cluster_node_rank=0, _worker_name="w")
+        lock._lock_manager = _AlwaysGrantingManager()
+        try:
+            assert lock.acquire(24324) is True
+            assert lock.acquire(24324) is True
+        finally:
+            for fd in lock._held_fds.values():
+                os.close(fd)
+
+    def test_release_frees_the_port_for_another_holder(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After release, a different process-level holder can take the same port."""
+        import os
+
+        lock = self._make_lock(tmp_path, monkeypatch)
+        lock._worker = SimpleNamespace(_cluster_node_rank=0, _worker_name="w")
+        lock._lock_manager = _AlwaysGrantingManager()
+        assert lock.acquire(24325) is True
+
+        other = self._make_lock(tmp_path, monkeypatch)
+        assert other._acquire_host_lock(24325) == (False, None)
+
+        lock.release(24325)
+        assert lock._held_fds == {}
+        assert lock._lock_manager.released == [24325]
+
+        locked, fd = other._acquire_host_lock(24325)
+        assert locked and fd is not None
+        os.close(fd)
+
+
+class _AlwaysGrantingManager:
+    """Stand-in for the Ray-side PortLockManager proxy."""
+
+    def __init__(self) -> None:
+        self.released: list[int] = []
+
+    def acquire(self, node_rank: int, worker_name: str, port: int) -> bool:
+        del node_rank, worker_name, port
+        return True
+
+    def release(self, node_rank: int, worker_name: str, port: int) -> None:
+        del node_rank, worker_name
+        self.released.append(port)
+
+
+class _RecordingPortLock:
+    """Port lock stub that records reservations and can refuse specific ports."""
+
+    def __init__(self, refuse: tuple[int, ...] = ()) -> None:
+        self.acquired: list[int] = []
+        self.released: list[int] = []
+        self._refuse = set(refuse)
+
+    def acquire(self, port: int) -> bool:
+        if port in self._refuse:
+            return False
+        self.acquired.append(port)
+        return True
+
+    def release(self, port: int) -> None:
+        self.released.append(port)
+
+
+class TestDerivedPortReservation:
+    """``Worker.acquire_free_port`` must reserve the ports its caller derives."""
+
+    @staticmethod
+    def _worker(lock: _RecordingPortLock):
+        from rlinf.scheduler.worker.worker import Worker
+
+        worker = object.__new__(Worker)
+        worker._port_lock = lock
+        return worker
+
+    def test_reserves_derived_offsets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from rlinf.scheduler.worker.worker import Worker
+
+        monkeypatch.setenv(PORT_RANGE_ENV, "24000-24999")
+        lock = _RecordingPortLock()
+        port = Worker.acquire_free_port(self._worker(lock), derived_offsets=(10000,))
+
+        assert port in lock.acquired
+        assert port + 10000 in lock.acquired, (
+            "The derived port was not reserved, so another worker could be handed it."
+        )
+
+    def test_retries_when_a_derived_port_is_taken(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from rlinf.scheduler.worker.worker import Worker
+
+        monkeypatch.setenv(PORT_RANGE_ENV, "24000-24999")
+        # Refuse one candidate's derived port; allocation must move to another base port.
+        blocked_base = 24500
+        lock = _RecordingPortLock(refuse=(blocked_base + 10000,))
+        port = Worker.acquire_free_port(self._worker(lock), derived_offsets=(10000,))
+
+        assert port != blocked_base
+        assert port + 10000 in lock.acquired
+        # Anything reserved for the rejected candidate must be handed back, otherwise a
+        # repeatedly unlucky loop would drain the band.
+        assert blocked_base not in lock.acquired or blocked_base in lock.released
+
+    def test_no_offsets_reserves_only_the_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from rlinf.scheduler.worker.worker import Worker
+
+        monkeypatch.setenv(PORT_RANGE_ENV, "24000-24999")
+        lock = _RecordingPortLock()
+        port = Worker.acquire_free_port(self._worker(lock))
+
+        assert lock.acquired == [port]
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])


### PR DESCRIPTION
### Description

Allocate worker listening ports from a dedicated band instead of the kernel's ephemeral range, and extend the port reservation from cluster scope to host scope.

`Cluster.find_free_port` bound to port 0, closed the socket, and returned the number. That only reports a port that *was* free: the kernel draws ephemeral ports (`net.ipv4.ip_local_port_range`, typically 32768-60999) for the source ports of *outbound* connections too, so the port could be handed to an unrelated outgoing socket before the reserving server bound it. `PortLockManager`'s record of the reservation lives in a Ray actor and is invisible to the kernel.

Changes:

- `find_free_port` allocates from `RLINF_PORT_RANGE` (default derived from the kernel's ephemeral range, `20000-32767` on a standard host) by bind-testing candidates from a random offset. Ports outside the ephemeral range are never auto-assigned, so the race is removed rather than narrowed. Falls back to the previous ephemeral behavior if the band is exhausted or misconfigured.
- `PortLock` additionally takes a non-blocking `flock` under `RLINF_PORT_LOCK_DIR` (default `/tmp/rlinf-port-locks`). Two Ray clusters on one host each get their own `PortLockManager` but share one kernel port space; the `flock` is what keeps them apart. It is held via an open fd, so the kernel releases it when the process dies -- no stale lock files to reap.
- `PortLockManager.release` / `PortLock.release` added; `acquire_free_port` now hands back reservations for a rejected candidate instead of leaking them.
- `acquire_free_port(derived_offsets=...)` reserves ports the caller derives from the returned one. Wired into the sglang server worker, whose gRPC port is `http_port + 10000` and was previously unreserved, so another worker could legitimately be handed it.
- `tests/e2e_tests/reasoning/run.sh` now runs `ray stop --force` before the run and on exit. CI runs these configs back to back on one self-hosted runner; without teardown a previous run's engine subprocesses outlive the step and keep holding ports while the next run starts a fresh, empty `PortLockManager`.

### Motivation and Context

Intermittent CI failures during engine startup, e.g. in `agent-reason-e2e-tests / reason-qwen-grpo-test`:

```
(RolloutGroup(rank=3)) torch.distributed.DistNetworkError: The server socket has failed to listen on any local network address. port: 43435, useIpv6: false, code: -98, name: EADDRINUSE, message: address already in use
```

Port 43435 was acquired via `acquire_free_port()` and passed to sglang as `dist_init_addr`. The engine bound it **9.4 seconds later**, from a subprocess, after model load and NCCL init -- ample time for the kernel to hand the same port to an outbound connection. 43435 sits inside `32768-60999`.

This is why probing the port never reproduced the failure: at check time the port genuinely is free, and the conflicting socket is an outbound connection (or a `TIME_WAIT` remnant) that a listener-oriented check does not enumerate. The gap between check and bind cannot be closed by checking harder.

### How has this been tested?

New `tests/unit_tests/test_port_allocation.py` (23 tests) covering band parsing and validation, allocation staying inside the band and outside the ephemeral range, `max_port_num` handling, skipping genuinely bound ports, the ephemeral fallback, the host-wide `flock` (second holder refused, release, degraded mode when the lock dir is unusable), and derived-port reservation including retry-and-release.

Full CPU/GPU unit suite run one file at a time with `ray stop` in between, matching `.github/workflows/unit-tests.yml`.

### Additional information (optional, e.g., figures and logs):

FAQ entry added under "Network Issues" (EN + ZH) explaining the symptom, why in-situ port checks never reproduce it, and the three fixes.

Not included, deliberately: retrying the engine launch on `EADDRINUSE`. The band change removes the cause; a retry would be belt-and-braces for handoffs across process boundaries we do not control, and is better argued on its own.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
