### PR TITLE
Feat/gr00t rollout backbone reuse

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,3 +91,12 @@ This deletes the `build` directory and its contents.
 Sphinx uses reStructuredText (RST), a simple yet powerful markup language for documentation.
 
 [RST grammar](https://zh-sphinx-doc.readthedocs.io/en/latest/rest.html)
+
+---
+
+## Engineering Reports
+
+These Markdown reports document implementation design and validation work that is
+not part of the Sphinx navigation:
+
+- [GR00T Rollout Backbone Feature Reuse](gr00t-rollout-backbone-feature-reuse.md)

--- a/docs/gr00t-rollout-backbone-feature-reuse.md
+++ b/docs/gr00t-rollout-backbone-feature-reuse.md
@@ -1,0 +1,390 @@
+# GR00T Rollout Backbone Feature Reuse: Design, Validation, Reproduction, and an IsaacLab Semantics Question
+
+## Executive summary
+
+This report describes frozen backbone feature reuse for the GR00T N1.5 Trocar PPO
+workload. Rollout computes a frozen Eagle backbone feature for an observed sample;
+the Actor reuses that feature across the four PPO update epochs that consume the
+same collected sample. The design does not assume that observations from different
+environments are equal, and it is not a general cache across rollout steps.
+
+The current upstream-oriented implementation is rebased on `be8d5c2d` and consists
+of five logical commits through `aec9e9f8`. It is the PR form of the independently
+reviewed and experimentally validated series from `c90951a0` through `c6696188`.
+The performance results below belong to that historical validation baseline; they
+must not be presented as measurements of the rebased series until its H20 E2E smoke
+has passed. On 8x H20 with 65,536 samples per step and 20 steps, steady steps 6-20
+measured:
+
+- matched baseline: `2176.445 s/step`, `30.111 samples/s`, `92420 MiB` peak;
+- clean candidate: `1521.060 s/step`, `43.086 samples/s`, `70879 MiB` peak;
+- versus the matched baseline: `+43.087%` throughput, `-30.113%` step time,
+  approximately `-50.83%` Actor time, and `-23.31%` sampled peak memory;
+- pinned-cache prototype reference: `1524.674 s`, `42.984 samples/s`, `68834 MiB`;
+  the candidate is `+0.238%` faster than the prototype, with only `3 MiB` of
+  headroom under the preregistered memory gate.
+
+The pinned-cache prototype reference is an earlier implementation, not a different
+algorithm. Runtime instrumentation is used only to make the two arms repeatable and
+is not part of the feature patch. The IsaacLab stage-update fix is a shared,
+independent task input for both arms. Early 20-step learning curves show no observed
+numerical regression, but a 64-episode evaluation crossed between arms. This is not
+enough evidence for an accuracy or convergence claim.
+
+## 1. Scope and reuse semantics
+
+The Eagle backbone in GR00T N1.5 is frozen, in evaluation mode, and has dropout
+disabled for this workload. During one PPO training step, Rollout evaluates the
+policy once for the observations. The same collected trajectory is then consumed by
+the Actor over four PPO update epochs. Recomputing a frozen backbone from images in
+every Actor epoch is redundant.
+
+Original path:
+
+```text
+images -> Actor recomputes frozen Eagle backbone -> action head / PPO update
+```
+
+Reuse path:
+
+```text
+Rollout: images -> frozen Eagle -> raw feature + mask
+                              |
+                              v
+Actor:   sample ID -> cached feature -> action head / PPO update x 4
+```
+
+The cache is scoped to one collected sample:
+
+- the global sample ID is the reuse and routing key;
+- the feature and mask were produced by the frozen backbone for that sample during Rollout;
+- the design does not assume equal observations across environments;
+- the feature is not retained across rollout steps; cache and staging state are cleared at step end.
+
+## 2. Architecture, data flow, and ownership
+
+### 2.1 Production data flow
+
+1. Rollout captures the raw feature and mask before the action-head mapping is mutated,
+   and keeps the producer CUDA tensors alive.
+2. A matching Rollout rank and Actor rank temporarily borrow a CUDA IPC view on the
+   same physical GPU. The borrow window covers only the D2H copy.
+3. The Actor copies the borrowed view into an Actor-owned pinned CPU cache and sends
+   the ACK only after the D2H copy completes.
+4. The normal Rollout to Env to Actor trajectory carries global sample IDs and owner
+   metadata, not the production feature payload.
+5. After shuffling, each Actor PPO microbatch gathers cached features by sample ID
+   and copies them to the training GPU on demand for the action head and PPO update.
+6. After all four epochs, or immediately after an exception, the Actor clears cache
+   and staging state and Rollout releases the producer tensor.
+
+### 2.2 Why the CUDA feature is not retained indefinitely
+
+Rollout retains the producer CUDA tensor only until the Actor completes the D2H copy.
+The borrowed view has a short lifetime. The Actor-owned pinned CPU cache covers the
+full PPO reuse window. This avoids keeping a complete feature batch in Rollout GPU
+memory across epochs and limits the OOM risk from long-lived feature storage.
+
+### 2.3 Fail-closed contract
+
+Each lease and stream block validates the model version, producer and consumer ranks,
+sample namespace, sample ID ordering, batch and block counts, byte count, and cache
+completeness. The protocol provides ACK/NACK handling, bounded timeouts, exception
+cleanup, and zero fallback/error counters.
+
+Malformed metadata, a missing ACK, an incomplete cache, a consumer exception, or an
+unsupported placement fails the current run and clears local state. It does not
+silently switch to a path with different data semantics. A timeout is terminal for
+the current run because the queued collective receive cannot be safely canceled.
+
+## 3. Five-commit map and key modules
+
+### 3.1 Five-commit map
+
+| Commit | Responsibility | Main content |
+|---|---|---|
+| `8a40dd4e` | Model boundary | Defines the frozen-backbone producer and consumer contract; capture occurs before action-head mutation |
+| `7ad065c3` | Borrowed CUDA IPC | Provides the same-GPU borrowed view, lease validation, and same-device rejection; unsupported placement fails closed |
+| `013bf278` | Pinned cache and stream | Adds the Actor-owned pinned CPU cache, D2H stream, ACK/NACK handling, timeout, and cleanup |
+| `48440aba` | Integration | Connects the stream to the embodied runner, Rollout, Env sample-ID routing, and FSDP Actor |
+| `aec9e9f8` | Configuration and docs | Adds the default-off configuration, production settings, EN/ZH docs, and topology constraints |
+
+### 3.2 Key modules
+
+| Module | Role |
+|---|---|
+| `rlinf/models/embodiment/gr00t/gr00t_n1d5/gr00t_action_model.py` | Captures the raw feature and mask; supports precomputed backbone inputs in the Actor |
+| `rlinf/runners/embodied_runner.py` | Enables the data plane only for the exact opt-in transport |
+| `rlinf/workers/rollout/hf/huggingface_worker.py` | Owns producer tensors, the borrowed IPC lease, ACK handling, and cleanup |
+| `rlinf/workers/env/env_worker.py` | Preserves global sample ID and owner metadata routing |
+| `rlinf/workers/actor/fsdp_actor_worker.py` | Checks model and placement constraints, gathers by sample ID, and cleans training state |
+| `rlinf/utils/backbone_cache.py` | Tracks model version, ranks, sample namespace, order, counts, and bytes |
+| `rlinf/utils/pinned_rollout_cache.py` | Implements the Actor-owned pinned CPU cache for four PPO epochs |
+| `rlinf/utils/pinned_feature_stream.py` | Implements borrowed-view receive, D2H, ACK/NACK, timeout, and lease release |
+
+## 4. Configuration and placement constraints
+
+Default off:
+
+```yaml
+actor:
+  model:
+    rollout_backbone_feature_transport: null
+```
+
+Production opt-in:
+
+```yaml
+actor:
+  model:
+    rollout_backbone_feature_transport: borrowed_ipc_pinned
+rollout:
+  pinned_feature_ipc_batch_blocks: 16
+  pinned_feature_ipc_timeout_seconds: 300
+  pinned_feature_verify_trajectory: false
+```
+
+`pinned_feature_verify_trajectory: true` is a debug parity mode. It retains an
+additional trajectory reference and compares features and masks. It is not a
+production performance setting.
+
+The supported scope is intentionally narrow:
+
+- GR00T N1.5 only; the backbone must be frozen and in eval mode, with dropout disabled and no SFT co-training;
+- synchronous embodied runner only, with `pipeline_stage_num=1` and `actor_split_num=1`;
+- equal Rollout and Actor world sizes, with rank `i` mapped to the same physical CUDA GPU;
+- no cross-GPU or cross-host support, and no NCCL or Gloo fallback;
+- borrowed IPC accepts CUDA tensors or tensor-list payloads only;
+- unsupported conditions fail closed instead of silently recomputing the backbone.
+
+## 5. Performance table
+
+### 5.1 Fixed experiment inputs
+
+- Image: `chenchaox72877/trocar-rlinf-bench@sha256:9f02e069ccb0e0a7e536833e789666e85f039c9024a77ac2f219c42cb1dfcf01`
+- Hardware: 8x H20 with same-GPU identity placement for Rollout and Actor ranks
+- Workload: 65,536 samples per step, 20 steps, steady steps 6-20
+- Historical matched baseline source: `c90951a0`, with the same deterministic Rollout and
+  critic instrumentation applied as the candidate
+- Historical validated candidate source: `c6696188`, runtime head `3e648e8b245f12ffeebda1f1c40284bcbb46d2be`
+- The runtime head contains deterministic Rollout and critic instrumentation for A/B
+  repeatability only. It is not part of the feature patch. Both arms use the same task input.
+- IsaacLab task input: `5db390fe6b615c10d2b57a7a12aa36159d928815`
+
+### 5.2 Baseline, candidate, and prototype reference
+
+| Arm | Step time (s) | Samples/s | Actor (s) | Env (s) | Rollout (s) | Sync (s) | Sampled peak (MiB) |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Matched baseline | 2176.445 | 30.111 | 1226.033 | 534.447 | 957.773 | 2.358 | 92420 |
+| Clean candidate | 1521.060 | 43.086 | 602.827 | 531.347 | 928.233 | 2.439 | 70879 |
+| Pinned-cache prototype reference | 1524.674 | 42.984 | - | - | - | - | 68834 |
+
+Versus the matched baseline, the clean candidate improves throughput by `+43.087%`,
+reduces step time by `-30.113%`, reduces Actor time by approximately `-50.83%`, and
+reduces sampled peak memory by `21541 MiB` or `-23.31%`. Env and synchronization time
+are nearly unchanged, so the primary gain is the removal of repeated frozen-backbone
+work for the same collected samples.
+
+The pinned-cache prototype reference is an earlier implementation, not another
+algorithm. The clean candidate is `+0.238%` faster than the prototype and has about
+`-0.237%` step time. Its peak is `2045 MiB` above the prototype. The preregistered
+prototype plus `2048 MiB` memory gate has only `3 MiB` of remaining margin and should
+be treated as a narrow residual risk.
+
+## 6. Validation gates and learning/convergence limits
+
+| Gate | Result | Evidence and boundary |
+|---|---|---|
+| Current PR source history and default-off path | PASS | Exactly five feature commits from `be8d5c2d` to `aec9e9f8`; rebase conflict review, diff check, Python compile, and YAML parse pass |
+| CPU focused suite | PASS | `50 passed, 1 skipped`; the CUDA round trip is run separately |
+| Real same-GPU CUDA IPC | PASS | Borrowed-storage alias test passed on H20 GPU 0 |
+| Model contract | PASS | Fresh/precomputed parity, raw pre-mutation capture, and fail-closed frozen/eval/dropout checks |
+| Eight-rank debug trajectory parity | PASS | Bitwise feature and mask parity with zero mismatch and zero fallback |
+| Four-epoch optimizer parity | PASS | Exact loss, gradient hash, parameter, and AdamW state results |
+| Production-shape two-step debug smoke | PASS | `verify_trajectory=true`; validates trajectory reference parity, not production-config performance |
+| Production 20-step E2E | PASS | `exit=0`, 20/20 steps, 160/160 stream/cache markers, zero fallback and zero error |
+| Matched baseline versus clean candidate | PASS | `+43.087%` throughput, above the preregistered `+10%` gate |
+| Clean candidate versus prototype | PASS | `+0.238%` throughput, above the preregistered `-3%` regression margin |
+| Peak GPU memory | PASS with narrow margin | Only `3 MiB` remains under the prototype plus `2048 MiB` gate |
+| Failure injection | Partial boundary | ACK/NACK, timeout, metadata, and cleanup have protocol tests; a full H20 fault-injection E2E remains follow-up work |
+| Independent static review | PASS | The final five-commit implementation was approved |
+
+The early 20-step curves are healthy and close between the two arms. Candidate
+first-five to last-five means changed from return `0.6883 -> 1.4297`, reward
+`0.005377 -> 0.011169`, and critic explained variance `0.7178 -> 0.8440`.
+The matched baseline ended at `1.4281 / 0.011157 / 0.8440`.
+
+The 64-episode evaluation crossed between arms: baseline step 20 had `success_once`
+of `31.25%` and candidate step 20 had `21.875%`; at step 10, candidate had `25%`
+and baseline had `9.375%`. `success_once` means that a positive stage reward was
+observed, while `success_at_end` was `0` for all arms. The sample is small and CUDA
+forward execution is non-bitwise. These results do not support an accuracy or
+convergence claim. The supported statement is only that no early numerical
+regression was observed.
+
+## 7. Reproduction
+
+### 7.1 Fixed inputs
+
+Freeze the source, runtime head, image, task input, placement, and workload before
+comparing arms:
+
+```text
+Current PR base: be8d5c2d...
+Current PR candidate: aec9e9f8...
+Historical matched baseline source: c90951a0...
+Historical validated candidate source: c6696188...
+Historical candidate runtime: 3e648e8b245f12ffeebda1f1c40284bcbb46d2be (base c6696188)
+Repeatability instrumentation: apply the same deterministic Rollout and critic seeding to both arms
+IsaacLab task input: 5db390fe6b615c10d2b57a7a12aa36159d928815
+Image: sha256:9f02e069ccb0e0a7e536833e789666e85f039c9024a77ac2f219c42cb1dfcf01
+Hardware: 8x H20
+Workload: 65,536 samples per step, 20 steps, steady 6-20
+Placement: Rollout rank i and Actor rank i on the same physical CUDA GPU
+```
+
+### 7.2 Fetch, worktree, and placement
+
+Set `REVIEW_REMOTE` to a Git remote pointing to the public `davidmlw/RLinf` fork.
+The example uses the remote name `david`; replace it with the name configured in
+your checkout. Fetch the remote, verify the public commit, and create the worktree
+directly from that commit:
+
+```bash
+REVIEW_REMOTE=david
+git fetch "$REVIEW_REMOTE"
+git cat-file -e aec9e9f8241b87a193c6fa8b0a885d6a61d13ce6^{commit}
+git worktree add ../gr00t-feature-candidate \
+  aec9e9f8241b87a193c6fa8b0a885d6a61d13ce6
+git -C ../gr00t-feature-candidate status --short
+git -C ../gr00t-feature-candidate log --oneline --reverse \
+  be8d5c2d28015146355dd2b47bce97331339f9d1...aec9e9f8241b87a193c6fa8b0a885d6a61d13ce6
+nvidia-smi -L
+nvidia-smi topo -m
+```
+
+Equal world size is not sufficient. Verify that Rollout rank `i` and Actor rank `i`
+resolve to the same physical GPU. Cross-GPU and cross-host placement must be rejected;
+borrowed IPC does not fall back to NCCL or Gloo.
+
+### 7.3 Configuration and test order
+
+First run with `rollout_backbone_feature_transport: null` to confirm the original
+image-to-Actor-backbone path. Then use the production opt-in configuration:
+
+```yaml
+actor:
+  model:
+    rollout_backbone_feature_transport: borrowed_ipc_pinned
+rollout:
+  pinned_feature_ipc_batch_blocks: 16
+  pinned_feature_ipc_timeout_seconds: 300
+  pinned_feature_verify_trajectory: false
+```
+
+The portable test order is:
+
+```bash
+# 1. Clean source and input hashes
+git status --short
+sha256sum <config> <runtime-overlay> <task-input>
+
+# 2. Model, protocol, and default-path unit suite
+pytest -q tests/unit_tests/test_backbone_feature_cache.py \
+  tests/unit_tests/test_borrowed_ipc_validation.py \
+  tests/unit_tests/test_gr00t_backbone_cache_interface.py \
+  tests/unit_tests/test_pinned_feature_actor.py \
+  tests/unit_tests/test_pinned_feature_sender.py \
+  tests/unit_tests/test_pinned_feature_stream.py \
+  tests/unit_tests/test_rollout_backbone_feature_reuse.py
+
+# 3. Real same-GPU CUDA IPC alias test
+pytest -q tests/unit_tests/test_intra_gpu_comm.py::TestSameDeviceCommunication::test_borrowed_tensor_list_aliases_producer_storage
+
+# 4. Four-epoch optimizer replay
+python <optimizer-parity-harness> --output-dir <artifact-dir>/optimizer-parity
+
+# 5. Production-shape debug parity, then the production 20-step candidate
+bash <candidate-launcher> 2 <artifact-dir>/smoke verify
+bash <candidate-launcher> 20 <artifact-dir>/production production
+```
+
+The Docker and IsaacLab launcher details are environment-specific. Adapt the mounts
+and wrapper paths rather than copying machine-local paths. The debug run must use
+`verify_trajectory=true`; the production run must disable it.
+
+### 7.4 Artifact retention checklist
+
+For every arm and gate, retain at least:
+
+- source commit, clean status, runtime head, and resolved config SHA;
+- image inspection output, task input commit, placement, and world-size manifest;
+- command line, environment summary, stdout, stderr, and exit code;
+- parsed step summary, throughput, phase timing, and step time;
+- per-device GPU memory samples and CPU or pinned-memory peak;
+- stream/cache marker counts, fallback/error counts, and lease/ACK/NACK counts;
+- optimizer loss, gradient, parameter, and AdamW hashes plus the parity summary;
+- evaluation seed, episode count, `success_once`, `success_at_end`, and video metadata.
+
+Use an immutable run ID for every artifact set and verify source, config, image, and
+task hashes before comparison. Runtime instrumentation is shared repeatability input
+only. The IsaacLab fix is a shared task input for both arms and must not be injected
+into only one arm.
+
+## 8. IsaacLab modification and explicit questions to owners
+
+### 8.1 Modification and current execution semantics
+
+The IsaacLab branch `fix/assemble-trocar-stage-update` at commit
+`5db390fe6b615c10d2b57a7a12aa36159d928815` changes the Trocar `update_stage`
+`RewTerm.weight` from `0.0` to `1.0`. `update_task_stage()` always returns a zero
+tensor, so the term itself does not add to total reward.
+
+The current `RewardManager.compute()` implementation explicitly continues when
+`term_cfg.weight == 0.0`. Under the old configuration, the side-effecting
+`update_task_stage()` function was never called and `task_stage` remained zero.
+Under the current implementation, the nonzero weight enables the state-machine
+update; it does not change the numeric reward contribution of that term.
+
+The new train and eval regression test checks only that
+`env_cfg.rewards.update_stage.weight == 1.0`. It does not yet verify actual stage
+transition, reset, sparse reward accounting, or total reward behavior.
+
+Therefore, the change is mechanically necessary under the current RewardManager
+behavior, but the architectural and task semantics remain open for owner review.
+
+### 8.2 Questions for IsaacLab and task owners
+
+1. Should state progression be implemented as a reward term at all?
+2. Is a zero-return function with `weight=1` the right minimal fix, or should the
+   side effect move to an event, step hook, or dedicated manager?
+3. Should RewardManager change its zero-weight skip semantics, or should IsaacLab
+   introduce an `always_run` or `state-update` term type?
+4. Is the ordering dependency, with `update_stage` before sparse reward terms, an
+   accepted contract that should be explicitly documented and tested?
+5. Does this change affect task definition or training comparability? Which upstream
+   regression tests are required for train/eval, stage transition, reset, reward
+   accounting, and checkpoint replay?
+
+## 9. Limitations and next steps
+
+- The candidate has only `3 MiB` of remaining margin under the prototype memory gate;
+  validate larger shapes, long runs, and combined configurations with memory guards.
+- Complete H20 failure-injection E2E remains to be tested for ACK timeout, consumer
+  exception, malformed metadata, and partial-cache cleanup.
+- The crossed 64-episode evaluation cannot establish convergence; use longer training
+  and a larger evaluation set.
+- The design covers GR00T N1.5, the synchronous runner with
+  `pipeline_stage_num=1`, and same-GPU identity placement. It does not generalize
+  to cross-GPU or cross-host placement.
+- `aec9e9f8` is an upstream-oriented implementation and should not be described as
+  already merged into the RLinf upstream product branch.
+
+## 10. Public links
+
+- [Current RLinf PR diff](https://github.com/davidmlw/RLinf/compare/be8d5c2d28015146355dd2b47bce97331339f9d1...aec9e9f8241b87a193c6fa8b0a885d6a61d13ce6)
+- [Current RLinf base commit](https://github.com/davidmlw/RLinf/commit/be8d5c2d28015146355dd2b47bce97331339f9d1)
+- [Current RLinf candidate commit](https://github.com/davidmlw/RLinf/commit/aec9e9f8241b87a193c6fa8b0a885d6a61d13ce6)
+- [Historically validated RLinf diff](https://github.com/davidmlw/RLinf/compare/c90951a0c799a750cb5294ed10587c61cc2af8bf...c6696188d14db68fdbebd584eff49110cb53a387)
+- [RLinf repeatability runtime commit](https://github.com/davidmlw/RLinf/commit/3e648e8b245f12ffeebda1f1c40284bcbb46d2be)
+- [IsaacLab stage-update commit](https://github.com/davidmlw/IsaacLab/commit/5db390fe6b615c10d2b57a7a12aa36159d928815)

--- a/docs/source-en/rst_source/examples/embodied/gr00t.rst
+++ b/docs/source-en/rst_source/examples/embodied/gr00t.rst
@@ -351,6 +351,33 @@ After fine-tuning, the system generates ``metadata.json`` and other statistical 
 - The current RL setup uses PPO with ``algorithm.loss_type: actor_critic``, so ``actor.model.add_value_head`` must be ``True`` during training.
 - The repository's validated LIBERO example uses ``num_action_chunks: 16`` and ``denoising_steps: 4``.
 
+Optional N1.5 Frozen-Backbone Reuse
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+GR00T-N1.5 can reuse the frozen backbone output produced during rollout instead
+of recomputing it during PPO training. The default remains the existing
+trajectory path. Enable the optimization explicitly:
+
+.. code:: yaml
+
+   actor:
+      model:
+         rollout_backbone_feature_transport: borrowed_ipc_pinned
+   rollout:
+      pinned_feature_ipc_batch_blocks: 1
+      pinned_feature_ipc_timeout_seconds: 300.0
+      pinned_feature_verify_trajectory: False
+
+The current implementation requires a frozen GR00T-N1.5 backbone in eval mode,
+equal rollout and actor world sizes with matching ranks on the same CUDA device,
+``pipeline_stage_num: 1``, and one Actor split per Env worker. Rollout retains
+each CUDA feature batch until Actor copies
+it into the pinned CPU cache and acknowledges the lease. Set
+``pinned_feature_verify_trajectory: True`` only for parity debugging because it
+also carries the feature payload in the trajectory.
+Cross-GPU and cross-host rank pairs are unsupported; this path does not fall
+back to NCCL or Gloo copies.
+
 ---------------
 
 Run It

--- a/docs/source-zh/rst_source/examples/embodied/gr00t.rst
+++ b/docs/source-zh/rst_source/examples/embodied/gr00t.rst
@@ -347,6 +347,32 @@ RLinf 框架针对GR00T-N1.6采用了高度解耦的两阶段训练架构：
 - 当前 RL 设置使用 PPO 且 ``algorithm.loss_type: actor_critic``，因此训练时必须保证 ``actor.model.add_value_head`` 为 ``True``。
 - 当前仓库中经过验证的 LIBERO 示例使用 ``num_action_chunks: 16`` 和 ``denoising_steps: 4``。
 
+可选的 N1.5 冻结 Backbone 复用
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+GR00T-N1.5 可以直接复用 rollout 阶段生成的冻结 backbone 输出，避免 PPO
+训练阶段重复计算。默认仍使用原有 trajectory 通路，需要显式启用：
+
+.. code:: yaml
+
+   actor:
+      model:
+         rollout_backbone_feature_transport: borrowed_ipc_pinned
+   rollout:
+      pinned_feature_ipc_batch_blocks: 1
+      pinned_feature_ipc_timeout_seconds: 300.0
+      pinned_feature_verify_trajectory: False
+
+当前实现要求 GR00T-N1.5 backbone 冻结且处于 eval 模式、rollout 与 actor
+world size 相同且同 rank 位于同一 CUDA device、``pipeline_stage_num: 1``，
+并且每个 Env worker 只对应一个
+Actor split。Rollout
+会保留每批 CUDA feature，直到 Actor 将其复制到 pinned CPU cache 并确认
+lease。``pinned_feature_verify_trajectory: True`` 仅用于一致性调试，因为它
+还会在 trajectory 中携带一份 feature payload。
+跨 GPU 或跨主机的 rank pair 不受支持；该通路不会回退到 NCCL 或 Gloo
+复制。
+
 ---------------
 
 运行

--- a/examples/embodiment/config/isaaclab_franka_stack_cube_ppo_gr00t.yaml
+++ b/examples/embodiment/config/isaaclab_franka_stack_cube_ppo_gr00t.yaml
@@ -112,6 +112,10 @@ rollout:
   backend: "huggingface"
   enable_offload: True
   pipeline_stage_num: 1
+  # Optional GR00T-N1.5 optimization. Keep null for the default trajectory path.
+  pinned_feature_ipc_batch_blocks: 1
+  pinned_feature_ipc_timeout_seconds: 300.0
+  pinned_feature_verify_trajectory: False
 
   model:
     model_path: "/path/to/RLinf-Gr00t-SFT-Stack-cube" # https://huggingface.co/RLinf/RLinf-Gr00t-SFT-Stack-cube
@@ -132,6 +136,7 @@ actor:
     embodiment_tag: "isaaclab_franka"
     obs_converter_type: "isaaclab_stack_cube"
     num_action_chunks: 16
+    rollout_backbone_feature_transport: null
 
   optim:
     lr: 1.0e-5

--- a/rlinf/models/embodiment/gr00t/gr00t_n1d5/gr00t_action_model.py
+++ b/rlinf/models/embodiment/gr00t/gr00t_n1d5/gr00t_action_model.py
@@ -15,7 +15,7 @@
 import json
 import random
 from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Mapping, Optional, Union
 
 import numpy as np
 import torch
@@ -42,6 +42,10 @@ from rlinf.models.embodiment.gr00t.utils import (
 )
 from rlinf.models.embodiment.modules.explore_noise_net import ExploreNoiseNet
 from rlinf.models.embodiment.modules.value_head import ValueHead
+from rlinf.utils.backbone_cache import (
+    ROLLOUT_BACKBONE_FEATURE_KEY,
+    ROLLOUT_BACKBONE_MASK_KEY,
+)
 
 
 class FlowMatchingActionHeadForRLActionPrediction(FlowmatchingActionHead):
@@ -505,6 +509,26 @@ class GR00T_N1_5_ForRLActionPrediction(GR00T_N1_5, BasePolicy):
         else:
             raise NotImplementedError
 
+    def _prepare_action_head_input(
+        self, forward_inputs: Mapping[str, torch.Tensor]
+    ) -> BatchFeature:
+        action_inputs = self.action_head.prepare_input(
+            {
+                "state": forward_inputs["state"],
+                "state_mask": forward_inputs["state_mask"],
+                "embodiment_id": forward_inputs["embodiment_id"],
+            }
+        )
+        for name, value in action_inputs.items():
+            if torch.is_floating_point(value):
+                action_inputs[name] = value.to(
+                    self.device,
+                    dtype=self.action_head.dtype,
+                )
+            else:
+                action_inputs[name] = value.to(self.device)
+        return action_inputs
+
     def default_forward(
         self,
         forward_inputs: dict[str, torch.Tensor],
@@ -512,23 +536,28 @@ class GR00T_N1_5_ForRLActionPrediction(GR00T_N1_5, BasePolicy):
         compute_entropy: bool = False,
         compute_values: bool = True,
         use_cache: bool = False,
+        precomputed_backbone: Optional[Mapping[str, torch.Tensor]] = None,
         **kwargs,
     ) -> dict[str, Any]:
-        normalized_input = {
-            "state": forward_inputs["state"],
-            "state_mask": forward_inputs["state_mask"],
-            "eagle_input_ids": forward_inputs["eagle_input_ids"],
-            "eagle_attention_mask": forward_inputs["eagle_attention_mask"],
-            "eagle_pixel_values": forward_inputs["eagle_pixel_values"].reshape(
-                -1, *forward_inputs["eagle_pixel_values"].shape[2:]
-            ),
-            "eagle_image_sizes": forward_inputs["eagle_image_sizes"].reshape(
-                -1, *forward_inputs["eagle_image_sizes"].shape[2:]
-            ),
-            "embodiment_id": forward_inputs["embodiment_id"],
-        }
-        backbone_inputs, action_inputs = self.prepare_input(normalized_input)
-        backbone_outputs = self.backbone(backbone_inputs)
+        if precomputed_backbone is None:
+            normalized_input = {
+                "state": forward_inputs["state"],
+                "state_mask": forward_inputs["state_mask"],
+                "eagle_input_ids": forward_inputs["eagle_input_ids"],
+                "eagle_attention_mask": forward_inputs["eagle_attention_mask"],
+                "eagle_pixel_values": forward_inputs["eagle_pixel_values"].reshape(
+                    -1, *forward_inputs["eagle_pixel_values"].shape[2:]
+                ),
+                "eagle_image_sizes": forward_inputs["eagle_image_sizes"].reshape(
+                    -1, *forward_inputs["eagle_image_sizes"].shape[2:]
+                ),
+                "embodiment_id": forward_inputs["embodiment_id"],
+            }
+            backbone_inputs, action_inputs = self.prepare_input(normalized_input)
+            backbone_outputs = self.backbone(backbone_inputs)
+        else:
+            action_inputs = self._prepare_action_head_input(forward_inputs)
+            backbone_outputs = BatchFeature(data=dict(precomputed_backbone))
 
         chains = forward_inputs["chains"]
         denoise_inds = forward_inputs["denoise_inds"]
@@ -662,6 +691,18 @@ class GR00T_N1_5_ForRLActionPrediction(GR00T_N1_5, BasePolicy):
         backbone_inputs, action_inputs = self.prepare_input(normalized_input)
         # Because the behavior of backbones remains the same for training and inference, we can use `forward` for backbones.
         backbone_outputs = self.backbone(backbone_inputs)
+        rollout_backbone_output = None
+        if getattr(self, "capture_rollout_backbone_output", False):
+            # The action head mutates backbone_outputs, so retain the raw frozen
+            # tensors before entering it. Disabled runs do not extend their lifetime.
+            rollout_backbone_output = {
+                ROLLOUT_BACKBONE_FEATURE_KEY: backbone_outputs[
+                    "backbone_features"
+                ].detach(),
+                ROLLOUT_BACKBONE_MASK_KEY: backbone_outputs[
+                    "backbone_attention_mask"
+                ].detach(),
+            }
         action_head_outputs, rlinf_outputs = self.action_head.get_rl_action(
             backbone_outputs, action_inputs, mode=mode
         )
@@ -685,6 +726,9 @@ class GR00T_N1_5_ForRLActionPrediction(GR00T_N1_5, BasePolicy):
         ].reshape(
             bsize, self.image_nums, *normalized_input["eagle_image_sizes"].shape[1:]
         )
+
+        if rollout_backbone_output is not None:
+            forward_inputs.update(rollout_backbone_output)
 
         result = {
             "prev_logprobs": rlinf_outputs["prev_logprobs"],

--- a/rlinf/runners/embodied_runner.py
+++ b/rlinf/runners/embodied_runner.py
@@ -24,6 +24,10 @@ from omegaconf.dictconfig import DictConfig
 
 from rlinf.scheduler import Channel
 from rlinf.scheduler import WorkerGroupFuncResult as Handle
+from rlinf.utils.backbone_cache import (
+    ROLLOUT_BACKBONE_TRANSPORT_KEY,
+    is_rollout_backbone_ipc_transport,
+)
 from rlinf.utils.distributed import ScopedTimer
 from rlinf.utils.logging import get_logger
 from rlinf.utils.metric_logger import MetricLogger
@@ -74,6 +78,12 @@ class EmbodiedRunner:
         self.overlap_env_bootstrap = bool(
             self.cfg.runner.get("overlap_env_bootstrap", False)
         )
+        feature_transport = self.cfg.actor.model.get(ROLLOUT_BACKBONE_TRANSPORT_KEY)
+        self.pinned_feature_ipc = is_rollout_backbone_ipc_transport(feature_transport)
+        if self.pinned_feature_ipc and self.cfg.rollout.pipeline_stage_num != 1:
+            raise ValueError(
+                "pinned rollout backbone transport currently requires pipeline_stage_num=1"
+            )
 
         # Step-gated profiling: ``cluster.profiling.steps`` lists the global step
         profiling_raw = self.cfg.cluster.get("profiling", None)
@@ -499,6 +509,11 @@ class EmbodiedRunner:
                     if _step % self.weight_sync_interval == 0:
                         self.update_rollout_weights()
                 with self.timer("generate_rollouts"):
+                    feature_stream_recv_handle: Handle | None = None
+                    if self.pinned_feature_ipc:
+                        feature_stream_recv_handle = (
+                            self.actor.recv_rollout_backbone_feature_stream()
+                        )
                     env_handle: Handle = self.env.interact(
                         input_channel=self.env_channel,
                         rollout_channel=self.rollout_channel,
@@ -519,8 +534,28 @@ class EmbodiedRunner:
                         input_channel=self.actor_channel
                     ).wait()
                     rollout_handle.wait()
+                    if self.pinned_feature_ipc:
+                        if feature_stream_recv_handle is None:
+                            raise RuntimeError(
+                                "pinned feature receiver was not started"
+                            )
+                        feature_stream_recv_handle.wait()
+                        self.rollout.finish_rollout_backbone_feature_stream().wait()
                     if self.reward is not None:
                         reward_handle.wait()
+                    if self.pinned_feature_ipc:
+                        source_ranks = [
+                            int(rank)
+                            for rank in self.actor.get_rollout_backbone_feature_source_rank().wait()
+                        ]
+                        logger.info(
+                            "Pinned backbone Actor-to-Rollout route: %s",
+                            source_ranks,
+                        )
+                        feature_recv_handle: Handle = (
+                            self.actor.recv_rollout_backbone_features(source_ranks)
+                        )
+                        feature_recv_handle.wait()
 
                 # compute advantages and returns.
                 with self.timer("cal_adv_and_returns"):

--- a/rlinf/scheduler/collective/collective_group.py
+++ b/rlinf/scheduler/collective/collective_group.py
@@ -290,6 +290,7 @@ class CollectiveGroup:
         async_op: bool = False,
         options: Optional[CollectiveGroupOptions] = None,
         piggyback_payload: Optional[Any] = None,
+        borrowed_ipc: bool = False,
     ) -> Optional[AsyncFuncWork]:
         """Implement the Worker's send method.
 
@@ -297,11 +298,23 @@ class CollectiveGroup:
 
         This function calls _atomic_send in a way so that it can be chained with previous send operations in the same channel.
         Otherwise, async send operations in the same channel may become out-of-order and mismatch with recv.
+
+        ``borrowed_ipc`` returns same-device CUDA views at the receiver. The
+        caller must retain the source tensors until an application-level
+        acknowledgement confirms that the receiver has finished with the views.
         """
+        object_type, tensor_data = self._get_object_info(object)
+        if borrowed_ipc and object_type not in (
+            CollectiveGroup.TENSOR,
+            CollectiveGroup.TENSOR_LIST,
+        ):
+            raise TypeError("borrowed IPC only supports a tensor or tensor list")
+        if borrowed_ipc and (tensor_data.cpu_tensors or not tensor_data.accel_tensors):
+            raise ValueError("borrowed IPC only supports CUDA tensor payloads")
+
         # Only iter the channel here and pass the channel id along the way.
         # Because the _atomic_send and all the send in the way may be called asynchronously while the channel_id in the class may be different.
         send_comm_id = next(self._send_comm_id_iter)
-        object_type, tensor_data = self._get_object_info(object)
 
         # Create AsyncFuncWork for the send operation
         send_work = AsyncFuncWork(
@@ -312,6 +325,7 @@ class CollectiveGroup:
             tensor_data=tensor_data,
             options=options,
             piggyback_payload=piggyback_payload,
+            borrowed_ipc=borrowed_ipc,
             pass_self=True,
         )
 
@@ -344,6 +358,7 @@ class CollectiveGroup:
         tensor_data: TensorData,
         options: Optional[CollectiveGroupOptions] = None,
         piggyback_payload: Optional[Any] = None,
+        borrowed_ipc: bool = False,
     ) -> Optional[AsyncFuncWork]:
         """Send an object to a specific address in the collective group in an out-of-place manner.
 
@@ -365,6 +380,7 @@ class CollectiveGroup:
                 piggyback_payload=piggyback_payload,
                 tensor_data=tensor_data,
                 work=work,
+                borrowed_ipc=borrowed_ipc,
             )
         elif object_type == CollectiveGroup.TENSOR_LIST:
             return self._send_tensor_list(
@@ -373,6 +389,7 @@ class CollectiveGroup:
                 piggyback_payload=piggyback_payload,
                 tensor_data=tensor_data,
                 work=work,
+                borrowed_ipc=borrowed_ipc,
             )
         elif object_type == CollectiveGroup.TENSOR_DICT:
             return self._send_tensor_dict(
@@ -401,6 +418,7 @@ class CollectiveGroup:
         self,
         async_op: bool = False,
         options: Optional[CollectiveGroupOptions] = None,
+        borrowed_ipc: bool = False,
     ) -> (
         AsyncFuncWork
         | torch.Tensor
@@ -424,6 +442,7 @@ class CollectiveGroup:
             comm_id=recv_comm_id,
             current_device=current_device,
             options=options,
+            borrowed_ipc=borrowed_ipc,
             pass_self=True,
         )
 
@@ -450,6 +469,7 @@ class CollectiveGroup:
         comm_id: int,
         current_device: Optional[int],
         options: Optional[CollectiveGroupOptions] = None,
+        borrowed_ipc: bool = False,
     ) -> (
         AsyncFuncWork
         | torch.Tensor
@@ -472,13 +492,17 @@ class CollectiveGroup:
             f"Receiving object type {object_type} from Rank {self._peer_rank} in group {self._group_info.group_name}"
         )
         if object_type == CollectiveGroup.TENSOR:
-            tensor, pb_data = self._recv_tensor_list(comm_id, work=work)
+            tensor, pb_data = self._recv_tensor_list(
+                comm_id, work=work, borrowed_ipc=borrowed_ipc
+            )
             assert len(tensor) == 1, (
                 f"Expected to receive one tensor but got {len(tensor)} tensors from Rank {self._peer_rank} in group {self._group_info.group_name}"
             )
             data = tensor[0]
         elif object_type == CollectiveGroup.TENSOR_LIST:
-            data, pb_data = self._recv_tensor_list(comm_id, work=work)
+            data, pb_data = self._recv_tensor_list(
+                comm_id, work=work, borrowed_ipc=borrowed_ipc
+            )
         elif object_type == CollectiveGroup.TENSOR_DICT:
             data, pb_data = self._recv_tensor_dict(comm_id, work=work)
         elif object_type == CollectiveGroup.DATACLASS_WITH_TENSORS:
@@ -1870,8 +1894,11 @@ class CollectiveGroup:
         tensors: list[torch.Tensor],
         comm_id: int,
         async_op: bool = False,
+        borrowed: bool = False,
     ) -> Optional[AsyncWork]:
-        """Handle same device send/recv in _send_tensor_list."""
+        """Handle same-device send/recv, optionally retaining producer storage."""
+        if borrowed:
+            Worker.torch_platform.current_stream().synchronize()
         tensor_handles = [reduce_tensor(tensor) for tensor in tensors]
         self._logger.debug(
             f"Sending {len(tensor_handles)} tensors via IPC from worker {self._cur_worker_address.get_name()}"
@@ -1898,12 +1925,15 @@ class CollectiveGroup:
             device=CollectiveGroup.CPU,
             comm_id=comm_id,
         )
-        Worker.torch_platform.ipc_collect()
+        if not borrowed:
+            Worker.torch_platform.ipc_collect()
 
         if async_op:
             return work
 
-    def _recv_tensor_list_via_ipc(self, comm_id: int) -> list[torch.Tensor]:
+    def _recv_tensor_list_via_ipc(
+        self, comm_id: int, *, borrowed: bool = False
+    ) -> list[torch.Tensor]:
         self._logger.debug(
             f"Receiving tensors via IPC in worker {self._cur_worker_address.get_name()}"
         )
@@ -1927,13 +1957,17 @@ class CollectiveGroup:
             rebuild_func(*rebuild_args)
             for (rebuild_func, rebuild_args) in tensor_handles
         ]
-        tensors = [
-            tensor.clone().detach().to(Worker.torch_platform.current_device())
-            for tensor in remote_tensors
-        ]
+        if borrowed:
+            tensors = [tensor.detach() for tensor in remote_tensors]
+        else:
+            tensors = [
+                tensor.clone().detach().to(Worker.torch_platform.current_device())
+                for tensor in remote_tensors
+            ]
 
         Worker.torch_platform.current_stream().synchronize()
-        remote_tensors.clear()
+        if not borrowed:
+            remote_tensors.clear()
         zero_tensor = torch.tensor(0, dtype=torch.long, device="cpu")
         self._recv(zero_tensor, CollectiveGroup.CPU, comm_id)
         Worker.torch_platform.ipc_collect()
@@ -2071,6 +2105,7 @@ class CollectiveGroup:
         async_op: bool = False,
         piggyback_payload: Optional[Any] = None,
         work: Optional[AsyncFuncWork] = None,
+        borrowed_ipc: bool = False,
     ) -> Optional[AsyncWork]:
         """Send a list of tensors to the specified destination address in the collective group.
 
@@ -2082,6 +2117,8 @@ class CollectiveGroup:
             piggyback_payload (Optional[Any]): The payload to piggyback on the send operation.
             work (Optional[AsyncFuncWork]): If provided, payload-transfer time is
                 attributed to this work via :meth:`_track_payload_time`.
+            borrowed_ipc (bool): Send same-device CUDA aliases without cloning.
+                The application must retain tensors until receiver acknowledgement.
 
         Returns:
             Optional[AsyncWork]: If async_op is True, returns an AsyncWork object for the asynchronous operation. If async_op is False, returns None.
@@ -2090,6 +2127,8 @@ class CollectiveGroup:
         cpu_tensor_mask = tensor_data.cpu_tensor_mask
         cpu_tensors = tensor_data.cpu_tensors
         accel_tensors = tensor_data.accel_tensors
+        if borrowed_ipc and (cpu_tensors or not accel_tensors):
+            raise RuntimeError("borrowed IPC only supports CUDA tensor payloads")
 
         dst_rank_in_group = self._peer_rank
         last_work: Optional[dist.Work] = None
@@ -2103,6 +2142,7 @@ class CollectiveGroup:
             "meta": tensor_shape_dtype,
             "pb": piggyback_payload,
             "cpu_tensor_mask": cpu_tensor_mask,
+            "borrowed_ipc": borrowed_ipc,
         }
         self._logger.debug(
             f"Sending tensor metadata {metadata} to Rank {dst_rank_in_group} in group {self._group_info.group_name}"
@@ -2137,13 +2177,20 @@ class CollectiveGroup:
             if accel_tensors:
                 # Handle CUDA tensor sending with IPC if the peer worker is on the same device
                 check_cuda_device_result = self._check_same_device_with_peer()
+                if borrowed_ipc and check_cuda_device_result != 1:
+                    raise RuntimeError(
+                        "borrowed IPC requires sender and receiver on the same CUDA device"
+                    )
                 if check_cuda_device_result == 0:
                     last_work = self._send_tensor_list_to_uncertain_peer(
                         accel_tensors, comm_id, async_op
                     )
                 elif check_cuda_device_result == 1:
                     last_work = self._send_tensor_list_via_ipc(
-                        accel_tensors, comm_id, async_op
+                        accel_tensors,
+                        comm_id,
+                        async_op,
+                        borrowed=borrowed_ipc,
                     )
                 else:
                     for tensor in accel_tensors:
@@ -2161,6 +2208,7 @@ class CollectiveGroup:
         self,
         comm_id: int,
         work: Optional[AsyncFuncWork] = None,
+        borrowed_ipc: bool = False,
     ) -> tuple[list[torch.Tensor], Any]:
         """Receive a list of tensors from the specified source address in the collective group.
 
@@ -2168,6 +2216,7 @@ class CollectiveGroup:
             comm_id (int): The ID for the recv operation.
             work (Optional[AsyncFuncWork]): If provided, payload-transfer time is
                 attributed to this work.
+            borrowed_ipc (bool): Accept same-device producer-owned CUDA aliases.
 
         Returns:
             tuple[List[torch.Tensor], Any]: A tuple of the received list of tensors and the piggyback payload.
@@ -2192,10 +2241,15 @@ class CollectiveGroup:
         tensor_shapes = metadata["meta"]
         pb_data = metadata["pb"]
         cpu_tensor_mask = metadata["cpu_tensor_mask"]
+        sender_borrowed_ipc = bool(metadata.get("borrowed_ipc", False))
+        mode_mismatch = sender_borrowed_ipc != borrowed_ipc
+        invalid_borrowed_payload = sender_borrowed_ipc and any(cpu_tensor_mask)
         has_accel_tensor = any(not m for m in cpu_tensor_mask)
 
         tensors = [
-            torch.empty(
+            None
+            if sender_borrowed_ipc and not is_cpu
+            else torch.empty(
                 shape,
                 dtype=dtype,
                 device=(
@@ -2230,6 +2284,10 @@ class CollectiveGroup:
                 self._recv(tensor, CollectiveGroup.CPU, comm_id)
             if has_accel_tensor:
                 check_cuda_device_result = self._check_same_device_with_peer()
+                if sender_borrowed_ipc and check_cuda_device_result != 1:
+                    raise RuntimeError(
+                        "borrowed IPC requires sender and receiver on the same CUDA device"
+                    )
                 if check_cuda_device_result == 0:
                     accel_shapes = [shape_dtype for _, _, shape_dtype in accel_entries]
                     received_accel_tensors = self._recv_tensor_list_to_uncertain_peer(
@@ -2240,7 +2298,9 @@ class CollectiveGroup:
                     ):
                         tensors[idx] = tensor
                 elif check_cuda_device_result == 1:
-                    received_accel_tensors = self._recv_tensor_list_via_ipc(comm_id)
+                    received_accel_tensors = self._recv_tensor_list_via_ipc(
+                        comm_id, borrowed=sender_borrowed_ipc
+                    )
                     for (idx, _, _), tensor in zip(
                         accel_entries, received_accel_tensors
                     ):
@@ -2248,6 +2308,16 @@ class CollectiveGroup:
                 else:
                     for _, tensor, _ in accel_entries:
                         self._recv(tensor, CollectiveGroup.ACCEL, comm_id)
+
+        if mode_mismatch or invalid_borrowed_payload:
+            if sender_borrowed_ipc:
+                tensors.clear()
+                Worker.torch_platform.ipc_collect()
+            if mode_mismatch:
+                raise RuntimeError(
+                    "borrowed IPC mode must be enabled explicitly on both sender and receiver"
+                )
+            raise RuntimeError("borrowed IPC only supports CUDA tensor payloads")
         return tensors, pb_data
 
     def _send_tensor_dict(

--- a/rlinf/scheduler/collective/collective_group.py
+++ b/rlinf/scheduler/collective/collective_group.py
@@ -1438,10 +1438,10 @@ class CollectiveGroup:
         Returns:
             Tuple of (definitely_same, uncertain, definitely_diff):
             - definitely_same: same node, both have exactly one accelerator, identical
-              device → use P2P IPC directly.
+              device -> use P2P IPC directly.
             - uncertain: same node, accelerator sets overlap but at least one side has
-              multiple accelerators → exchange current-device at runtime to decide.
-            - definitely_diff: different node or no accelerator overlap → accelerator collective.
+              multiple accelerators -> exchange current-device at runtime to decide.
+            - definitely_diff: different node or no accelerator overlap -> accelerator collective.
         """
         src = self._group_info.workers[src_rank]
         src_devices = set(src.available_accelerators)

--- a/rlinf/scheduler/worker/worker.py
+++ b/rlinf/scheduler/worker/worker.py
@@ -565,6 +565,7 @@ class Worker(metaclass=WorkerMeta):
         async_op: bool = False,
         options: Optional["CollectiveGroupOptions"] = None,
         piggyback_payload: Optional[Any] = None,
+        borrowed_ipc: bool = False,
     ):
         """Send an object to a specific worker address in the collective group.
 
@@ -592,6 +593,9 @@ class Worker(metaclass=WorkerMeta):
             async_op (bool): Whether to perform the operation asynchronously.
             options (Optional[CollectiveGroupOptions]): The options for the collective group. The options will only take effect when two workers first communicate with each other, and will be ignored for subsequent communications. This option must match the options of the recv side.
             piggyback_payload (Optional[Any]): The payload to piggyback on the send operation. This payload will be sent to the recv side and can be used to pass additional information to the recv side without disrupting the object's data structure, e.g., list/dict of tensors that are optimized for sending.
+            borrowed_ipc (bool): Return same-device CUDA aliases instead of
+                receiver-owned clones. The sender must retain the source tensors
+                until an application-level acknowledgement is received.
 
         Returns:
             Optional[AsyncWork]: An AsyncWork object if async_op is True, otherwise None.
@@ -604,6 +608,7 @@ class Worker(metaclass=WorkerMeta):
             async_op=async_op,
             options=options,
             piggyback_payload=piggyback_payload,
+            borrowed_ipc=borrowed_ipc,
         )
 
     def recv(
@@ -612,6 +617,7 @@ class Worker(metaclass=WorkerMeta):
         src_rank: int | list[int],
         async_op: bool = False,
         options: Optional["CollectiveGroupOptions"] = None,
+        borrowed_ipc: bool = False,
     ):
         """Out-of-place receive of an object from a specific worker address in the collective group.
 
@@ -629,13 +635,20 @@ class Worker(metaclass=WorkerMeta):
             src_group_name (str): The name of the source worker group.
             src_rank (int | List[int]): The rank or list of ranks in the source worker group to receive the object from. For SPMD-like workers, this should be a single rank. For SPSD-like workers forked by parent workers, this can be a list of ranks that forms a path from the root worker to the target worker.
             options (Optional[CollectiveGroupOptions]): The options for the collective group. The options will only take effect when two workers first communicate with each other, and will be ignored for subsequent communications. This option must match the options of the send side.
+            borrowed_ipc (bool): Accept producer-owned same-device CUDA aliases.
+                This must match the sender and requires explicit lifetime
+                acknowledgement by the caller.
 
         Returns:
             AsyncWork | torch.Tensor | List[torch.Tensor] | Dict[str, torch.Tensor] | Any: An AsyncWork object if async_op is True, otherwise the received object. If the send side sends a piggyback payload, the received object will be a tuple of the received object and the piggyback payload.
         """
         src_addr = WorkerAddress(src_group_name, ranks=src_rank)
         group = self._get_collective_group(src_addr)
-        return group.recv(async_op=async_op, options=options)
+        return group.recv(
+            async_op=async_op,
+            options=options,
+            borrowed_ipc=borrowed_ipc,
+        )
 
     def send_tensor(
         self,

--- a/rlinf/utils/backbone_cache.py
+++ b/rlinf/utils/backbone_cache.py
@@ -1,0 +1,133 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+ROLLOUT_BACKBONE_FEATURE_KEY = "rollout_backbone_features"
+ROLLOUT_BACKBONE_MASK_KEY = "rollout_backbone_attention_mask"
+ROLLOUT_BACKBONE_SAMPLE_IDS_KEY = "_rlinf_rollout_backbone_sample_ids"
+ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE = 1 << 40
+ROLLOUT_BACKBONE_TRANSPORT_KEY = "rollout_backbone_feature_transport"
+ROLLOUT_BACKBONE_BORROWED_IPC_PINNED = "borrowed_ipc_pinned"
+
+
+def is_rollout_backbone_ipc_transport(transport: str | None) -> bool:
+    return transport == ROLLOUT_BACKBONE_BORROWED_IPC_PINNED
+
+
+ROLLOUT_BACKBONE_INPUT_KEYS = (
+    "eagle_input_ids",
+    "eagle_attention_mask",
+    "eagle_pixel_values",
+    "eagle_image_sizes",
+)
+
+BackboneOutput = dict[str, torch.Tensor]
+
+
+def rollout_backbone_channel_key(actor_rank: int) -> str:
+    return f"rollout_backbone_actor_rank_{int(actor_rank)}"
+
+
+def rollout_backbone_producer_rank(sample_ids: torch.Tensor) -> int:
+    """Return the single Rollout rank encoded by a sample-ID tensor."""
+    flat_ids = sample_ids.reshape(-1).to(dtype=torch.int64, device="cpu")
+    if flat_ids.numel() == 0 or int(flat_ids.min().item()) < 0:
+        raise ValueError(
+            "rollout backbone sample IDs must be non-empty and non-negative"
+        )
+    producer_ranks = torch.div(
+        flat_ids,
+        ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE,
+        rounding_mode="floor",
+    )
+    unique_ranks, counts = producer_ranks.unique(return_counts=True)
+    if unique_ranks.numel() != 1:
+        rank_counts = {
+            int(rank): int(count)
+            for rank, count in zip(unique_ranks.tolist(), counts.tolist())
+        }
+        raise ValueError(
+            "one trajectory spans multiple Rollout feature producers: "
+            f"counts={rank_counts}"
+        )
+    return int(unique_ranks.item())
+
+
+def validate_rollout_backbone_sample_ids(
+    sample_ids: torch.Tensor,
+    *,
+    producer_rank: int,
+    total_samples: int,
+) -> None:
+    """Require exactly one occurrence of every sample in a producer namespace."""
+    if producer_rank < 0 or total_samples <= 0:
+        raise ValueError("invalid rollout backbone sample-ID contract")
+    flat_ids = sample_ids.reshape(-1).to(dtype=torch.int64, device="cpu")
+    sample_id_base = producer_rank * ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE
+    expected_ids = torch.arange(
+        sample_id_base,
+        sample_id_base + total_samples,
+        dtype=torch.int64,
+    )
+    if flat_ids.numel() != total_samples or not torch.equal(
+        flat_ids.sort().values, expected_ids
+    ):
+        raise ValueError(
+            "trajectory sample IDs do not form the pinned backbone cache"
+        )
+
+
+def filter_rollout_backbone_transport(
+    forward_inputs: dict[str, torch.Tensor],
+    *,
+    reuse_enabled: bool,
+) -> bool:
+    """Keep either raw Eagle inputs or a complete reusable backbone output."""
+    if not reuse_enabled:
+        forward_inputs.pop(ROLLOUT_BACKBONE_FEATURE_KEY, None)
+        forward_inputs.pop(ROLLOUT_BACKBONE_MASK_KEY, None)
+        return False
+
+    has_complete_feature = all(
+        key in forward_inputs
+        for key in (ROLLOUT_BACKBONE_FEATURE_KEY, ROLLOUT_BACKBONE_MASK_KEY)
+    )
+    if not has_complete_feature:
+        forward_inputs.pop(ROLLOUT_BACKBONE_FEATURE_KEY, None)
+        forward_inputs.pop(ROLLOUT_BACKBONE_MASK_KEY, None)
+        return False
+
+    for key in ROLLOUT_BACKBONE_INPUT_KEYS:
+        forward_inputs.pop(key, None)
+    return True
+
+
+def validate_frozen_backbone(backbone: nn.Module) -> None:
+    parameters = list(backbone.parameters())
+    if not parameters:
+        raise ValueError("backbone cache requires a backbone with parameters")
+    trainable = sum(
+        parameter.numel() for parameter in parameters if parameter.requires_grad
+    )
+    if trainable:
+        raise ValueError(
+            "backbone cache requires every backbone parameter to be frozen; "
+            f"found {trainable} trainable parameters"
+        )
+    if backbone.training:
+        raise ValueError("backbone cache requires the backbone to be in eval mode")

--- a/rlinf/utils/backbone_cache.py
+++ b/rlinf/utils/backbone_cache.py
@@ -87,9 +87,7 @@ def validate_rollout_backbone_sample_ids(
     if flat_ids.numel() != total_samples or not torch.equal(
         flat_ids.sort().values, expected_ids
     ):
-        raise ValueError(
-            "trajectory sample IDs do not form the pinned backbone cache"
-        )
+        raise ValueError("trajectory sample IDs do not form the pinned backbone cache")
 
 
 def filter_rollout_backbone_transport(

--- a/rlinf/utils/pinned_feature_stream.py
+++ b/rlinf/utils/pinned_feature_stream.py
@@ -21,6 +21,44 @@ from rlinf.utils.backbone_cache import ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE
 from rlinf.utils.pinned_rollout_cache import PinnedRolloutBackboneCache
 
 
+def compute_rollout_backbone_stream_counts(
+    *,
+    rollout_epochs: int,
+    max_steps_per_epoch: int,
+    num_action_chunks: int,
+    pipeline_stages: int,
+    total_num_envs: int,
+    world_size: int,
+) -> tuple[int, int]:
+    """Return the number of policy-output blocks and feature samples per rank."""
+    values = {
+        "rollout_epochs": rollout_epochs,
+        "max_steps_per_epoch": max_steps_per_epoch,
+        "num_action_chunks": num_action_chunks,
+        "pipeline_stages": pipeline_stages,
+        "total_num_envs": total_num_envs,
+        "world_size": world_size,
+    }
+    invalid = [name for name, value in values.items() if value <= 0]
+    if invalid:
+        raise ValueError(f"rollout backbone stream counts require positive {invalid}")
+    if max_steps_per_epoch % num_action_chunks:
+        raise ValueError(
+            "max_steps_per_epoch must be divisible by num_action_chunks for "
+            "rollout backbone streaming"
+        )
+    if total_num_envs % (world_size * pipeline_stages):
+        raise ValueError(
+            "total_num_envs must be divisible by world_size * pipeline_stages "
+            "for rollout backbone streaming"
+        )
+
+    chunk_steps = max_steps_per_epoch // num_action_chunks
+    expected_blocks = rollout_epochs * chunk_steps * pipeline_stages
+    expected_samples = rollout_epochs * chunk_steps * total_num_envs // world_size
+    return expected_blocks, expected_samples
+
+
 async def receive_pinned_rollout_backbone_stream(
     worker: Any,
     *,

--- a/rlinf/utils/pinned_feature_stream.py
+++ b/rlinf/utils/pinned_feature_stream.py
@@ -1,0 +1,230 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from rlinf.utils.backbone_cache import ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE
+from rlinf.utils.pinned_rollout_cache import PinnedRolloutBackboneCache
+
+
+async def receive_pinned_rollout_backbone_stream(
+    worker: Any,
+    *,
+    source_rank: int,
+    consumer_rank: int,
+    model_version: int,
+    expected_blocks: int,
+    expected_samples: int,
+    blocks_per_batch: int,
+    rollout_group_name: str,
+    timeout_seconds: float,
+) -> tuple[PinnedRolloutBackboneCache, dict[str, Any], dict[str, float]]:
+    if expected_blocks <= 0 or expected_samples <= 0:
+        raise ValueError("pinned backbone stream requires positive expected counts")
+    if blocks_per_batch <= 0:
+        raise ValueError("pinned backbone batch size must be positive")
+    if timeout_seconds <= 0:
+        raise ValueError("pinned backbone stream timeout must be positive")
+
+    cache: PinnedRolloutBackboneCache | None = None
+    stream_metadata: dict[str, Any] | None = None
+    received_bytes = 0
+    completed_blocks = 0
+    completed_samples = 0
+    expected_batches = (expected_blocks + blocks_per_batch - 1) // blocks_per_batch
+    received = None
+    metadata = None
+    tensors = []
+    blocks = []
+    try:
+        for expected_batch_index in range(expected_batches):
+            received = None
+            metadata = None
+            tensors = []
+            blocks = []
+            recv_work = worker.recv(
+                src_group_name=rollout_group_name,
+                src_rank=source_rank,
+                async_op=True,
+                borrowed_ipc=True,
+            )
+            try:
+                received = await asyncio.wait_for(
+                    recv_work.async_wait(), timeout=timeout_seconds
+                )
+            except asyncio.TimeoutError as error:
+                raise TimeoutError(
+                    "timed out waiting for pinned backbone batch "
+                    f"{expected_batch_index}/{expected_batches} from Rollout rank "
+                    f"{source_rank}"
+                ) from error
+            if not isinstance(received, tuple) or len(received) != 2:
+                raise RuntimeError("pinned backbone IPC requires tensors and metadata")
+            tensors, metadata = received
+            if not isinstance(metadata, dict) or metadata.get("schema") != 3:
+                raise RuntimeError(f"unsupported pinned backbone metadata: {metadata}")
+            if not isinstance(tensors, list) or not tensors or len(tensors) % 2:
+                raise RuntimeError("pinned backbone batch requires feature/mask pairs")
+            if int(metadata.get("batch_index", -1)) != expected_batch_index:
+                raise RuntimeError("pinned backbone batches arrived out of order")
+            if int(metadata.get("start_block_index", -1)) != completed_blocks:
+                raise RuntimeError("pinned backbone batch block range is invalid")
+            if int(metadata.get("total_blocks", -1)) != expected_blocks:
+                raise RuntimeError("pinned backbone total block count changed")
+            if int(metadata.get("total_samples", -1)) != expected_samples:
+                raise RuntimeError("pinned backbone total sample count changed")
+            if int(metadata.get("producer_rank", -1)) != source_rank:
+                raise RuntimeError("pinned backbone producer rank does not match route")
+            if int(metadata.get("consumer_rank", -1)) != consumer_rank:
+                raise RuntimeError("pinned backbone consumer rank does not match Actor")
+            if int(metadata.get("model_version", -1)) != model_version:
+                raise RuntimeError("pinned backbone model version does not match Actor")
+            expected_base = source_rank * ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE
+            if int(metadata.get("sample_id_base", -1)) != expected_base:
+                raise RuntimeError("pinned backbone sample-ID namespace is invalid")
+            if int(metadata.get("offset", -1)) != completed_samples:
+                raise RuntimeError("pinned backbone batch sample offset is invalid")
+
+            block_sizes = [int(size) for size in metadata.get("block_sizes", [])]
+            expected_batch_blocks = min(
+                blocks_per_batch, expected_blocks - completed_blocks
+            )
+            if len(block_sizes) != expected_batch_blocks:
+                raise RuntimeError("pinned backbone batch block count mismatch")
+            if len(tensors) != 2 * len(block_sizes) or any(
+                size <= 0 for size in block_sizes
+            ):
+                raise RuntimeError("pinned backbone batch tensor schema is invalid")
+
+            batch_bytes = 0
+            for block_offset, block_size in enumerate(block_sizes):
+                feature = tensors[2 * block_offset]
+                mask = tensors[2 * block_offset + 1]
+                if feature.shape[0] != block_size or mask.shape[0] != block_size:
+                    raise RuntimeError(
+                        "pinned backbone feature/mask block size mismatch"
+                    )
+                blocks.append((feature, mask))
+                batch_bytes += sum(
+                    tensor.numel() * tensor.element_size() for tensor in (feature, mask)
+                )
+            if batch_bytes != int(metadata.get("bytes", -1)):
+                raise RuntimeError("pinned backbone batch byte count mismatch")
+
+            if cache is None:
+                first_feature, first_mask = blocks[0]
+                cache = PinnedRolloutBackboneCache(
+                    total_samples=expected_samples,
+                    feature_example=first_feature,
+                    mask_example=first_mask,
+                    device=worker.torch_platform.current_device(),
+                )
+                stream_metadata = dict(metadata)
+            elif stream_metadata is None or metadata.get(
+                "lease_id"
+            ) != stream_metadata.get("lease_id"):
+                raise RuntimeError("pinned backbone lease changed within one stream")
+
+            cache.store_blocks(offset=completed_samples, blocks=blocks)
+            completed_blocks += len(block_sizes)
+            completed_samples += sum(block_sizes)
+            received_bytes += batch_bytes
+            if expected_batch_index + 1 == expected_batches and (
+                completed_blocks != expected_blocks
+                or completed_samples != expected_samples
+            ):
+                raise RuntimeError(
+                    "pinned backbone stream ended with incomplete counts"
+                )
+
+            lease_id = str(metadata.get("lease_id", ""))
+            blocks.clear()
+            tensors.clear()
+            received = None
+            worker.torch_platform.ipc_collect()
+            worker.send(
+                {
+                    "schema": 3,
+                    "status": "ok",
+                    "lease_id": lease_id,
+                    "batch_index": expected_batch_index,
+                    "completed_blocks": completed_blocks,
+                },
+                dst_group_name=rollout_group_name,
+                dst_rank=source_rank,
+            )
+
+            log_stride = max(1, expected_blocks // 4)
+            if expected_batch_index == 0 or completed_blocks % log_stride == 0:
+                worker.log_info(
+                    "PINNED_FEATURE_BATCH_STORED "
+                    f"rank={consumer_rank} lease={lease_id} "
+                    f"batches={expected_batch_index + 1}/{expected_batches} "
+                    f"blocks={completed_blocks}/{expected_blocks} "
+                    f"bytes={received_bytes}"
+                )
+    except Exception as error:
+        if cache is not None:
+            cache.clear()
+        blocks.clear()
+        if isinstance(tensors, list):
+            tensors.clear()
+        received = None
+        worker.torch_platform.ipc_collect()
+        if isinstance(metadata, dict) and metadata.get("lease_id"):
+            worker.send(
+                {
+                    "schema": 3,
+                    "status": "error",
+                    "lease_id": str(metadata["lease_id"]),
+                    "batch_index": int(metadata.get("batch_index", -1)),
+                    "completed_blocks": completed_blocks,
+                    "error": f"{type(error).__name__}: {error}",
+                },
+                dst_group_name=rollout_group_name,
+                dst_rank=source_rank,
+            )
+        raise
+
+    if cache is None or stream_metadata is None:
+        raise RuntimeError("pinned backbone stream produced no cache")
+    if completed_blocks != expected_blocks or completed_samples != expected_samples:
+        raise RuntimeError("pinned backbone stream ended with incomplete counts")
+    try:
+        cache.finalize()
+    except Exception:
+        cache.clear()
+        worker.torch_platform.ipc_collect()
+        raise
+    stats = cache.stats()
+    worker.log_info(
+        "PINNED_FEATURE_CACHE_READY "
+        f"rank={consumer_rank} lease={stream_metadata['lease_id']} "
+        f"batches={expected_batches} samples={stats.samples} bytes={stats.bytes} "
+        f"alloc_s={stats.allocation_seconds:.6f} d2h_s={stats.d2h_seconds:.6f}"
+    )
+    return (
+        cache,
+        stream_metadata,
+        {
+            "actor/pinned_feature_bytes": float(stats.bytes),
+            "actor/pinned_feature_samples": float(stats.samples),
+            "actor/pinned_feature_batches": float(expected_batches),
+            "actor/pinned_feature_allocation_seconds": stats.allocation_seconds,
+            "actor/pinned_feature_d2h_seconds": stats.d2h_seconds,
+        },
+    )

--- a/rlinf/utils/pinned_rollout_cache.py
+++ b/rlinf/utils/pinned_rollout_cache.py
@@ -1,0 +1,281 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import torch
+
+from rlinf.utils.backbone_cache import BackboneOutput
+
+
+@dataclass(frozen=True)
+class PinnedRolloutBackboneCacheStats:
+    bytes: int
+    samples: int
+    stored_samples: int
+    loads: int
+    loaded_samples: int
+    allocation_seconds: float
+    d2h_seconds: float
+    cpu_gather_seconds: float
+    h2d_seconds: float
+    staging_bytes: int
+
+
+class PinnedRolloutBackboneCache:
+    """Actor-owned pinned cache populated from short-lived CUDA IPC views."""
+
+    def __init__(
+        self,
+        *,
+        total_samples: int,
+        feature_example: torch.Tensor,
+        mask_example: torch.Tensor,
+        device: torch.device | str | int,
+    ) -> None:
+        if total_samples <= 0:
+            raise ValueError("pinned rollout backbone cache requires positive samples")
+        if feature_example.device.type != "cuda" or mask_example.device.type != "cuda":
+            raise ValueError(
+                "pinned rollout backbone source tensors must be CUDA tensors"
+            )
+        if feature_example.shape[0] != mask_example.shape[0]:
+            raise ValueError("pinned rollout backbone feature/mask batch mismatch")
+
+        self._device = (
+            torch.device("cuda", device)
+            if isinstance(device, int)
+            else torch.device(device)
+        )
+        if self._device.type != "cuda":
+            raise ValueError(
+                "pinned rollout backbone destination must be a CUDA device"
+            )
+        self._samples = int(total_samples)
+        allocation_start = time.perf_counter()
+        self._features: torch.Tensor | None = torch.empty(
+            (self._samples, *feature_example.shape[1:]),
+            dtype=feature_example.dtype,
+            device="cpu",
+            pin_memory=True,
+        )
+        self._masks: torch.Tensor | None = torch.empty(
+            (self._samples, *mask_example.shape[1:]),
+            dtype=mask_example.dtype,
+            device="cpu",
+            pin_memory=True,
+        )
+        self._allocation_seconds = time.perf_counter() - allocation_start
+        self._bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in (self._features, self._masks)
+        )
+        self._copy_stream = torch.cuda.Stream(device=self._device)
+        self._stored_samples = 0
+        self._loads = 0
+        self._loaded_samples = 0
+        self._d2h_seconds = 0.0
+        self._cpu_gather_seconds = 0.0
+        self._h2d_seconds = 0.0
+        self._staging: list[dict[str, object]] = [{}, {}]
+
+    @property
+    def samples(self) -> int:
+        return self._samples
+
+    def store_block(
+        self,
+        *,
+        offset: int,
+        feature: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> None:
+        self.store_blocks(offset=offset, blocks=[(feature, mask)])
+
+    def store_blocks(
+        self,
+        *,
+        offset: int,
+        blocks: list[tuple[torch.Tensor, torch.Tensor]],
+    ) -> None:
+        if self._features is None or self._masks is None:
+            raise RuntimeError("pinned rollout backbone cache was cleared")
+        if offset != self._stored_samples:
+            raise ValueError(
+                "pinned rollout backbone blocks must arrive in order: "
+                f"expected offset {self._stored_samples}, got {offset}"
+            )
+        if not blocks:
+            raise ValueError("pinned rollout backbone batch must not be empty")
+
+        validated_blocks: list[tuple[torch.Tensor, torch.Tensor, int, int]] = []
+        end = offset
+        for feature, mask in blocks:
+            if feature.device != self._device or mask.device != self._device:
+                raise ValueError(
+                    "pinned rollout backbone block is on the wrong CUDA device"
+                )
+            if feature.shape[0] != mask.shape[0]:
+                raise ValueError("pinned rollout backbone feature/mask block mismatch")
+            block_size = int(feature.shape[0])
+            block_end = end + block_size
+            if block_end > self._samples:
+                raise ValueError("pinned rollout backbone block exceeds cache capacity")
+            if tuple(feature.shape[1:]) != tuple(self._features.shape[1:]):
+                raise ValueError("pinned rollout backbone feature shape changed")
+            if tuple(mask.shape[1:]) != tuple(self._masks.shape[1:]):
+                raise ValueError("pinned rollout backbone mask shape changed")
+            if feature.dtype != self._features.dtype or mask.dtype != self._masks.dtype:
+                raise ValueError("pinned rollout backbone dtype changed")
+            validated_blocks.append((feature, mask, end, block_end))
+            end = block_end
+
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(self._copy_stream):
+            start_event.record(self._copy_stream)
+            for feature, mask, block_offset, block_end in validated_blocks:
+                self._features[block_offset:block_end].copy_(
+                    feature.detach(), non_blocking=True
+                )
+                self._masks[block_offset:block_end].copy_(
+                    mask.detach(), non_blocking=True
+                )
+            end_event.record(self._copy_stream)
+        end_event.synchronize()
+        self._d2h_seconds += start_event.elapsed_time(end_event) / 1000.0
+        self._stored_samples = end
+
+    def finalize(self) -> None:
+        if self._stored_samples != self._samples:
+            raise RuntimeError(
+                "pinned rollout backbone stream ended early: "
+                f"stored {self._stored_samples} of {self._samples} samples"
+            )
+
+    def _complete_staging_slot(self, slot: dict[str, object]) -> None:
+        end_event = slot.pop("end_event", None)
+        start_event = slot.pop("start_event", None)
+        if end_event is not None:
+            assert isinstance(end_event, torch.cuda.Event)
+            assert isinstance(start_event, torch.cuda.Event)
+            end_event.synchronize()
+            self._h2d_seconds += start_event.elapsed_time(end_event) / 1000.0
+
+    def _get_staging_slot(self, sample_count: int) -> dict[str, object]:
+        if self._features is None or self._masks is None:
+            raise RuntimeError("pinned rollout backbone cache was cleared")
+        slot = self._staging[self._loads % len(self._staging)]
+        self._complete_staging_slot(slot)
+        feature_shape = (sample_count, *self._features.shape[1:])
+        mask_shape = (sample_count, *self._masks.shape[1:])
+        feature_staging = slot.get("features")
+        mask_staging = slot.get("masks")
+        if not isinstance(feature_staging, torch.Tensor) or tuple(
+            feature_staging.shape
+        ) != tuple(feature_shape):
+            feature_staging = torch.empty(
+                feature_shape,
+                dtype=self._features.dtype,
+                device="cpu",
+                pin_memory=True,
+            )
+            slot["features"] = feature_staging
+        if not isinstance(mask_staging, torch.Tensor) or tuple(
+            mask_staging.shape
+        ) != tuple(mask_shape):
+            mask_staging = torch.empty(
+                mask_shape,
+                dtype=self._masks.dtype,
+                device="cpu",
+                pin_memory=True,
+            )
+            slot["masks"] = mask_staging
+        return slot
+
+    def load(self, sample_ids: torch.Tensor) -> BackboneOutput:
+        if self._features is None or self._masks is None:
+            raise RuntimeError("pinned rollout backbone cache was cleared")
+        if self._stored_samples != self._samples:
+            raise RuntimeError("pinned rollout backbone cache is incomplete")
+        sample_ids = sample_ids.reshape(-1).to(dtype=torch.int64, device="cpu")
+        if sample_ids.numel() == 0:
+            raise ValueError("pinned rollout backbone sample IDs must be non-empty")
+        min_id = int(sample_ids.min().item())
+        max_id = int(sample_ids.max().item())
+        if min_id < 0 or max_id >= self._samples:
+            raise IndexError(
+                f"pinned rollout backbone sample IDs [{min_id}, {max_id}] exceed "
+                f"cache size {self._samples}"
+            )
+
+        slot = self._get_staging_slot(sample_ids.numel())
+        feature_staging = slot["features"]
+        mask_staging = slot["masks"]
+        assert isinstance(feature_staging, torch.Tensor)
+        assert isinstance(mask_staging, torch.Tensor)
+        gather_start = time.perf_counter()
+        torch.index_select(self._features, 0, sample_ids, out=feature_staging)
+        torch.index_select(self._masks, 0, sample_ids, out=mask_staging)
+        self._cpu_gather_seconds += time.perf_counter() - gather_start
+
+        feature_out = torch.empty_like(feature_staging, device=self._device)
+        mask_out = torch.empty_like(mask_staging, device=self._device)
+        stream = torch.cuda.current_stream(self._device)
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record(stream)
+        feature_out.copy_(feature_staging, non_blocking=True)
+        mask_out.copy_(mask_staging, non_blocking=True)
+        end_event.record(stream)
+        slot["start_event"] = start_event
+        slot["end_event"] = end_event
+        self._loads += 1
+        self._loaded_samples += sample_ids.numel()
+        return {
+            "backbone_features": feature_out,
+            "backbone_attention_mask": mask_out,
+        }
+
+    def stats(self) -> PinnedRolloutBackboneCacheStats:
+        for slot in self._staging:
+            self._complete_staging_slot(slot)
+        staging_bytes = sum(
+            value.numel() * value.element_size()
+            for slot in self._staging
+            for value in slot.values()
+            if isinstance(value, torch.Tensor)
+        )
+        return PinnedRolloutBackboneCacheStats(
+            bytes=self._bytes,
+            samples=self._samples,
+            stored_samples=self._stored_samples,
+            loads=self._loads,
+            loaded_samples=self._loaded_samples,
+            allocation_seconds=self._allocation_seconds,
+            d2h_seconds=self._d2h_seconds,
+            cpu_gather_seconds=self._cpu_gather_seconds,
+            h2d_seconds=self._h2d_seconds,
+            staging_bytes=staging_bytes,
+        )
+
+    def clear(self) -> None:
+        for slot in self._staging:
+            self._complete_staging_slot(slot)
+            slot.clear()
+        self._features = None
+        self._masks = None

--- a/rlinf/workers/actor/fsdp_actor_worker.py
+++ b/rlinf/workers/actor/fsdp_actor_worker.py
@@ -85,7 +85,10 @@ from rlinf.utils.nested_dict_process import (
     put_tensor_device,
     split_dict_to_chunk,
 )
-from rlinf.utils.pinned_feature_stream import receive_pinned_rollout_backbone_stream
+from rlinf.utils.pinned_feature_stream import (
+    compute_rollout_backbone_stream_counts,
+    receive_pinned_rollout_backbone_stream,
+)
 from rlinf.utils.pinned_rollout_cache import PinnedRolloutBackboneCache
 from rlinf.utils.placement import (
     HybridComponentPlacement,
@@ -1286,12 +1289,15 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
             return {}
         if self._pinned_rollout_backbone_cache is not None:
             raise RuntimeError("previous rollout backbone cache is still active")
-        expected_blocks = int(
-            self.cfg.env.train.rollout_epoch
-            * self.cfg.env.train.max_steps_per_rollout_epoch
-        )
-        expected_samples = int(
-            expected_blocks * self.cfg.env.train.total_num_envs // self._world_size
+        expected_blocks, expected_samples = compute_rollout_backbone_stream_counts(
+            rollout_epochs=int(self.cfg.env.train.rollout_epoch),
+            max_steps_per_epoch=int(
+                self.cfg.env.train.max_steps_per_rollout_epoch
+            ),
+            num_action_chunks=int(self.cfg.actor.model.num_action_chunks),
+            pipeline_stages=int(self.stage_num),
+            total_num_envs=int(self.cfg.env.train.total_num_envs),
+            world_size=int(self._world_size),
         )
         cache, metadata, metrics = await receive_pinned_rollout_backbone_stream(
             self,

--- a/rlinf/workers/actor/fsdp_actor_worker.py
+++ b/rlinf/workers/actor/fsdp_actor_worker.py
@@ -14,7 +14,7 @@
 
 import time
 from functools import partial
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import torch
@@ -44,6 +44,19 @@ from rlinf.hybrid_engines.weight_syncer import WeightSyncer
 from rlinf.models import get_model
 from rlinf.models.embodiment.base_policy import ForwardType
 from rlinf.scheduler import Channel, Cluster, Worker
+from rlinf.utils.backbone_cache import (
+    ROLLOUT_BACKBONE_BORROWED_IPC_PINNED,
+    ROLLOUT_BACKBONE_FEATURE_KEY,
+    ROLLOUT_BACKBONE_MASK_KEY,
+    ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE,
+    ROLLOUT_BACKBONE_SAMPLE_IDS_KEY,
+    ROLLOUT_BACKBONE_TRANSPORT_KEY,
+    is_rollout_backbone_ipc_transport,
+    rollout_backbone_channel_key,
+    rollout_backbone_producer_rank,
+    validate_frozen_backbone,
+    validate_rollout_backbone_sample_ids,
+)
 from rlinf.utils.data_iter_utils import (
     get_iterator_k_split,
     get_reverse_idx,
@@ -72,6 +85,8 @@ from rlinf.utils.nested_dict_process import (
     put_tensor_device,
     split_dict_to_chunk,
 )
+from rlinf.utils.pinned_feature_stream import receive_pinned_rollout_backbone_stream
+from rlinf.utils.pinned_rollout_cache import PinnedRolloutBackboneCache
 from rlinf.utils.placement import (
     HybridComponentPlacement,
     ModelParallelComponentPlacement,
@@ -1087,6 +1102,35 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
 
         self.enable_sft_co_train = cfg.actor.get("enable_sft_co_train", False)
         self.version = 0
+        feature_transport = cfg.actor.model.get(ROLLOUT_BACKBONE_TRANSPORT_KEY)
+        if feature_transport not in (None, ROLLOUT_BACKBONE_BORROWED_IPC_PINNED):
+            raise ValueError(
+                f"unsupported rollout backbone feature transport: {feature_transport}"
+            )
+        self._pinned_feature_ipc_enabled = is_rollout_backbone_ipc_transport(
+            feature_transport
+        )
+        self._pinned_feature_ipc_batch_blocks = int(
+            cfg.rollout.get("pinned_feature_ipc_batch_blocks", 1)
+        )
+        self._pinned_feature_ipc_timeout_seconds = float(
+            cfg.rollout.get("pinned_feature_ipc_timeout_seconds", 300.0)
+        )
+        if self._pinned_feature_ipc_batch_blocks <= 0:
+            raise ValueError("rollout.pinned_feature_ipc_batch_blocks must be positive")
+        if self._pinned_feature_ipc_timeout_seconds <= 0:
+            raise ValueError(
+                "rollout.pinned_feature_ipc_timeout_seconds must be positive"
+            )
+        if self._pinned_feature_ipc_enabled and (
+            self._component_placement.get_world_size("rollout")
+            != self._component_placement.get_world_size("actor")
+        ):
+            raise ValueError(
+                "pinned rollout backbone transport currently requires equal Rollout/Actor world sizes"
+            )
+        self._pinned_backbone_metadata: dict[str, Any] | None = None
+        self._pinned_rollout_backbone_cache: PinnedRolloutBackboneCache | None = None
         if self.enable_sft_co_train:
             self._build_sft_data_loader()
 
@@ -1211,12 +1255,104 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
 
         recv_list = []
         for _ in range(split_num):
-            trajectory: Trajectory = await input_channel.get(async_op=True).async_wait()
+            channel_key = (
+                rollout_backbone_channel_key(self._rank)
+                if self._pinned_feature_ipc_enabled
+                else None
+            )
+            if channel_key is None:
+                recv_work = input_channel.get(async_op=True)
+            else:
+                recv_work = input_channel.get(key=channel_key, async_op=True)
+            trajectory: Trajectory = await recv_work.async_wait()
             recv_list.append(trajectory)
 
         self.rollout_batch = convert_trajectories_to_batch(recv_list)
 
         self.rollout_batch = self._process_received_rollout_batch(self.rollout_batch)
+
+    def get_rollout_backbone_feature_source_rank(self) -> int:
+        if not self._pinned_feature_ipc_enabled:
+            return self._rank
+        forward_inputs = self.rollout_batch.get("forward_inputs", {})
+        sample_ids = forward_inputs.get(ROLLOUT_BACKBONE_SAMPLE_IDS_KEY)
+        if sample_ids is None:
+            raise RuntimeError("trajectory is missing pinned backbone sample IDs")
+        return rollout_backbone_producer_rank(sample_ids)
+
+    @Worker.timer("actor/feature_stream_recv")
+    async def recv_rollout_backbone_feature_stream(self) -> dict[str, float]:
+        if not self._pinned_feature_ipc_enabled:
+            return {}
+        if self._pinned_rollout_backbone_cache is not None:
+            raise RuntimeError("previous rollout backbone cache is still active")
+        expected_blocks = int(
+            self.cfg.env.train.rollout_epoch
+            * self.cfg.env.train.max_steps_per_rollout_epoch
+        )
+        expected_samples = int(
+            expected_blocks * self.cfg.env.train.total_num_envs // self._world_size
+        )
+        cache, metadata, metrics = await receive_pinned_rollout_backbone_stream(
+            self,
+            source_rank=self._rank,
+            consumer_rank=self._rank,
+            model_version=int(self.version),
+            expected_blocks=expected_blocks,
+            expected_samples=expected_samples,
+            blocks_per_batch=self._pinned_feature_ipc_batch_blocks,
+            rollout_group_name=self._rollout_group_name,
+            timeout_seconds=self._pinned_feature_ipc_timeout_seconds,
+        )
+        self._pinned_rollout_backbone_cache = cache
+        self._pinned_backbone_metadata = metadata
+        return metrics
+
+    def validate_rollout_backbone_feature_stream(
+        self, source_ranks: list[int]
+    ) -> dict[str, float]:
+        if not self._pinned_feature_ipc_enabled:
+            return {}
+        if len(source_ranks) != self._world_size or sorted(source_ranks) != list(
+            range(self._world_size)
+        ):
+            raise RuntimeError(
+                f"pinned backbone route must be a rank permutation: {source_ranks}"
+            )
+        source_rank = int(source_ranks[self._rank])
+        if source_rank != self._rank:
+            raise RuntimeError(
+                "streaming pinned backbone IPC requires identity same-GPU routing"
+            )
+        cache = self._pinned_rollout_backbone_cache
+        metadata = self._pinned_backbone_metadata
+        if cache is None or metadata is None:
+            raise RuntimeError("pinned backbone stream is not ready")
+        forward_inputs = self.rollout_batch.get("forward_inputs", {})
+        sample_ids = forward_inputs.get(ROLLOUT_BACKBONE_SAMPLE_IDS_KEY)
+        if sample_ids is None:
+            raise RuntimeError("trajectory is missing pinned backbone sample IDs")
+        sample_id_base = int(metadata["sample_id_base"])
+        if sample_id_base != source_rank * ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE:
+            raise RuntimeError("pinned backbone sample-ID namespace is invalid")
+        validate_rollout_backbone_sample_ids(
+            sample_ids,
+            producer_rank=source_rank,
+            total_samples=cache.samples,
+        )
+        self.log_info(
+            "PINNED_FEATURE_ROUTE_VALID "
+            f"rank={self._rank} source={source_rank} samples={cache.samples}"
+        )
+        return {"actor/pinned_feature_route_valid": 1.0}
+
+    @Worker.timer("actor/feature_recv")
+    def recv_rollout_backbone_features(
+        self, source_ranks: list[int]
+    ) -> dict[str, float]:
+        if not self._pinned_feature_ipc_enabled:
+            return {}
+        return self.validate_rollout_backbone_feature_stream(source_ranks)
 
     def _process_received_rollout_batch(
         self, rollout_batch: dict[str, torch.Tensor]
@@ -1491,8 +1627,52 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
             )
         return loss
 
-    @Worker.timer("run_training")
+    def _validate_pinned_backbone_contract(self) -> bool:
+        """Validate the pinned Rollout feature-reuse contract."""
+        if not self._pinned_feature_ipc_enabled:
+            return False
+        if SupportedModel(self.cfg.actor.model.model_type) != SupportedModel.GR00T:
+            raise ValueError(
+                "pinned rollout backbone transport currently supports GR00T N1.5 only"
+            )
+        if self.enable_sft_co_train:
+            raise ValueError(
+                "pinned rollout backbone transport is incompatible with SFT co-training"
+            )
+        if not self.cfg.actor.model.rl_head_config.get("disable_dropout", False):
+            raise ValueError(
+                "pinned rollout backbone transport requires disable_dropout=true"
+            )
+        model = self.model
+        while hasattr(model, "module"):
+            model = model.module
+        backbone = getattr(model, "backbone", None)
+        if backbone is None:
+            raise ValueError("GR00T model does not expose a backbone module")
+        backbone.eval()
+        validate_frozen_backbone(backbone)
+        return True
+
+    def _clear_pinned_rollout_backbone_cache(self) -> None:
+        cache = self._pinned_rollout_backbone_cache
+        if cache is not None:
+            cache.clear()
+        self._pinned_rollout_backbone_cache = None
+        self._pinned_backbone_metadata = None
+        rollout_batch = getattr(self, "rollout_batch", None)
+        if isinstance(rollout_batch, dict):
+            forward_inputs = rollout_batch.get("forward_inputs", {})
+            forward_inputs.pop(ROLLOUT_BACKBONE_SAMPLE_IDS_KEY, None)
+
     def run_training(self) -> None:
+        try:
+            return self._run_training_impl()
+        except Exception:
+            self._clear_pinned_rollout_backbone_cache()
+            raise
+
+    @Worker.timer("run_training")
+    def _run_training_impl(self) -> None:
         """
         Run the training process using the received rollout batch.
         """
@@ -1515,6 +1695,13 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
                 )
 
         self.model.train()
+        reuse_rollout_feature = self._validate_pinned_backbone_contract()
+        pinned_rollout_cache = self._pinned_rollout_backbone_cache
+        if self._pinned_feature_ipc_enabled and pinned_rollout_cache is None:
+            raise RuntimeError("pinned backbone transport is enabled without a cache")
+        if self._pinned_feature_ipc_enabled and not reuse_rollout_feature:
+            raise RuntimeError("pinned backbone transport requires feature reuse")
+        self._reuse_feature_fallbacks = 0
         rollout_size = (
             self.rollout_batch["prev_logprobs"].shape[0]
             * self.rollout_batch["prev_logprobs"].shape[1]
@@ -1537,7 +1724,7 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
         )
         metrics = {}
         update_epoch = self.cfg.algorithm.get("update_epoch", 1)
-        for _ in range(update_epoch):
+        for epoch_idx in range(update_epoch):
             rollout_dataloader_iter = split_dict_to_chunk(
                 self.rollout_batch,
                 rollout_size // batch_size_per_rank,
@@ -1561,10 +1748,67 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
 
                 self.optimizer.zero_grad()
                 for idx, batch in enumerate(train_micro_batch):
+                    if pinned_rollout_cache is not None:
+                        forward_inputs = batch.get("forward_inputs", {})
+                        sample_ids = forward_inputs.pop(
+                            ROLLOUT_BACKBONE_SAMPLE_IDS_KEY, None
+                        )
+                        if sample_ids is None:
+                            raise RuntimeError(
+                                "training microbatch is missing pinned backbone sample IDs"
+                            )
+                        metadata = self._pinned_backbone_metadata
+                        if metadata is None:
+                            raise RuntimeError(
+                                "pinned backbone metadata was released early"
+                            )
+                        local_sample_ids = sample_ids - int(metadata["sample_id_base"])
+                        pinned_output = pinned_rollout_cache.load(local_sample_ids)
+                        if bool(metadata.get("verify_trajectory", False)):
+                            trajectory_feature = forward_inputs.get(
+                                ROLLOUT_BACKBONE_FEATURE_KEY
+                            )
+                            trajectory_mask = forward_inputs.get(
+                                ROLLOUT_BACKBONE_MASK_KEY
+                            )
+                            if trajectory_feature is None or trajectory_mask is None:
+                                raise RuntimeError(
+                                    "pinned feature transport verification requires trajectory features"
+                                )
+                            if not torch.equal(
+                                pinned_output["backbone_features"],
+                                trajectory_feature.to(self.device),
+                            ):
+                                max_diff = (
+                                    (
+                                        pinned_output["backbone_features"].float()
+                                        - trajectory_feature.to(self.device).float()
+                                    )
+                                    .abs()
+                                    .max()
+                                )
+                                raise RuntimeError(
+                                    "pinned feature transport feature mismatch against trajectory "
+                                    f"reference: max_diff={float(max_diff.item())}"
+                                )
+                            if not torch.equal(
+                                pinned_output["backbone_attention_mask"],
+                                trajectory_mask.to(self.device),
+                            ):
+                                raise RuntimeError(
+                                    "pinned feature transport attention mask mismatch against trajectory"
+                                )
+                        forward_inputs[ROLLOUT_BACKBONE_FEATURE_KEY] = pinned_output[
+                            "backbone_features"
+                        ]
+                        forward_inputs[ROLLOUT_BACKBONE_MASK_KEY] = pinned_output[
+                            "backbone_attention_mask"
+                        ]
                     self.train_micro_batch(
                         micro_batch=batch,
                         metrics=metrics,
                         is_last=(idx + 1) == self.gradient_accumulation,
+                        reuse_rollout_feature=reuse_rollout_feature,
                     )
                     # avoid gpu memory leak
                     train_micro_batch[idx] = None
@@ -1580,6 +1824,42 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
                 if len(lr_list) > 1:
                     data["critic/lr"] = lr_list[1]
                 append_to_dict(metrics, data)
+        if pinned_rollout_cache is not None:
+            pinned_stats = pinned_rollout_cache.stats()
+            append_to_dict(
+                metrics,
+                {
+                    "actor/pinned_feature_loads": float(pinned_stats.loads),
+                    "actor/pinned_feature_loaded_samples": float(
+                        pinned_stats.loaded_samples
+                    ),
+                    "actor/pinned_feature_bytes": float(pinned_stats.bytes),
+                    "actor/pinned_feature_staging_bytes": float(
+                        pinned_stats.staging_bytes
+                    ),
+                    "actor/pinned_feature_allocation_seconds": (
+                        pinned_stats.allocation_seconds
+                    ),
+                    "actor/pinned_feature_d2h_seconds": pinned_stats.d2h_seconds,
+                    "actor/pinned_feature_cpu_gather_seconds": (
+                        pinned_stats.cpu_gather_seconds
+                    ),
+                    "actor/pinned_feature_h2d_seconds": pinned_stats.h2d_seconds,
+                },
+            )
+            self.log_info(
+                "PINNED_FEATURE_TRAINING_DONE "
+                f"rank={self._rank} loads={pinned_stats.loads} "
+                f"loaded_samples={pinned_stats.loaded_samples} "
+                f"cpu_gather_s={pinned_stats.cpu_gather_seconds:.6f} "
+                f"h2d_s={pinned_stats.h2d_seconds:.6f}"
+            )
+            self._clear_pinned_rollout_backbone_cache()
+        if reuse_rollout_feature:
+            append_to_dict(
+                metrics,
+                {"actor/reuse_feature_fallbacks": float(self._reuse_feature_fallbacks)},
+            )
         # put LR scheduler step here
         self.lr_scheduler.step()
         self.optimizer.zero_grad()
@@ -1605,8 +1885,29 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
         metrics: dict[str, list[float]],
         *,
         is_last: bool,
+        reuse_rollout_feature: bool = False,
     ) -> None:
+        backbone_kwargs = {}
+
         micro_batch = put_tensor_device(micro_batch, self.device)
+
+        if reuse_rollout_feature:
+            fwd = micro_batch.get("forward_inputs", {})
+            reuse_feat = fwd.pop(ROLLOUT_BACKBONE_FEATURE_KEY, None)
+            reuse_mask = fwd.pop(ROLLOUT_BACKBONE_MASK_KEY, None)
+            if reuse_feat is not None and reuse_mask is not None:
+                backbone_kwargs = {
+                    "precomputed_backbone": {
+                        "backbone_features": reuse_feat.detach(),
+                        "backbone_attention_mask": reuse_mask.detach(),
+                    }
+                }
+            else:
+                self._reuse_feature_fallbacks += 1
+                raise RuntimeError(
+                    "pinned rollout backbone cache returned an incomplete feature"
+                )
+
         backward_ctx = self.before_micro_batch(self.model, is_last_micro_batch=is_last)
         advantages = micro_batch["advantages"]
         prev_logprobs = micro_batch["prev_logprobs"]
@@ -1639,6 +1940,7 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
                 compute_entropy=self.cfg.algorithm.entropy_bonus > 0,
                 compute_values=compute_values,
                 use_cache=False,
+                **backbone_kwargs,
                 **kwargs,
             )
 

--- a/rlinf/workers/env/env_worker.py
+++ b/rlinf/workers/env/env_worker.py
@@ -39,6 +39,13 @@ from rlinf.envs.action_utils import prepare_actions
 from rlinf.envs.utils import get_env_attr
 from rlinf.envs.wrappers import RecordVideo
 from rlinf.scheduler import Channel, Cluster, CommMapper, Worker
+from rlinf.utils.backbone_cache import (
+    ROLLOUT_BACKBONE_SAMPLE_IDS_KEY,
+    ROLLOUT_BACKBONE_TRANSPORT_KEY,
+    is_rollout_backbone_ipc_transport,
+    rollout_backbone_channel_key,
+    rollout_backbone_producer_rank,
+)
 from rlinf.utils.data_iter_utils import split_list
 from rlinf.utils.distributed import masked_stats, normalize_from_stats
 from rlinf.utils.metric_utils import compute_split_num
@@ -105,6 +112,9 @@ class EnvWorker(Worker):
         self.model_cfg = (
             self.cfg.rollout.model if self.only_eval else self.cfg.actor.model
         )
+        self._pinned_feature_ipc_enabled = is_rollout_backbone_ipc_transport(
+            self.model_cfg.get(ROLLOUT_BACKBONE_TRANSPORT_KEY)
+        )
         train_env_cfg = self.cfg.env.get("train", None)
         eval_env_cfg = self.cfg.env.get("eval", None)
         self.enable_train = not self.only_eval and train_env_cfg is not None
@@ -160,6 +170,10 @@ class EnvWorker(Worker):
         self.actor_split_num = (
             1 if not self.enable_train else self.get_actor_split_num()
         )
+        if self._pinned_feature_ipc_enabled and self.actor_split_num != 1:
+            raise ValueError(
+                "pinned rollout backbone transport currently requires actor_split_num=1"
+            )
         if self.use_training_pipeline and self.enable_train:
             self._init_pipeline_params()
 
@@ -990,7 +1004,22 @@ class EnvWorker(Worker):
         )
         trajectory_builder.clear()
         for trajectory in trajectories:
-            channel.put(trajectory, async_op=True)
+            if self._pinned_feature_ipc_enabled:
+                sample_ids = trajectory.forward_inputs.get(
+                    ROLLOUT_BACKBONE_SAMPLE_IDS_KEY
+                )
+                if sample_ids is None:
+                    raise RuntimeError(
+                        "pinned backbone trajectory is missing sample IDs"
+                    )
+                actor_rank = rollout_backbone_producer_rank(sample_ids)
+                channel.put(
+                    trajectory,
+                    key=rollout_backbone_channel_key(actor_rank),
+                    async_op=True,
+                )
+            else:
+                channel.put(trajectory, async_op=True)
         del trajectories
         gc.collect()
 

--- a/rlinf/workers/rollout/hf/async_huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/async_huggingface_worker.py
@@ -23,6 +23,11 @@ from rlinf.workers.rollout.hf.huggingface_worker import MultiStepRolloutWorker
 class AsyncMultiStepRolloutWorker(MultiStepRolloutWorker):
     def __init__(self, cfg: DictConfig):
         super().__init__(cfg)
+        if self._pinned_feature_ipc_enabled:
+            raise ValueError(
+                "pinned rollout backbone transport only supports the synchronous "
+                "embodied runner"
+            )
         self._generate_task: asyncio.Task = None
         self.staleness_threshold = cfg.algorithm.get("staleness_threshold", None)
         # set the decoupled rollout worker sync weight time
@@ -181,7 +186,7 @@ class AsyncMultiStepRolloutWorker(MultiStepRolloutWorker):
                 rlt_switch_flags=env_output.get("rlt_switch_flags", None),
                 intervene_requested=env_output.get("intervene_flags", None),
             )
-            policy_output = self._build_policy_output(
+            policy_output = await self._build_policy_output_with_transport(
                 actions,
                 result,
                 final_obs=env_output.get("final_obs", None),

--- a/rlinf/workers/rollout/hf/huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/huggingface_worker.py
@@ -34,6 +34,16 @@ from rlinf.hybrid_engines.weight_syncer import WeightSyncer
 from rlinf.models import get_model
 from rlinf.models.embodiment.base_policy import BasePolicy
 from rlinf.scheduler import Channel, Cluster, Worker, split_channel_message
+from rlinf.utils.backbone_cache import (
+    ROLLOUT_BACKBONE_BORROWED_IPC_PINNED,
+    ROLLOUT_BACKBONE_FEATURE_KEY,
+    ROLLOUT_BACKBONE_MASK_KEY,
+    ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE,
+    ROLLOUT_BACKBONE_SAMPLE_IDS_KEY,
+    ROLLOUT_BACKBONE_TRANSPORT_KEY,
+    filter_rollout_backbone_transport,
+    is_rollout_backbone_ipc_transport,
+)
 from rlinf.utils.placement import HybridComponentPlacement
 
 
@@ -136,6 +146,290 @@ class MultiStepRolloutWorker(Worker):
             }
         self.rollout_queue_size = self.cfg.rollout.get("rollout_queue_size", 0)
 
+        feature_transport = self.model_cfg.get(ROLLOUT_BACKBONE_TRANSPORT_KEY)
+        if feature_transport not in (None, ROLLOUT_BACKBONE_BORROWED_IPC_PINNED):
+            raise ValueError(
+                f"unsupported rollout backbone feature transport: {feature_transport}"
+            )
+        self._pinned_feature_ipc_enabled = is_rollout_backbone_ipc_transport(
+            feature_transport
+        )
+        if (
+            self._pinned_feature_ipc_enabled
+            and SupportedModel(self.model_cfg.model_type) != SupportedModel.GR00T
+        ):
+            raise ValueError(
+                "pinned rollout backbone transport currently supports GR00T N1.5 only"
+            )
+        if self._pinned_feature_ipc_enabled and (
+            self.placement.get_world_size("rollout")
+            != self.placement.get_world_size("actor")
+        ):
+            raise ValueError(
+                "pinned rollout backbone transport currently requires equal Rollout/Actor world sizes"
+            )
+        self._pinned_feature_verify_trajectory = bool(
+            self.cfg.rollout.get("pinned_feature_verify_trajectory", False)
+        )
+        self._pinned_feature_ipc_batch_blocks = int(
+            self.cfg.rollout.get("pinned_feature_ipc_batch_blocks", 1)
+        )
+        self._pinned_feature_ipc_timeout_seconds = float(
+            self.cfg.rollout.get("pinned_feature_ipc_timeout_seconds", 300.0)
+        )
+        if self._pinned_feature_ipc_batch_blocks <= 0:
+            raise ValueError("rollout.pinned_feature_ipc_batch_blocks must be positive")
+        if self._pinned_feature_ipc_timeout_seconds <= 0:
+            raise ValueError(
+                "rollout.pinned_feature_ipc_timeout_seconds must be positive"
+            )
+        self._pinned_feature_tensors: list[torch.Tensor] = []
+        self._pinned_feature_block_sizes: list[int] = []
+        self._pinned_feature_samples = 0
+        self._pinned_feature_lease_seq = 0
+        self._pinned_feature_active_lease: str | None = None
+        self._pinned_feature_consumer_rank: int | None = None
+        self._pinned_stream_expected_blocks = 0
+        self._pinned_stream_expected_samples = 0
+        self._pinned_stream_blocks = 0
+        self._pinned_stream_expected_batches = 0
+        self._pinned_stream_batches = 0
+        self._pinned_stream_bytes = 0
+        self._pinned_stream_wait_seconds = 0.0
+
+    def _begin_pinned_feature_lease(self) -> None:
+        if not self._pinned_feature_ipc_enabled:
+            return
+        if (
+            self._pinned_feature_tensors
+            or self._pinned_feature_active_lease
+            or self._pinned_feature_consumer_rank is not None
+        ):
+            raise RuntimeError(
+                "previous pinned backbone lease was not released before rollout"
+            )
+        self._pinned_feature_block_sizes.clear()
+        self._pinned_feature_samples = 0
+        self._pinned_stream_blocks = 0
+        self._pinned_stream_batches = 0
+        self._pinned_stream_bytes = 0
+        self._pinned_stream_wait_seconds = 0.0
+        self._pinned_feature_lease_seq += 1
+        self._pinned_feature_active_lease = (
+            f"pinned-r{self._rank}-l{self._pinned_feature_lease_seq}"
+        )
+        self._pinned_feature_consumer_rank = self._rank
+        self._pinned_stream_expected_blocks = int(
+            self.cfg.env.train.rollout_epoch
+            * self.cfg.env.train.max_steps_per_rollout_epoch
+        )
+        self._pinned_stream_expected_samples = int(
+            self._pinned_stream_expected_blocks
+            * self.cfg.env.train.total_num_envs
+            // self._world_size
+        )
+        if (
+            self._pinned_stream_expected_blocks <= 0
+            or self._pinned_stream_expected_samples <= 0
+        ):
+            self._abort_pinned_feature_stream()
+            raise ValueError("pinned feature stream requires positive block counts")
+        if self._pinned_stream_expected_samples >= ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE:
+            self._abort_pinned_feature_stream()
+            raise ValueError("rollout sample count exceeds its feature ID namespace")
+        self._pinned_stream_expected_batches = (
+            self._pinned_stream_expected_blocks
+            + self._pinned_feature_ipc_batch_blocks
+            - 1
+        ) // self._pinned_feature_ipc_batch_blocks
+
+    def _abort_pinned_feature_stream(self) -> None:
+        self._pinned_feature_tensors.clear()
+        self._pinned_feature_block_sizes.clear()
+        self._pinned_feature_samples = 0
+        self._pinned_feature_active_lease = None
+        self._pinned_feature_consumer_rank = None
+        self.torch_platform.ipc_collect()
+
+    async def _retain_pinned_feature_block(
+        self, forward_inputs: dict[str, torch.Tensor]
+    ) -> None:
+        feature = forward_inputs.get(ROLLOUT_BACKBONE_FEATURE_KEY)
+        mask = forward_inputs.get(ROLLOUT_BACKBONE_MASK_KEY)
+        if feature is None or mask is None:
+            raise RuntimeError("pinned backbone IPC requires complete rollout features")
+        if feature.device.type != "cuda" or mask.device.type != "cuda":
+            raise RuntimeError("pinned backbone IPC requires producer CUDA tensors")
+        if feature.shape[0] != mask.shape[0]:
+            raise RuntimeError("pinned backbone feature/mask batch mismatch")
+
+        filter_rollout_backbone_transport(forward_inputs, reuse_enabled=True)
+        block_size = int(feature.shape[0])
+        sample_id_base = self._rank * ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE
+        sample_ids = torch.arange(
+            sample_id_base + self._pinned_feature_samples,
+            sample_id_base + self._pinned_feature_samples + block_size,
+            dtype=torch.int64,
+            device="cpu",
+        )
+        forward_inputs[ROLLOUT_BACKBONE_SAMPLE_IDS_KEY] = sample_ids
+        if not self._pinned_feature_verify_trajectory:
+            forward_inputs.pop(ROLLOUT_BACKBONE_FEATURE_KEY)
+            forward_inputs.pop(ROLLOUT_BACKBONE_MASK_KEY)
+        self._pinned_feature_tensors.extend((feature.detach(), mask.detach()))
+        self._pinned_feature_block_sizes.append(block_size)
+        self._pinned_feature_samples += block_size
+        if self._pinned_feature_ipc_enabled and (
+            len(self._pinned_feature_block_sizes)
+            >= self._pinned_feature_ipc_batch_blocks
+            or self._pinned_feature_samples == self._pinned_stream_expected_samples
+        ):
+            await self._flush_pinned_feature_batch()
+
+    async def _flush_pinned_feature_batch(self) -> None:
+        lease_id = self._pinned_feature_active_lease
+        consumer_rank = self._pinned_feature_consumer_rank
+        if lease_id is None or consumer_rank is None:
+            raise RuntimeError("pinned backbone stream is not active")
+        if not self._pinned_feature_block_sizes:
+            raise RuntimeError("pinned backbone batch is empty")
+        block_sizes = list(self._pinned_feature_block_sizes)
+        tensors = list(self._pinned_feature_tensors)
+        if len(tensors) != 2 * len(block_sizes):
+            raise RuntimeError("pinned backbone batch tensor count is invalid")
+        batch_index = self._pinned_stream_batches
+        start_block_index = self._pinned_stream_blocks
+        batch_samples = sum(block_sizes)
+        offset = self._pinned_feature_samples - batch_samples
+        byte_count = sum(tensor.numel() * tensor.element_size() for tensor in tensors)
+        metadata = {
+            "schema": 3,
+            "lease_id": lease_id,
+            "batch_index": batch_index,
+            "start_block_index": start_block_index,
+            "total_blocks": self._pinned_stream_expected_blocks,
+            "offset": offset,
+            "block_sizes": block_sizes,
+            "total_samples": self._pinned_stream_expected_samples,
+            "producer_rank": self._rank,
+            "consumer_rank": consumer_rank,
+            "model_version": int(self.version),
+            "sample_id_base": self._rank * ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE,
+            "bytes": byte_count,
+            "verify_trajectory": self._pinned_feature_verify_trajectory,
+        }
+        wait_start = time.perf_counter()
+        try:
+            self.send(
+                tensors,
+                dst_group_name=self.actor_group_name,
+                dst_rank=consumer_rank,
+                piggyback_payload=metadata,
+                borrowed_ipc=True,
+            )
+            recv_work = self.recv(
+                src_group_name=self.actor_group_name,
+                src_rank=consumer_rank,
+                async_op=True,
+            )
+            try:
+                ack = await asyncio.wait_for(
+                    recv_work.async_wait(),
+                    timeout=self._pinned_feature_ipc_timeout_seconds,
+                )
+            except asyncio.TimeoutError as error:
+                raise TimeoutError(
+                    "timed out waiting for Actor ACK for pinned backbone batch "
+                    f"{batch_index} lease {lease_id}"
+                ) from error
+            if isinstance(ack, dict) and ack.get("status") == "error":
+                raise RuntimeError(
+                    "Actor rejected pinned backbone batch "
+                    f"{batch_index}: {ack.get('error', 'unknown error')}"
+                )
+            if (
+                not isinstance(ack, dict)
+                or ack.get("schema") != 3
+                or ack.get("status") != "ok"
+                or ack.get("lease_id") != lease_id
+                or int(ack.get("batch_index", -1)) != batch_index
+                or int(ack.get("completed_blocks", -1))
+                != start_block_index + len(block_sizes)
+            ):
+                raise RuntimeError(
+                    f"pinned backbone batch ACK mismatch at batch {batch_index}: {ack}"
+                )
+        except Exception:
+            tensors.clear()
+            self._abort_pinned_feature_stream()
+            raise
+        finally:
+            self._pinned_stream_wait_seconds += time.perf_counter() - wait_start
+        self._pinned_stream_batches += 1
+        self._pinned_stream_blocks += len(block_sizes)
+        self._pinned_stream_bytes += byte_count
+        self._pinned_feature_tensors.clear()
+        self._pinned_feature_block_sizes.clear()
+        tensors.clear()
+        self.torch_platform.ipc_collect()
+        log_stride = max(1, self._pinned_stream_expected_blocks // 4)
+        if batch_index == 0 or self._pinned_stream_blocks % log_stride == 0:
+            self.log_info(
+                "PINNED_FEATURE_BATCH_RELEASE "
+                f"rank={self._rank} lease={lease_id} "
+                f"batches={self._pinned_stream_batches}/"
+                f"{self._pinned_stream_expected_batches} "
+                f"blocks={self._pinned_stream_blocks}/"
+                f"{self._pinned_stream_expected_blocks} bytes={self._pinned_stream_bytes}"
+            )
+
+    @Worker.timer("rollout/feature_stream")
+    def finish_rollout_backbone_feature_stream(self) -> dict[str, float]:
+        if not self._pinned_feature_ipc_enabled:
+            return {}
+        try:
+            if self._pinned_feature_tensors or self._pinned_feature_block_sizes:
+                raise RuntimeError("pinned backbone stream has an unflushed batch")
+            if self._pinned_stream_blocks != self._pinned_stream_expected_blocks:
+                raise RuntimeError(
+                    "pinned backbone block stream count mismatch: "
+                    f"{self._pinned_stream_blocks}/"
+                    f"{self._pinned_stream_expected_blocks}"
+                )
+            if self._pinned_stream_batches != self._pinned_stream_expected_batches:
+                raise RuntimeError(
+                    "pinned backbone batch stream count mismatch: "
+                    f"{self._pinned_stream_batches}/"
+                    f"{self._pinned_stream_expected_batches}"
+                )
+            if self._pinned_feature_samples != self._pinned_stream_expected_samples:
+                raise RuntimeError(
+                    "pinned backbone sample stream count mismatch: "
+                    f"{self._pinned_feature_samples}/"
+                    f"{self._pinned_stream_expected_samples}"
+                )
+        except Exception:
+            self._abort_pinned_feature_stream()
+            raise
+        lease_id = self._pinned_feature_active_lease
+        self.log_info(
+            "PINNED_FEATURE_STREAM_DONE "
+            f"rank={self._rank} lease={lease_id} "
+            f"batches={self._pinned_stream_batches} "
+            f"blocks={self._pinned_stream_blocks} "
+            f"samples={self._pinned_feature_samples} "
+            f"bytes={self._pinned_stream_bytes} "
+            f"wait_s={self._pinned_stream_wait_seconds:.6f}"
+        )
+        self._pinned_feature_active_lease = None
+        self._pinned_feature_consumer_rank = None
+        return {
+            "rollout/pinned_feature_bytes": float(self._pinned_stream_bytes),
+            "rollout/pinned_feature_blocks": float(self._pinned_stream_blocks),
+            "rollout/pinned_feature_batches": float(self._pinned_stream_batches),
+            "rollout/pinned_feature_wait_seconds": self._pinned_stream_wait_seconds,
+        }
+
     def init_worker(self):
         rollout_model_config = copy.deepcopy(self.model_cfg)
         with open_dict(rollout_model_config):
@@ -143,6 +437,7 @@ class MultiStepRolloutWorker(Worker):
             rollout_model_config.model_path = self.cfg.rollout.model.model_path
 
         self.hf_model: BasePolicy = get_model(rollout_model_config)
+        self.hf_model.capture_rollout_backbone_output = self._pinned_feature_ipc_enabled
 
         if self.cfg.runner.get("ckpt_path", None):
             model_dict = torch.load(self.cfg.runner.ckpt_path)
@@ -607,6 +902,29 @@ class MultiStepRolloutWorker(Worker):
             ),
         )
 
+    async def _build_policy_output_with_transport(
+        self,
+        actions: torch.Tensor,
+        result: dict[str, Any],
+        *,
+        final_obs: dict[str, Any] | None = None,
+    ) -> PolicyOutput:
+        policy_output = self._build_policy_output(
+            actions,
+            result,
+            final_obs=final_obs,
+        )
+        forward_inputs = policy_output.forward_inputs
+        if forward_inputs is not None:
+            if self._pinned_feature_ipc_enabled:
+                await self._retain_pinned_feature_block(forward_inputs)
+            else:
+                filter_rollout_backbone_transport(
+                    forward_inputs,
+                    reuse_enabled=False,
+                )
+        return policy_output
+
     def get_bootstrap_values(
         self, final_obs: dict[str, Any] | None
     ) -> torch.Tensor | None:
@@ -694,7 +1012,7 @@ class MultiStepRolloutWorker(Worker):
                     intervene_requested=env_output.get("intervene_flags", None),
                 )
 
-                policy_output = self._build_policy_output(
+                policy_output = await self._build_policy_output_with_transport(
                     actions,
                     result,
                     final_obs=env_output.get("final_obs", None),
@@ -729,7 +1047,7 @@ class MultiStepRolloutWorker(Worker):
 
             if self.enable_opd:
                 # OPD keeps this path separate to retain student action tokens for post-rollout teacher logprobs.
-                policy_output = self._build_policy_output(
+                policy_output = await self._build_policy_output_with_transport(
                     actions,
                     result,
                     final_obs=env_output.get("final_obs", None),
@@ -766,6 +1084,7 @@ class MultiStepRolloutWorker(Worker):
         input_channel: Channel,
         output_channel: Channel,
     ):
+        self._begin_pinned_feature_lease()
         if self.enable_offload:
             self.reload_model()
 

--- a/rlinf/workers/rollout/hf/huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/huggingface_worker.py
@@ -909,12 +909,9 @@ class MultiStepRolloutWorker(Worker):
         *,
         final_obs: dict[str, Any] | None = None,
     ) -> PolicyOutput:
-        policy_output = self._build_policy_output(
-            actions,
-            result,
-            final_obs=final_obs,
-        )
-        forward_inputs = policy_output.forward_inputs
+        # Retain producer CUDA tensors before PolicyOutput.__post_init__ moves
+        # its generic trajectory payload to CPU.
+        forward_inputs = result.get("forward_inputs")
         if forward_inputs is not None:
             if self._pinned_feature_ipc_enabled:
                 await self._retain_pinned_feature_block(forward_inputs)
@@ -923,7 +920,7 @@ class MultiStepRolloutWorker(Worker):
                     forward_inputs,
                     reuse_enabled=False,
                 )
-        return policy_output
+        return self._build_policy_output(actions, result, final_obs=final_obs)
 
     def get_bootstrap_values(
         self, final_obs: dict[str, Any] | None

--- a/rlinf/workers/rollout/hf/huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/huggingface_worker.py
@@ -44,6 +44,9 @@ from rlinf.utils.backbone_cache import (
     filter_rollout_backbone_transport,
     is_rollout_backbone_ipc_transport,
 )
+from rlinf.utils.pinned_feature_stream import (
+    compute_rollout_backbone_stream_counts,
+)
 from rlinf.utils.placement import HybridComponentPlacement
 
 
@@ -219,14 +222,18 @@ class MultiStepRolloutWorker(Worker):
             f"pinned-r{self._rank}-l{self._pinned_feature_lease_seq}"
         )
         self._pinned_feature_consumer_rank = self._rank
-        self._pinned_stream_expected_blocks = int(
-            self.cfg.env.train.rollout_epoch
-            * self.cfg.env.train.max_steps_per_rollout_epoch
-        )
-        self._pinned_stream_expected_samples = int(
-            self._pinned_stream_expected_blocks
-            * self.cfg.env.train.total_num_envs
-            // self._world_size
+        (
+            self._pinned_stream_expected_blocks,
+            self._pinned_stream_expected_samples,
+        ) = compute_rollout_backbone_stream_counts(
+            rollout_epochs=int(self.cfg.env.train.rollout_epoch),
+            max_steps_per_epoch=int(
+                self.cfg.env.train.max_steps_per_rollout_epoch
+            ),
+            num_action_chunks=int(self.model_cfg.num_action_chunks),
+            pipeline_stages=int(self.num_pipeline_stages),
+            total_num_envs=int(self.cfg.env.train.total_num_envs),
+            world_size=int(self._world_size),
         )
         if (
             self._pinned_stream_expected_blocks <= 0

--- a/tests/unit_tests/test_backbone_feature_cache.py
+++ b/tests/unit_tests/test_backbone_feature_cache.py
@@ -1,0 +1,180 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from torch import nn
+
+from rlinf.utils.backbone_cache import (
+    ROLLOUT_BACKBONE_FEATURE_KEY,
+    ROLLOUT_BACKBONE_INPUT_KEYS,
+    ROLLOUT_BACKBONE_MASK_KEY,
+    ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE,
+    filter_rollout_backbone_transport,
+    rollout_backbone_producer_rank,
+    validate_frozen_backbone,
+    validate_rollout_backbone_sample_ids,
+)
+from rlinf.utils.pinned_rollout_cache import PinnedRolloutBackboneCache
+
+
+def test_sample_ids_encode_one_rollout_producer():
+    base = 3 * ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE
+    sample_ids = torch.tensor([[base + 2, base], [base + 1, base + 3]])
+
+    assert rollout_backbone_producer_rank(sample_ids) == 3
+
+
+@pytest.mark.parametrize(
+    "sample_ids",
+    [
+        torch.tensor([], dtype=torch.int64),
+        torch.tensor([-1]),
+        torch.tensor([0, ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE]),
+    ],
+)
+def test_sample_ids_reject_invalid_producer_namespaces(sample_ids):
+    with pytest.raises(ValueError):
+        rollout_backbone_producer_rank(sample_ids)
+
+
+def test_sample_ids_form_complete_permuted_cache_namespace():
+    base = 2 * ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE
+    validate_rollout_backbone_sample_ids(
+        torch.tensor([base + 2, base, base + 3, base + 1]),
+        producer_rank=2,
+        total_samples=4,
+    )
+
+
+@pytest.mark.parametrize(
+    "sample_ids",
+    [
+        torch.tensor([0, 1, 2]),
+        torch.tensor([0, 1, 1, 3]),
+        torch.tensor([0, 1, 2, ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE]),
+    ],
+)
+def test_sample_ids_reject_incomplete_or_mixed_cache(sample_ids):
+    with pytest.raises(ValueError, match="do not form"):
+        validate_rollout_backbone_sample_ids(
+            sample_ids,
+            producer_rank=0,
+            total_samples=4,
+        )
+
+
+def test_frozen_eval_backbone_is_required():
+    backbone = nn.Linear(2, 2)
+    with pytest.raises(ValueError, match="trainable"):
+        validate_frozen_backbone(backbone)
+
+    backbone.requires_grad_(False)
+    with pytest.raises(ValueError, match="eval mode"):
+        validate_frozen_backbone(backbone)
+
+    backbone.eval()
+    validate_frozen_backbone(backbone)
+
+
+def _rollout_forward_inputs():
+    return {
+        **{key: torch.ones(1) for key in ROLLOUT_BACKBONE_INPUT_KEYS},
+        ROLLOUT_BACKBONE_FEATURE_KEY: torch.ones(1),
+        ROLLOUT_BACKBONE_MASK_KEY: torch.ones(1),
+    }
+
+
+def test_transport_disabled_drops_feature_and_keeps_raw_inputs():
+    forward_inputs = _rollout_forward_inputs()
+    assert not filter_rollout_backbone_transport(forward_inputs, reuse_enabled=False)
+    assert ROLLOUT_BACKBONE_FEATURE_KEY not in forward_inputs
+    assert ROLLOUT_BACKBONE_MASK_KEY not in forward_inputs
+    assert all(key in forward_inputs for key in ROLLOUT_BACKBONE_INPUT_KEYS)
+
+
+def test_complete_feature_drops_raw_backbone_inputs():
+    forward_inputs = _rollout_forward_inputs()
+    assert filter_rollout_backbone_transport(
+        forward_inputs,
+        reuse_enabled=True,
+    )
+    assert ROLLOUT_BACKBONE_FEATURE_KEY in forward_inputs
+    assert ROLLOUT_BACKBONE_MASK_KEY in forward_inputs
+    assert all(key not in forward_inputs for key in ROLLOUT_BACKBONE_INPUT_KEYS)
+
+
+def test_incomplete_feature_keeps_raw_inputs_for_fallback():
+    forward_inputs = _rollout_forward_inputs()
+    forward_inputs.pop(ROLLOUT_BACKBONE_MASK_KEY)
+    assert not filter_rollout_backbone_transport(
+        forward_inputs,
+        reuse_enabled=True,
+    )
+    assert ROLLOUT_BACKBONE_FEATURE_KEY not in forward_inputs
+    assert ROLLOUT_BACKBONE_MASK_KEY not in forward_inputs
+    assert all(key in forward_inputs for key in ROLLOUT_BACKBONE_INPUT_KEYS)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_streamed_pinned_cache_round_trip_and_stats():
+    device = torch.device("cuda", torch.cuda.current_device())
+    features = torch.arange(5 * 3 * 2, dtype=torch.float32, device=device).reshape(
+        5, 3, 2
+    )
+    masks = torch.arange(5 * 3, dtype=torch.int64, device=device).reshape(5, 3)
+    cache = PinnedRolloutBackboneCache(
+        total_samples=5,
+        feature_example=features[:2],
+        mask_example=masks[:2],
+        device=device,
+    )
+
+    cache.store_block(offset=0, feature=features[:2], mask=masks[:2])
+    cache.store_blocks(
+        offset=2,
+        blocks=[
+            (features[2:4], masks[2:4]),
+            (features[4:], masks[4:]),
+        ],
+    )
+    cache.finalize()
+
+    first_ids = torch.tensor([4, 0, 2], dtype=torch.int64)
+    second_ids = torch.tensor([1, 3], dtype=torch.int64)
+    first = cache.load(first_ids)
+    second = cache.load(second_ids)
+    torch.testing.assert_close(
+        first["backbone_features"], features.index_select(0, first_ids.to(device))
+    )
+    torch.testing.assert_close(
+        first["backbone_attention_mask"], masks.index_select(0, first_ids.to(device))
+    )
+    torch.testing.assert_close(
+        second["backbone_features"], features.index_select(0, second_ids.to(device))
+    )
+    torch.testing.assert_close(
+        second["backbone_attention_mask"], masks.index_select(0, second_ids.to(device))
+    )
+
+    stats = cache.stats()
+    assert stats.samples == 5
+    assert stats.stored_samples == 5
+    assert stats.loads == 2
+    assert stats.loaded_samples == 5
+    assert stats.staging_bytes > 0
+
+    cache.clear()
+    with pytest.raises(RuntimeError, match="cleared"):
+        cache.load(torch.tensor([0]))

--- a/tests/unit_tests/test_borrowed_ipc_validation.py
+++ b/tests/unit_tests/test_borrowed_ipc_validation.py
@@ -1,0 +1,123 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+
+from rlinf.scheduler.collective.collective_group import CollectiveGroup
+from rlinf.scheduler.worker.worker import Worker
+
+
+def _bare_group():
+    group = object.__new__(CollectiveGroup)
+    group._logger = SimpleNamespace(debug=lambda *args, **kwargs: None)
+    group._peer_rank = 0
+    group._group_info = SimpleNamespace(group_name="test")
+    return group
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        torch.ones(1),
+        [torch.ones(1)],
+        [],
+    ],
+)
+def test_borrowed_ipc_rejects_non_cuda_payload_before_send(payload):
+    group = _bare_group()
+
+    with pytest.raises(ValueError, match="CUDA tensor payloads"):
+        group.send(payload, borrowed_ipc=True)
+
+
+def test_borrowed_ipc_rejects_unsupported_container_before_send():
+    group = _bare_group()
+
+    with pytest.raises(TypeError, match="tensor or tensor list"):
+        group.send({"value": torch.ones(1)}, borrowed_ipc=True)
+
+
+def test_borrowed_mode_mismatch_drains_ipc_payload_before_error(monkeypatch):
+    group = _bare_group()
+    received_modes = []
+
+    def recv(self, tensor, device, comm_id):
+        del self, device, comm_id
+        if tensor.dtype == torch.long:
+            tensor.fill_(1)
+
+    def recv_ipc(self, comm_id, *, borrowed=False):
+        del self, comm_id
+        received_modes.append(borrowed)
+        return [torch.ones(1)]
+
+    group._recv = MethodType(recv, group)
+    group._tensor_to_object = MethodType(
+        lambda self, tensor, size: {
+            "meta": [(torch.Size([1]), torch.float32)],
+            "pb": None,
+            "cpu_tensor_mask": [False],
+            "borrowed_ipc": True,
+        },
+        group,
+    )
+    group._check_same_device_with_peer = MethodType(lambda self: 1, group)
+    group._recv_tensor_list_via_ipc = MethodType(recv_ipc, group)
+
+    class Platform:
+        collects = 0
+
+        @staticmethod
+        def ipc_collect():
+            Platform.collects += 1
+
+    monkeypatch.setattr(Worker, "torch_platform", Platform)
+
+    with pytest.raises(RuntimeError, match="enabled explicitly on both"):
+        group._recv_tensor_list(comm_id=0, borrowed_ipc=False)
+
+    assert received_modes == [True]
+    assert Platform.collects == 1
+
+
+def test_borrowed_ipc_receiver_rejects_non_colocated_sender_before_payload():
+    group = _bare_group()
+    recv_calls = []
+
+    def recv(self, tensor, device, comm_id):
+        del self, comm_id
+        recv_calls.append(device)
+        if tensor.dtype == torch.long:
+            tensor.fill_(1)
+
+    group._recv = MethodType(recv, group)
+    group._tensor_to_object = MethodType(
+        lambda self, tensor, size: {
+            "meta": [(torch.Size([1]), torch.float32)],
+            "pb": None,
+            "cpu_tensor_mask": [False],
+            "borrowed_ipc": True,
+        },
+        group,
+    )
+    group._check_same_device_with_peer = MethodType(lambda self: -1, group)
+
+    with pytest.raises(RuntimeError, match="same CUDA device"):
+        group._recv_tensor_list(comm_id=0, borrowed_ipc=True)
+
+    # Only metadata size and metadata were consumed; no tensor payload receive ran.
+    assert recv_calls == [CollectiveGroup.CPU, CollectiveGroup.CPU]

--- a/tests/unit_tests/test_gr00t_backbone_cache_interface.py
+++ b/tests/unit_tests/test_gr00t_backbone_cache_interface.py
@@ -1,0 +1,119 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+def test_gr00t_fresh_and_precomputed_backbone_outputs_match():
+    pytest.importorskip("gr00t")
+    from transformers.feature_extraction_utils import BatchFeature
+
+    from rlinf.models.embodiment.gr00t.gr00t_n1d5.gr00t_action_model import (
+        GR00T_N1_5_ForRLActionPrediction,
+    )
+
+    class FakeBackbone:
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, inputs):
+            self.calls += 1
+            return BatchFeature(data={"backbone_features": inputs["features"] * 2})
+
+    class FakeActionHead:
+        action_chunk = 1
+        rl_config = SimpleNamespace(joint_logprob=False)
+        dtype = torch.float32
+
+        @staticmethod
+        def prepare_input(batch):
+            return BatchFeature(data=batch)
+
+        def __call__(
+            self,
+            *,
+            backbone_output,
+            action_input,
+            chains,
+            denoise_inds,
+            compute_values,
+        ):
+            del action_input, chains, denoise_inds, compute_values
+            features = backbone_output["backbone_features"]
+            log_probs = features[:, None, None, :2]
+            values = features.mean(dim=-1, keepdim=True)
+            return log_probs, values
+
+    class FakePolicy:
+        valid_action_dim = 2
+        device = torch.device("cpu")
+        _prepare_action_head_input = (
+            GR00T_N1_5_ForRLActionPrediction._prepare_action_head_input
+        )
+
+        def __init__(self):
+            self.backbone = FakeBackbone()
+            self.action_head = FakeActionHead()
+
+        @staticmethod
+        def prepare_input(normalized_input):
+            return (
+                BatchFeature(data={"features": normalized_input["state"]}),
+                BatchFeature(data={}),
+            )
+
+    batch_size = 2
+    forward_inputs = {
+        "state": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        "state_mask": torch.ones(batch_size, 2),
+        "eagle_input_ids": torch.ones(batch_size, 1, dtype=torch.int64),
+        "eagle_attention_mask": torch.ones(batch_size, 1, dtype=torch.int64),
+        "eagle_pixel_values": torch.ones(batch_size, 1, 1),
+        "eagle_image_sizes": torch.ones(batch_size, 1, 1),
+        "embodiment_id": torch.zeros(batch_size, dtype=torch.int64),
+        "chains": torch.zeros(batch_size, 1),
+        "denoise_inds": torch.zeros(batch_size, 1, dtype=torch.int64),
+    }
+    prev_logprobs = torch.zeros(batch_size, 1, 1, 2)
+
+    fresh = GR00T_N1_5_ForRLActionPrediction.default_forward(
+        FakePolicy(),
+        forward_inputs=forward_inputs,
+        prev_logprobs=prev_logprobs,
+    )
+    raw_backbone = {
+        "backbone_features": (forward_inputs["state"] * 2).detach(),
+    }
+
+    policy = FakePolicy()
+    feature_only_inputs = {
+        key: value
+        for key, value in forward_inputs.items()
+        if not key.startswith("eagle_")
+    }
+    cached = GR00T_N1_5_ForRLActionPrediction.default_forward(
+        policy,
+        forward_inputs=feature_only_inputs,
+        prev_logprobs=prev_logprobs,
+        precomputed_backbone=raw_backbone,
+    )
+
+    assert policy.backbone.calls == 0
+    assert all(not key.startswith("eagle_") for key in feature_only_inputs)
+    assert not raw_backbone["backbone_features"].requires_grad
+    for key in ("logprobs", "prev_logprobs", "values"):
+        torch.testing.assert_close(cached[key], fresh[key])

--- a/tests/unit_tests/test_intra_gpu_comm.py
+++ b/tests/unit_tests/test_intra_gpu_comm.py
@@ -99,6 +99,27 @@ class SenderWorker(Worker):
                 self.async_wait(work)
         return True
 
+    def send_borrowed_tensor_list(self, group_name):
+        """Send a CUDA tensor list while retaining producer ownership."""
+        self._borrowed_tensors = [torch.arange(4, device=get_device()).reshape(2, 2)]
+        self.send(
+            self._borrowed_tensors,
+            group_name,
+            dst_rank=self._rank,
+            piggyback_payload={"lease_id": "test-lease"},
+            borrowed_ipc=True,
+        )
+        return True
+
+    def read_borrowed_tensor(self):
+        Worker.torch_platform.current_stream().synchronize()
+        return self._borrowed_tensors[0].cpu()
+
+    def release_borrowed_tensor(self):
+        self._borrowed_tensors.clear()
+        Worker.torch_platform.ipc_collect()
+        return True
+
     def send_mixed_gpu_tensor_list(self, async_op, group_name):
         """Sends a list of tensors from different accelerators."""
         num_gpus = accelerator_device_count()
@@ -146,6 +167,24 @@ class ReceiverWorker(Worker):
             else:
                 self.async_wait(work)
         return tensor
+
+    def recv_borrowed_tensor_list(self, group_name):
+        """Receive producer-owned CUDA views and mutate through the IPC alias."""
+        tensors, metadata = self.recv(
+            group_name,
+            src_rank=self._rank,
+            borrowed_ipc=True,
+        )
+        assert metadata == {"lease_id": "test-lease"}
+        tensors[0].add_(10)
+        Worker.torch_platform.current_stream().synchronize()
+        self._borrowed_tensors = tensors
+        return tensors[0].cpu()
+
+    def release_borrowed_tensor(self):
+        self._borrowed_tensors.clear()
+        Worker.torch_platform.ipc_collect()
+        return True
 
     def recv_tensor_list(self, async_op, group_name):
         """Receives a list of tensors using recv."""
@@ -250,6 +289,21 @@ class TestSameDeviceCommunication:
         result = result[0]
         expected = torch.ones(3, 3) * 0  # Sender rank is 0
         assert torch.equal(result.cpu(), expected)
+
+    def test_borrowed_tensor_list_aliases_producer_storage(
+        self, single_shared_gpu_groups
+    ):
+        sender_group, receiver_group = single_shared_gpu_groups
+        sender_handle = sender_group.send_borrowed_tensor_list(RECEIVER_GROUP_NAME)
+        receiver_handle = receiver_group.recv_borrowed_tensor_list(SENDER_GROUP_NAME)
+        sender_handle.wait()
+        received = receiver_handle.wait()[0]
+        producer = sender_group.read_borrowed_tensor().wait()[0]
+        expected = torch.arange(4).reshape(2, 2) + 10
+        assert torch.equal(received, expected)
+        assert torch.equal(producer, expected)
+        receiver_group.release_borrowed_tensor().wait()
+        sender_group.release_borrowed_tensor().wait()
 
     @pytest.mark.parametrize("async_op", [0, 1, 2], ids=["sync", "async", "asyncio"])
     def test_tensor_list_on_single_shared_gpu(self, single_shared_gpu_groups, async_op):

--- a/tests/unit_tests/test_pinned_feature_actor.py
+++ b/tests/unit_tests/test_pinned_feature_actor.py
@@ -1,0 +1,56 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from rlinf.utils.backbone_cache import ROLLOUT_BACKBONE_SAMPLE_IDS_KEY
+from rlinf.workers.actor.fsdp_actor_worker import EmbodiedFSDPActor
+
+
+def test_actor_training_exception_clears_cache_and_sample_ids():
+    class Cache:
+        cleared = False
+
+        def clear(self):
+            self.cleared = True
+
+    class Actor:
+        _clear_pinned_rollout_backbone_cache = (
+            EmbodiedFSDPActor._clear_pinned_rollout_backbone_cache
+        )
+
+        def __init__(self):
+            self._pinned_rollout_backbone_cache = Cache()
+            self._pinned_backbone_metadata = {"lease_id": "lease-1"}
+            self.rollout_batch = {
+                "forward_inputs": {
+                    ROLLOUT_BACKBONE_SAMPLE_IDS_KEY: torch.tensor([0, 1])
+                }
+            }
+
+        @staticmethod
+        def _run_training_impl():
+            raise RuntimeError("injected training failure")
+
+    actor = Actor()
+    cache = actor._pinned_rollout_backbone_cache
+
+    with pytest.raises(RuntimeError, match="injected training failure"):
+        EmbodiedFSDPActor.run_training(actor)
+
+    assert cache.cleared
+    assert actor._pinned_rollout_backbone_cache is None
+    assert actor._pinned_backbone_metadata is None
+    assert ROLLOUT_BACKBONE_SAMPLE_IDS_KEY not in actor.rollout_batch["forward_inputs"]

--- a/tests/unit_tests/test_pinned_feature_sender.py
+++ b/tests/unit_tests/test_pinned_feature_sender.py
@@ -1,0 +1,280 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from rlinf.data.schema.embodied_types import PolicyOutput
+from rlinf.utils.backbone_cache import (
+    ROLLOUT_BACKBONE_FEATURE_KEY,
+    ROLLOUT_BACKBONE_MASK_KEY,
+)
+from rlinf.workers.rollout.hf.async_huggingface_worker import (
+    AsyncMultiStepRolloutWorker,
+)
+from rlinf.workers.rollout.hf.huggingface_worker import MultiStepRolloutWorker
+
+
+class _ImmediateWork:
+    def __init__(self, value) -> None:
+        self.value = value
+
+    async def async_wait(self):
+        return self.value
+
+
+class _NeverWork:
+    async def async_wait(self):
+        await asyncio.Event().wait()
+
+
+class _FakePlatform:
+    def __init__(self) -> None:
+        self.collects = 0
+
+    def ipc_collect(self) -> None:
+        self.collects += 1
+
+
+class _FakeSender:
+    _begin_pinned_feature_lease = MultiStepRolloutWorker._begin_pinned_feature_lease
+    _abort_pinned_feature_stream = MultiStepRolloutWorker._abort_pinned_feature_stream
+
+    def __init__(self, ack) -> None:
+        self._rank = 2
+        self._world_size = 4
+        self.version = 7
+        self.cfg = SimpleNamespace(
+            env=SimpleNamespace(
+                train=SimpleNamespace(
+                    rollout_epoch=1,
+                    max_steps_per_rollout_epoch=1,
+                    total_num_envs=8,
+                )
+            )
+        )
+        self.actor_group_name = "actor"
+        self.torch_platform = _FakePlatform()
+        self.sent = []
+        self.logs = []
+        self.ack = ack
+        self._pinned_feature_verify_trajectory = False
+        self._pinned_feature_ipc_enabled = True
+        self._pinned_feature_ipc_batch_blocks = 1
+        self._pinned_feature_ipc_timeout_seconds = 0.05
+        self._pinned_feature_tensors = [
+            torch.ones(2, 3),
+            torch.ones(2, 3, dtype=torch.bool),
+        ]
+        self._pinned_feature_block_sizes = [2]
+        self._pinned_feature_samples = 2
+        self._pinned_feature_active_lease = "lease-1"
+        self._pinned_feature_lease_seq = 1
+        self._pinned_feature_consumer_rank = 2
+        self._pinned_stream_expected_blocks = 1
+        self._pinned_stream_expected_samples = 2
+        self._pinned_stream_expected_batches = 1
+        self._pinned_stream_batches = 0
+        self._pinned_stream_blocks = 0
+        self._pinned_stream_bytes = 0
+        self._pinned_stream_wait_seconds = 0.0
+
+    def send(self, tensors, **kwargs) -> None:
+        self.sent.append((tensors, kwargs))
+
+    def recv(self, **kwargs):
+        assert kwargs["async_op"] is True
+        if self.ack is None:
+            return _NeverWork()
+        return _ImmediateWork(self.ack)
+
+    def log_info(self, message) -> None:
+        self.logs.append(message)
+
+
+class _FakePolicyOutputBuilder:
+    _build_policy_output = MultiStepRolloutWorker._build_policy_output
+    _build_policy_output_with_transport = (
+        MultiStepRolloutWorker._build_policy_output_with_transport
+    )
+
+    def __init__(self, *, pinned_feature_ipc_enabled: bool) -> None:
+        self.collect_prev_infos = True
+        self.enable_dagger = False
+        self.version = 3
+        self._pinned_feature_ipc_enabled = pinned_feature_ipc_enabled
+        self.retained_forward_inputs = None
+
+    @staticmethod
+    def get_bootstrap_values(_final_obs):
+        return None
+
+    async def _retain_pinned_feature_block(self, forward_inputs) -> None:
+        self.retained_forward_inputs = forward_inputs
+
+
+def _flush(sender):
+    return asyncio.run(MultiStepRolloutWorker._flush_pinned_feature_batch(sender))
+
+
+def _ok_ack():
+    return {
+        "schema": 3,
+        "status": "ok",
+        "lease_id": "lease-1",
+        "batch_index": 0,
+        "completed_blocks": 1,
+    }
+
+
+def _policy_result():
+    return {
+        "prev_logprobs": torch.zeros(2, 1),
+        "prev_values": torch.ones(2, 1),
+        "forward_inputs": {
+            ROLLOUT_BACKBONE_FEATURE_KEY: torch.ones(2, 3),
+            ROLLOUT_BACKBONE_MASK_KEY: torch.ones(2, 3, dtype=torch.bool),
+        },
+    }
+
+
+def test_policy_output_builder_preserves_synchronous_api():
+    builder = _FakePolicyOutputBuilder(pinned_feature_ipc_enabled=False)
+
+    output = builder._build_policy_output(torch.zeros(2, 1), _policy_result())
+
+    assert isinstance(output, PolicyOutput)
+    assert output.versions.tolist() == [[3.0], [3.0]]
+
+
+def test_policy_output_transport_wrapper_awaits_pinned_retention():
+    builder = _FakePolicyOutputBuilder(pinned_feature_ipc_enabled=True)
+
+    output = asyncio.run(
+        builder._build_policy_output_with_transport(
+            torch.zeros(2, 1),
+            _policy_result(),
+        )
+    )
+
+    assert isinstance(output, PolicyOutput)
+    assert builder.retained_forward_inputs is output.forward_inputs
+
+
+def test_async_rollout_rejects_pinned_feature_transport(monkeypatch):
+    def _fake_base_init(self, _cfg):
+        self._pinned_feature_ipc_enabled = True
+
+    monkeypatch.setattr(MultiStepRolloutWorker, "__init__", _fake_base_init)
+
+    with pytest.raises(ValueError, match="only supports the synchronous"):
+        AsyncMultiStepRolloutWorker(None)
+
+
+def test_sender_releases_batch_only_after_valid_ack():
+    sender = _FakeSender(_ok_ack())
+
+    _flush(sender)
+
+    assert sender._pinned_stream_batches == 1
+    assert sender._pinned_stream_blocks == 1
+    assert sender._pinned_feature_tensors == []
+    assert sender._pinned_feature_block_sizes == []
+    assert sender._pinned_feature_active_lease == "lease-1"
+    assert sender.torch_platform.collects == 1
+
+
+def test_sender_aborts_lease_when_actor_nacks_batch():
+    ack = _ok_ack()
+    ack.update(status="error", error="RuntimeError: wrong model version")
+    sender = _FakeSender(ack)
+
+    with pytest.raises(RuntimeError, match="wrong model version"):
+        _flush(sender)
+
+    assert sender._pinned_feature_tensors == []
+    assert sender._pinned_feature_block_sizes == []
+    assert sender._pinned_feature_active_lease is None
+    assert sender._pinned_feature_consumer_rank is None
+    assert sender.torch_platform.collects == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema", 2),
+        ("lease_id", "other-lease"),
+        ("batch_index", 1),
+        ("completed_blocks", 0),
+    ],
+)
+def test_sender_aborts_lease_on_malformed_ack(field, value):
+    ack = _ok_ack()
+    ack[field] = value
+    sender = _FakeSender(ack)
+
+    with pytest.raises(RuntimeError, match="ACK mismatch"):
+        _flush(sender)
+
+    assert sender._pinned_feature_tensors == []
+    assert sender._pinned_feature_block_sizes == []
+    assert sender._pinned_feature_active_lease is None
+    assert sender._pinned_feature_consumer_rank is None
+    assert sender.torch_platform.collects == 1
+
+
+def test_sender_times_out_and_aborts_lease_when_actor_does_not_ack():
+    sender = _FakeSender(None)
+
+    with pytest.raises(TimeoutError, match="lease lease-1"):
+        _flush(sender)
+
+    assert sender._pinned_feature_tensors == []
+    assert sender._pinned_feature_block_sizes == []
+    assert sender._pinned_feature_active_lease is None
+    assert sender._pinned_feature_consumer_rank is None
+    assert sender.torch_platform.collects == 1
+
+
+def test_sender_can_start_a_new_lease_after_nack_cleanup():
+    rejected = _ok_ack()
+    rejected.update(status="error", error="injected failure")
+    sender = _FakeSender(rejected)
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        _flush(sender)
+
+    sender._begin_pinned_feature_lease()
+    assert sender._pinned_feature_active_lease == "pinned-r2-l2"
+    assert sender._pinned_stream_expected_blocks == 1
+    assert sender._pinned_stream_expected_samples == 2
+
+    sender._pinned_feature_tensors = [
+        torch.ones(2, 3),
+        torch.ones(2, 3, dtype=torch.bool),
+    ]
+    sender._pinned_feature_block_sizes = [2]
+    sender._pinned_feature_samples = 2
+    sender.ack = {
+        **_ok_ack(),
+        "lease_id": "pinned-r2-l2",
+    }
+    _flush(sender)
+
+    assert sender._pinned_stream_batches == 1
+    assert sender._pinned_stream_blocks == 1
+    assert sender._pinned_feature_active_lease == "pinned-r2-l2"

--- a/tests/unit_tests/test_pinned_feature_sender.py
+++ b/tests/unit_tests/test_pinned_feature_sender.py
@@ -107,7 +107,6 @@ class _FakeSender:
 
 
 class _FakePolicyOutputBuilder:
-    _build_policy_output = MultiStepRolloutWorker._build_policy_output
     _build_policy_output_with_transport = (
         MultiStepRolloutWorker._build_policy_output_with_transport
     )
@@ -118,12 +117,23 @@ class _FakePolicyOutputBuilder:
         self.version = 3
         self._pinned_feature_ipc_enabled = pinned_feature_ipc_enabled
         self.retained_forward_inputs = None
+        self.transport_events = []
+
+    def _build_policy_output(self, actions, result, *, final_obs=None):
+        self.transport_events.append("build")
+        return MultiStepRolloutWorker._build_policy_output(
+            self,
+            actions,
+            result,
+            final_obs=final_obs,
+        )
 
     @staticmethod
     def get_bootstrap_values(_final_obs):
         return None
 
     async def _retain_pinned_feature_block(self, forward_inputs) -> None:
+        self.transport_events.append("retain")
         self.retained_forward_inputs = forward_inputs
 
 
@@ -173,6 +183,7 @@ def test_policy_output_transport_wrapper_awaits_pinned_retention():
 
     assert isinstance(output, PolicyOutput)
     assert builder.retained_forward_inputs is output.forward_inputs
+    assert builder.transport_events == ["retain", "build"]
 
 
 def test_async_rollout_rejects_pinned_feature_transport(monkeypatch):

--- a/tests/unit_tests/test_pinned_feature_sender.py
+++ b/tests/unit_tests/test_pinned_feature_sender.py
@@ -68,6 +68,8 @@ class _FakeSender:
             )
         )
         self.actor_group_name = "actor"
+        self.model_cfg = SimpleNamespace(num_action_chunks=1)
+        self.num_pipeline_stages = 1
         self.torch_platform = _FakePlatform()
         self.sent = []
         self.logs = []

--- a/tests/unit_tests/test_pinned_feature_stream.py
+++ b/tests/unit_tests/test_pinned_feature_stream.py
@@ -1,0 +1,339 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from rlinf.utils import pinned_feature_stream
+from rlinf.utils.backbone_cache import ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE
+
+
+@dataclass(frozen=True)
+class _Stats:
+    bytes: int
+    samples: int
+    allocation_seconds: float = 0.01
+    d2h_seconds: float = 0.02
+
+
+class _FakeCache:
+    instances = []
+
+    def __init__(self, *, total_samples, feature_example, mask_example, device) -> None:
+        del feature_example, mask_example, device
+        self.samples = total_samples
+        self.stored = 0
+        self.byte_count = 0
+        self.finalized = False
+        self.cleared = False
+        self.__class__.instances.append(self)
+
+    def store_blocks(self, *, offset, blocks) -> None:
+        assert offset == self.stored
+        for feature, mask in blocks:
+            self.stored += feature.shape[0]
+            self.byte_count += sum(
+                tensor.numel() * tensor.element_size() for tensor in (feature, mask)
+            )
+
+    def finalize(self) -> None:
+        if self.stored != self.samples:
+            raise RuntimeError("incomplete fake cache")
+        self.finalized = True
+
+    def stats(self) -> _Stats:
+        return _Stats(bytes=self.byte_count, samples=self.samples)
+
+    def clear(self) -> None:
+        self.cleared = True
+
+
+class _ImmediateWork:
+    def __init__(self, value) -> None:
+        self.value = value
+
+    async def async_wait(self):
+        return self.value
+
+
+class _NeverWork:
+    async def async_wait(self):
+        await asyncio.Event().wait()
+
+
+class _FakePlatform:
+    def __init__(self) -> None:
+        self.collects = 0
+
+    @staticmethod
+    def current_device():
+        return 0
+
+    def ipc_collect(self) -> None:
+        self.collects += 1
+
+
+class _FakeWorker:
+    def __init__(self, received) -> None:
+        self.received = list(received)
+        self.sent = []
+        self.logs = []
+        self.torch_platform = _FakePlatform()
+
+    def recv(self, **kwargs):
+        assert kwargs["async_op"] is True
+        assert kwargs["borrowed_ipc"] is True
+        return _ImmediateWork(self.received.pop(0))
+
+    def send(self, payload, **kwargs) -> None:
+        self.sent.append((payload, kwargs))
+
+    def log_info(self, message) -> None:
+        self.logs.append(message)
+
+
+class _TimeoutWorker(_FakeWorker):
+    def __init__(self) -> None:
+        super().__init__([])
+
+    def recv(self, **kwargs):
+        assert kwargs["async_op"] is True
+        assert kwargs["borrowed_ipc"] is True
+        return _NeverWork()
+
+
+def _block(size: int):
+    return (
+        torch.arange(size * 3, dtype=torch.float32).reshape(size, 3),
+        torch.ones(size, 3, dtype=torch.bool),
+    )
+
+
+def _batch(
+    *,
+    batch_index: int,
+    start_block_index: int,
+    offset: int,
+    block_sizes: list[int],
+    total_blocks: int = 3,
+    total_samples: int = 6,
+    source_rank: int = 2,
+    consumer_rank: int = 5,
+    model_version: int = 7,
+    lease_id: str = "lease-1",
+):
+    blocks = [_block(size) for size in block_sizes]
+    tensors = [tensor for block in blocks for tensor in block]
+    byte_count = sum(tensor.numel() * tensor.element_size() for tensor in tensors)
+    metadata = {
+        "schema": 3,
+        "lease_id": lease_id,
+        "batch_index": batch_index,
+        "start_block_index": start_block_index,
+        "total_blocks": total_blocks,
+        "total_samples": total_samples,
+        "producer_rank": source_rank,
+        "consumer_rank": consumer_rank,
+        "model_version": model_version,
+        "sample_id_base": source_rank * ROLLOUT_BACKBONE_SAMPLE_ID_STRIDE,
+        "offset": offset,
+        "block_sizes": block_sizes,
+        "bytes": byte_count,
+    }
+    return tensors, metadata
+
+
+def _receive(
+    worker,
+    *,
+    expected_blocks=3,
+    expected_samples=6,
+    blocks_per_batch=2,
+    timeout_seconds=1.0,
+):
+    return asyncio.run(
+        pinned_feature_stream.receive_pinned_rollout_backbone_stream(
+            worker,
+            source_rank=2,
+            consumer_rank=5,
+            model_version=7,
+            expected_blocks=expected_blocks,
+            expected_samples=expected_samples,
+            blocks_per_batch=blocks_per_batch,
+            rollout_group_name="rollout",
+            timeout_seconds=timeout_seconds,
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def fake_cache(monkeypatch):
+    _FakeCache.instances.clear()
+    monkeypatch.setattr(pinned_feature_stream, "PinnedRolloutBackboneCache", _FakeCache)
+
+
+def test_receive_stream_validates_counts_and_acks_each_batch():
+    worker = _FakeWorker(
+        [
+            _batch(
+                batch_index=0,
+                start_block_index=0,
+                offset=0,
+                block_sizes=[2, 2],
+            ),
+            _batch(
+                batch_index=1,
+                start_block_index=2,
+                offset=4,
+                block_sizes=[2],
+            ),
+        ]
+    )
+
+    cache, metadata, metrics = _receive(worker)
+
+    assert cache.finalized
+    assert metadata["lease_id"] == "lease-1"
+    assert [entry[0]["batch_index"] for entry in worker.sent] == [0, 1]
+    assert [entry[0]["completed_blocks"] for entry in worker.sent] == [2, 3]
+    assert all(entry[0]["status"] == "ok" for entry in worker.sent)
+    assert worker.torch_platform.collects == 2
+    assert metrics["actor/pinned_feature_samples"] == 6.0
+    assert metrics["actor/pinned_feature_batches"] == 2.0
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("schema", 2, "unsupported pinned backbone metadata"),
+        ("batch_index", 1, "batches arrived out of order"),
+        ("start_block_index", 1, "block range is invalid"),
+        ("total_blocks", 4, "total block count changed"),
+        ("total_samples", 7, "total sample count changed"),
+        ("producer_rank", 3, "producer rank does not match route"),
+        ("consumer_rank", 4, "consumer rank does not match Actor"),
+        ("model_version", 8, "model version does not match Actor"),
+        ("sample_id_base", 0, "sample-ID namespace is invalid"),
+        ("offset", 1, "sample offset is invalid"),
+        ("block_sizes", [2], "block count mismatch"),
+        ("bytes", 1, "byte count mismatch"),
+    ],
+)
+def test_receive_stream_rejects_malformed_first_batch(field, value, message):
+    tensors, metadata = _batch(
+        batch_index=0,
+        start_block_index=0,
+        offset=0,
+        block_sizes=[2, 2],
+    )
+    metadata[field] = value
+    worker = _FakeWorker([(tensors, metadata)])
+
+    with pytest.raises(RuntimeError, match=message):
+        _receive(worker)
+
+    assert len(worker.sent) == 1
+    assert worker.sent[0][0]["status"] == "error"
+    assert message in worker.sent[0][0]["error"]
+
+
+def test_receive_stream_rejects_lease_change_before_second_ack():
+    worker = _FakeWorker(
+        [
+            _batch(
+                batch_index=0,
+                start_block_index=0,
+                offset=0,
+                block_sizes=[3],
+                total_blocks=2,
+            ),
+            _batch(
+                batch_index=1,
+                start_block_index=1,
+                offset=3,
+                block_sizes=[3],
+                total_blocks=2,
+                lease_id="lease-2",
+            ),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="lease changed"):
+        _receive(worker, expected_blocks=2, blocks_per_batch=1)
+
+    assert len(worker.sent) == 2
+    assert worker.sent[0][0]["lease_id"] == "lease-1"
+    assert worker.sent[0][0]["status"] == "ok"
+    assert worker.sent[1][0]["status"] == "error"
+    assert _FakeCache.instances[0].cleared
+
+
+def test_receive_stream_rejects_incomplete_sample_count():
+    worker = _FakeWorker(
+        [
+            _batch(
+                batch_index=0,
+                start_block_index=0,
+                offset=0,
+                block_sizes=[2, 2],
+            ),
+            _batch(
+                batch_index=1,
+                start_block_index=2,
+                offset=4,
+                block_sizes=[1],
+            ),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="incomplete counts"):
+        _receive(worker)
+
+    assert worker.sent[-1][0]["status"] == "error"
+    assert _FakeCache.instances[0].cleared
+
+
+@pytest.mark.parametrize(
+    ("expected_blocks", "expected_samples", "blocks_per_batch"),
+    [(0, 1, 1), (1, 0, 1), (1, 1, 0)],
+)
+def test_receive_stream_requires_positive_contract_counts(
+    expected_blocks, expected_samples, blocks_per_batch
+):
+    worker = _FakeWorker([])
+    with pytest.raises(ValueError):
+        _receive(
+            worker,
+            expected_blocks=expected_blocks,
+            expected_samples=expected_samples,
+            blocks_per_batch=blocks_per_batch,
+        )
+
+
+def test_receive_stream_requires_positive_timeout():
+    with pytest.raises(ValueError, match="timeout"):
+        _receive(_FakeWorker([]), timeout_seconds=0)
+
+
+def test_receive_stream_times_out_without_a_producer_batch():
+    worker = _TimeoutWorker()
+
+    with pytest.raises(TimeoutError, match="Rollout rank 2"):
+        _receive(worker, timeout_seconds=0.01)
+
+    assert not worker.sent
+    assert worker.torch_platform.collects == 1

--- a/tests/unit_tests/test_pinned_feature_stream.py
+++ b/tests/unit_tests/test_pinned_feature_stream.py
@@ -217,6 +217,42 @@ def test_receive_stream_validates_counts_and_acks_each_batch():
 
 
 @pytest.mark.parametrize(
+    ("num_action_chunks", "pipeline_stages", "expected"),
+    [
+        (1, 1, (1024, 8192)),
+        (16, 1, (64, 512)),
+        (16, 2, (128, 512)),
+    ],
+)
+def test_compute_stream_counts_follow_policy_decisions(
+    num_action_chunks, pipeline_stages, expected
+):
+    assert (
+        pinned_feature_stream.compute_rollout_backbone_stream_counts(
+            rollout_epochs=8,
+            max_steps_per_epoch=128,
+            num_action_chunks=num_action_chunks,
+            pipeline_stages=pipeline_stages,
+            total_num_envs=64,
+            world_size=8,
+        )
+        == expected
+    )
+
+
+def test_compute_stream_counts_reject_partial_action_chunk():
+    with pytest.raises(ValueError, match="divisible by num_action_chunks"):
+        pinned_feature_stream.compute_rollout_backbone_stream_counts(
+            rollout_epochs=8,
+            max_steps_per_epoch=127,
+            num_action_chunks=16,
+            pipeline_stages=1,
+            total_num_envs=64,
+            world_size=8,
+        )
+
+
+@pytest.mark.parametrize(
     ("field", "value", "message"),
     [
         ("schema", 2, "unsupported pinned backbone metadata"),

--- a/tests/unit_tests/test_rollout_backbone_feature_reuse.py
+++ b/tests/unit_tests/test_rollout_backbone_feature_reuse.py
@@ -1,0 +1,166 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+
+def test_rollout_reuse_captures_raw_backbone_output_before_action_head_mutation():
+    pytest.importorskip("gr00t")
+    from transformers.feature_extraction_utils import BatchFeature
+
+    from rlinf.models.embodiment.gr00t.gr00t_n1d5.gr00t_action_model import (
+        GR00T_N1_5_ForRLActionPrediction,
+    )
+    from rlinf.utils.backbone_cache import (
+        ROLLOUT_BACKBONE_FEATURE_KEY,
+        ROLLOUT_BACKBONE_MASK_KEY,
+    )
+
+    raw_features = torch.tensor(
+        [[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]],
+        requires_grad=True,
+    )
+    raw_mask = torch.ones(2, 2, dtype=torch.bool)
+
+    class FakeBackbone:
+        def __call__(self, backbone_inputs):
+            del backbone_inputs
+            return BatchFeature(
+                data={
+                    "backbone_features": raw_features,
+                    "backbone_attention_mask": raw_mask,
+                }
+            )
+
+    class MutatingActionHead:
+        @staticmethod
+        def get_rl_action(backbone_outputs, action_inputs, mode):
+            del action_inputs, mode
+            # Matches FlowmatchingActionHead.process_backbone_output(): the
+            # BatchFeature mapping is updated with action-head-processed data.
+            backbone_outputs["backbone_features"] = (
+                backbone_outputs["backbone_features"] + 100.0
+            )
+            batch_size = backbone_outputs["backbone_features"].shape[0]
+            return {}, {
+                "actions": torch.zeros(batch_size, 1),
+                "chains": torch.zeros(batch_size, 1),
+                "denoise_inds": torch.zeros(batch_size, 1, dtype=torch.int64),
+                "prev_logprobs": torch.zeros(batch_size, 1),
+                "prev_values": torch.zeros(batch_size, 1),
+            }
+
+    class FakePolicy:
+        image_nums = 1
+        backbone = FakeBackbone()
+        action_head = MutatingActionHead()
+        capture_rollout_backbone_output = True
+
+        @staticmethod
+        def prepare_input(normalized_input):
+            del normalized_input
+            return BatchFeature(data={}), BatchFeature(data={})
+
+        @staticmethod
+        def validate_data(action_head_outputs, backbone_outputs, is_training):
+            del action_head_outputs, backbone_outputs, is_training
+
+    normalized_input = {
+        "state": torch.zeros(2, 1),
+        "state_mask": torch.ones(2, 1),
+        "eagle_input_ids": torch.ones(2, 1, dtype=torch.int64),
+        "eagle_attention_mask": torch.ones(2, 1, dtype=torch.int64),
+        "eagle_pixel_values": torch.ones(2, 1, 1),
+        "eagle_image_sizes": torch.ones(2, 1, 1),
+        "embodiment_id": torch.zeros(2, dtype=torch.int64),
+    }
+
+    _, result = GR00T_N1_5_ForRLActionPrediction._get_rl_action(
+        FakePolicy(), normalized_input
+    )
+    forward_inputs = result["forward_inputs"]
+
+    torch.testing.assert_close(
+        forward_inputs[ROLLOUT_BACKBONE_FEATURE_KEY], raw_features.detach()
+    )
+    torch.testing.assert_close(forward_inputs[ROLLOUT_BACKBONE_MASK_KEY], raw_mask)
+    assert not forward_inputs[ROLLOUT_BACKBONE_FEATURE_KEY].requires_grad
+
+
+def test_rollout_does_not_retain_backbone_output_when_transport_is_disabled():
+    pytest.importorskip("gr00t")
+    from transformers.feature_extraction_utils import BatchFeature
+
+    from rlinf.models.embodiment.gr00t.gr00t_n1d5.gr00t_action_model import (
+        GR00T_N1_5_ForRLActionPrediction,
+    )
+    from rlinf.utils.backbone_cache import (
+        ROLLOUT_BACKBONE_FEATURE_KEY,
+        ROLLOUT_BACKBONE_MASK_KEY,
+    )
+
+    class FakeBackbone:
+        @staticmethod
+        def __call__(backbone_inputs):
+            del backbone_inputs
+            return BatchFeature(
+                data={
+                    "backbone_features": torch.ones(1, 1, 2),
+                    "backbone_attention_mask": torch.ones(1, 1, dtype=torch.bool),
+                }
+            )
+
+    class FakeActionHead:
+        @staticmethod
+        def get_rl_action(backbone_outputs, action_inputs, mode):
+            del backbone_outputs, action_inputs, mode
+            return {}, {
+                "actions": torch.zeros(1, 1),
+                "chains": torch.zeros(1, 1),
+                "denoise_inds": torch.zeros(1, 1, dtype=torch.int64),
+                "prev_logprobs": torch.zeros(1, 1),
+                "prev_values": torch.zeros(1, 1),
+            }
+
+    class FakePolicy:
+        image_nums = 1
+        backbone = FakeBackbone()
+        action_head = FakeActionHead()
+
+        @staticmethod
+        def prepare_input(normalized_input):
+            del normalized_input
+            return BatchFeature(data={}), BatchFeature(data={})
+
+        @staticmethod
+        def validate_data(action_head_outputs, backbone_outputs, is_training):
+            del action_head_outputs, backbone_outputs, is_training
+
+    normalized_input = {
+        "state": torch.zeros(1, 1),
+        "state_mask": torch.ones(1, 1),
+        "eagle_input_ids": torch.ones(1, 1, dtype=torch.int64),
+        "eagle_attention_mask": torch.ones(1, 1, dtype=torch.int64),
+        "eagle_pixel_values": torch.ones(1, 1, 1),
+        "eagle_image_sizes": torch.ones(1, 1, 1),
+        "embodiment_id": torch.zeros(1, dtype=torch.int64),
+    }
+
+    _, result = GR00T_N1_5_ForRLActionPrediction._get_rl_action(
+        FakePolicy(), normalized_input
+    )
+
+    assert ROLLOUT_BACKBONE_FEATURE_KEY not in result["forward_inputs"]
+    assert ROLLOUT_BACKBONE_MASK_KEY not in result["forward_inputs"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
feat(gr00t): reuse rollout backbone features during PPO training
 ### Description

  This PR adds opt-in reuse of frozen GR00T N1.5 backbone features between Rollout and Actor workers.

  The implementation:

  - Captures the frozen Eagle backbone feature and mask during rollout.
  - Transfers same-GPU feature tensors through a borrowed CUDA IPC view.
  - Copies the borrowed tensors into an Actor-owned pinned CPU cache before acknowledging and releasing the producer tensors.
  - Carries sample IDs through the normal Rollout -> Env -> Actor trajectory path.
  - Loads cached features by sample ID for each shuffled PPO microbatch.
  - Reuses the features across all PPO update epochs instead of recomputing the frozen backbone from images.
  - Validates model version, rank ownership, sample IDs, block counts, byte counts, ACKs, cache completeness, and resource cleanup.
  - Fails closed for unsupported configurations, including async rollout, cross-GPU placement, unequal Actor/Rollout world sizes, and pipeline configurations other than pipeline_stage_num=1.
  - Keeps the feature disabled by default through rollout_backbone_feature_transport: null.
  - Adds configuration documentation, architecture documentation, and focused unit/CUDA tests.

  The cache is scoped to each collected sample. It does not reuse features across different observations or rollout steps.

  ### Motivation and Context

  For this PPO workload, the Eagle vision-language backbone is frozen and evaluated once by Rollout for each observation. The Actor subsequently trains on the same collected samples for four PPO epochs.

  Without feature reuse, the Actor recomputes the frozen backbone from the original images during every PPO epoch. This repeated computation does not update the backbone and was a major contributor to Actor time and GPU
  memory usage.

  The new path computes the feature once during Rollout and reuses the exact per-sample result during Actor training. The goal is to remove redundant frozen-backbone computation while preserving the original PPO data and
  optimization semantics.

  ### How has this been tested?

  The current branch was rebased onto RLinf main at:

  - Base: be8d5c2d28015146355dd2b47bce97331339f9d1
  - Tested branch HEAD: 25bee6deb2982c5a9614f8bad0add035455d0893

  Static validation:

  - Ruff 0.14.3 lint passed for all changed Python files.
  - Ruff formatting check passed.
  - Python compilation passed for all changed Python files.
  - YAML parsing passed.
  - git diff --check passed.
  - All commits contain Signed-off-by.

  Results:

  - CPU focused suite: 53 passed, 1 skipped
  - Real same-GPU borrowed CUDA IPC test: 1 passed

  The focused suite covers:

  - Frozen-backbone model contracts and precomputed-feature parity.
  - Feature filtering and sample-ID validation.
  - Pinned cache storage, lookup, and cleanup.
  - Borrowed CUDA IPC metadata and lifetime validation.
  - Stream batching, ACK/NACK, timeout, and failure cleanup.
  - Actor cleanup after training exceptions.
  - Preservation of the synchronous PolicyOutput builder API.
  - Async transport wrapper behavior.
  - Fail-closed rejection of the unsupported async runner configuration.

  Historical matched performance validation of the same feature implementation was run for 20 steps on 8 H20 GPUs with 65,536 samples per step. Steady steps 6-20 measured:

   Configuration        Step time          Throughput    Actor time    Sampled peak GPU memory
  ━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━
   Matched baseline    2176.445 s    30.111 samples/s    1226.033 s                  92420 MiB
  ──────────────────  ────────────  ──────────────────  ────────────  ─────────────────────────
   Feature reuse       1521.060 s    43.086 samples/s     602.827 s                  70879 MiB

  This corresponds to:

  - +43.087% throughput
  - -30.113% step time
  - approximately -50.83% Actor time
  - -23.31% sampled peak GPU memory

  These performance measurements were collected before rebasing onto the latest main. The rebased branch has passed the focused compatibility tests above, but the complete 20-step E2E performance benchmark has not yet
  been rerun on the new base.

  ### Additional information (optional, e.g., figures and logs):

  The detailed design, protocol, placement constraints, validation evidence, performance results, and reproduction procedure are documented in:

  docs/gr00t-rollout-backbone-feature-reuse.md

  The Trocar benchmark also used a separate IsaacLab task-side stage-update change, applied identically to both comparison arms. That IsaacLab change is not included in this PR and is independent of the RLinf feature
  transport implementation.

  ### Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Documentation update (Document-only update)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

  ### Checklist:

  - [x] My code follows the code style of this project.
  - [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.