### PR TITLE
fix(async): safely overlap rollout weight sync

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -99,6 +99,7 @@ jobs:
               - 'rlinf/models/diffusion/**'
               - 'rlinf/models/worldmodel/**'
               - 'rlinf/runners/*embodied*.py'
+              - 'rlinf/runners/async_weight_sync_mixin.py'
               - 'rlinf/runners/*reward*.py'
               - 'examples/embodiment/*'
               - 'examples/embodiment/config/*/**'

--- a/docs/source-en/rst_source/extending/weight_syncer.rst
+++ b/docs/source-en/rst_source/extending/weight_syncer.rst
@@ -463,19 +463,34 @@ the end.
 Behavior In Async Training
 ------------------------------
 
-In async embodied training, if ``actor.sync_weight_no_wait=true`` is enabled,
-rollout-side weight receiving and applying are handled in a background
-``asyncio`` task.
+Both ``AsyncEmbodiedRunner`` and ``AsyncPPOEmbodiedRunner`` honor
+``actor.sync_weight_no_wait``. When it is ``true``, synchronization after an
+actor update hands control back to the runner immediately while the rollout
+worker receives and applies the weights in a background ``asyncio`` task. The
+first actor-to-rollout synchronization stays blocking, so a new or resumed run
+cannot sample with weights that have not landed yet.
+
+This option requires ``weight_syncer.type=patch``. Patch mode applies a
+synchronization in one step, whereas bucket mode yields between buckets, which
+would let inference observe a model with only some of the new weights applied.
+RLinf rejects that combination rather than allowing the torn read.
 
 This means:
 
 - rollout does not necessarily block immediately when actor requests a sync
 - new weights only become effective after the background task completes
 - there may be a small delay between "sync requested" and "sync applied"
+- a request arriving while the previous sync is still running is coalesced
+  rather than queued, so a slow transfer cannot build up a backlog
+
+The runner tracks rollout-side *application*, not just sender completion. Both
+a later blocking synchronization and normal teardown wait for any background
+application to finish first.
 
 In this async path, version propagation matters more. ``WeightSyncer.apply(...)``
 returns the version that was actually applied on rollout, and rollout updates
-its internal version state from that result.
+its internal version state from that result. Generated trajectories carry that
+applied version, which is what async PPO uses to measure and filter stale data.
 
 
 Performance Suggestions

--- a/docs/source-zh/rst_source/extending/weight_syncer.rst
+++ b/docs/source-zh/rst_source/extending/weight_syncer.rst
@@ -411,18 +411,30 @@ Bucket 模式会把当前选中的同步子集切成多个块顺序发送。它�
 Async 场景下的行为
 ------------------------------
 
-在 async 具身训练中，如果启用了 ``actor.sync_weight_no_wait=true``，
-rollout 侧的权重接收与应用会放到后台 ``asyncio`` task 中执行。
+``AsyncEmbodiedRunner`` 与 ``AsyncPPOEmbodiedRunner`` 都支持
+``actor.sync_weight_no_wait``。当它为 ``true`` 时，actor 更新后的同步会立即把控制权
+交还给 runner，而 rollout worker 在后台 ``asyncio`` task 中接收并应用权重。
+actor 到 rollout 的首次同步仍然是阻塞的，确保新任务或恢复的任务不会在权重尚未落地时
+就开始采样。
+
+该选项要求 ``weight_syncer.type=patch``。patch 模式一次性完成整轮应用，而 bucket
+模式会在 bucket 之间让出执行权，可能让推理观察到只应用了部分新权重的模型。
+RLinf 会直接拒绝这种组合，而不是放任这种撕裂读取。
 
 这意味着：
 
 - actor 发起同步请求后，rollout 不一定立刻阻塞等待。
 - 新权重要等到后台任务完成后，才真正对 rollout 生效。
 - 权重的“请求时刻”与“生效时刻”之间可能存在一个小延迟。
+- 如果上一次同步仍在进行，新请求会被合并而不是排队，因此慢传输不会堆积成积压。
 
-因此在 async 场景下，``version`` 的传递就比较重要。  
+runner 跟踪的是 rollout 侧的\ **应用**\ 完成状态，而不只是发送端的完成状态。
+后续的阻塞式同步和 runner 正常退出，都会先等待后台的权重应用结束。
+
+因此在 async 场景下，``version`` 的传递就比较重要。
 当前 ``WeightSyncer.apply(...)`` 会返回本次真正应用到 rollout 上的版本号，
-rollout 再据此更新自身版本状态。
+rollout 再据此更新自身版本状态。生成的 trajectory 会带上这个已应用版本号，
+async PPO 正是据此统计并过滤陈旧数据。
 
 
 性能建议

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -904,6 +904,21 @@ def validate_megatron_cfg(cfg: DictConfig) -> DictConfig:
     return cfg
 
 
+def validate_weight_sync_overlap_cfg(cfg):
+    """Reject overlapping weight sync with a syncer that applies in pieces.
+
+    Patch applies a synchronization in one step. Bucket yields between buckets,
+    so a rollout generating concurrently could sample a model with only part of
+    the new weights applied.
+    """
+    if not cfg.get("actor", {}).get("sync_weight_no_wait", False):
+        return
+    assert cfg.get("weight_syncer", {}).get("type", None) == "patch", (
+        "actor.sync_weight_no_wait=true requires weight_syncer.type=patch so a "
+        "rollout cannot observe a partially applied bucket sync."
+    )
+
+
 def validate_embodied_cfg(cfg):
     only_eval = (
         cfg.runner.get("only_eval", False)
@@ -1180,6 +1195,8 @@ def validate_embodied_cfg(cfg):
                 assert cfg.env.train.base_config_name == "r1pro_behavior", (
                     f"Only r1pro_behavior is supported for omnigibson, got {cfg.env.train.base_config_name}"
                 )
+
+    validate_weight_sync_overlap_cfg(cfg)
     return cfg
 
 

--- a/rlinf/runners/async_embodied_runner.py
+++ b/rlinf/runners/async_embodied_runner.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Union
 
 from omegaconf.dictconfig import DictConfig
 
+from rlinf.runners.async_weight_sync_mixin import AsyncWeightSyncMixin
 from rlinf.runners.embodied_runner import EmbodiedRunner
 from rlinf.scheduler import Channel
 from rlinf.scheduler import WorkerGroupFuncResult as Handle
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
     )
 
 
-class AsyncEmbodiedRunner(EmbodiedRunner):
+class AsyncEmbodiedRunner(AsyncWeightSyncMixin, EmbodiedRunner):
     def __init__(
         self,
         cfg: DictConfig,
@@ -54,10 +55,7 @@ class AsyncEmbodiedRunner(EmbodiedRunner):
         self.env_metric_channel = Channel.create("EnvMetric")
         self.rollout_metric_channel = Channel.create("RolloutMetric")
 
-        self._pending_rollout_weight_sync = None
-        self._weight_sync_coalesced_total = 0
-        self._weight_sync_request_total = 0
-        self.sync_weight_no_wait = self.cfg.actor.get("sync_weight_no_wait", False)
+        self.init_weight_sync_state()
 
     def get_env_metrics(self) -> tuple[dict, list[dict], list[dict]]:
         results: list[dict] = []
@@ -103,39 +101,6 @@ class AsyncEmbodiedRunner(EmbodiedRunner):
         )
         return time_metrics, ranked_time_metrics_list
 
-    def _cleanup_pending_rollout_weight_sync(self, no_wait):
-        if self._pending_rollout_weight_sync is None:
-            return True
-
-        rollout_handle, actor_handle = self._pending_rollout_weight_sync
-        self.logger.info(
-            f"Rollout handle done: {rollout_handle.done()}, actor handle done: {actor_handle.done()}"
-        )
-        if no_wait and (not rollout_handle.done() or not actor_handle.done()):
-            return False
-
-        rollout_handle.wait()
-        actor_handle.wait()
-        self._pending_rollout_weight_sync = None
-        return True
-
-    def update_rollout_weights(self, no_wait=False):
-        if not no_wait:
-            return super().update_rollout_weights()
-
-        self._weight_sync_request_total += 1
-        if not self._cleanup_pending_rollout_weight_sync(no_wait):
-            self._weight_sync_coalesced_total += 1
-            self.logger.info(
-                f"Weight sync coalesced {self._weight_sync_coalesced_total} times.\n"
-                f"Request total {self._weight_sync_request_total} times."
-            )
-            return
-
-        rollout_handle: Handle = self.rollout.request_actor_sync_model()
-        actor_handle: Handle = self.actor.sync_model_to_rollout()
-        self._pending_rollout_weight_sync = (rollout_handle, actor_handle)
-
     def evaluate(self):
         env_handle: Handle = self.env.evaluate(
             input_channel=self.env_channel,
@@ -157,7 +122,9 @@ class AsyncEmbodiedRunner(EmbodiedRunner):
     def run(self):
         start_step = self.global_step
         start_time = time.time()
-        self.update_rollout_weights(no_wait=self.sync_weight_no_wait)
+        # Rollout must start from the actor's exact initial/resumed weights, so
+        # this first sync always blocks even when overlap is enabled.
+        self.update_rollout_weights()
 
         env_handle: Handle = self.env.interact(
             input_channel=self.env_channel,
@@ -307,6 +274,9 @@ class AsyncEmbodiedRunner(EmbodiedRunner):
 
             if profiled_step is not None:
                 self._close_profiling_window(profiled_step)
+
+        # Let any in-flight non-blocking sync land before the workers go away.
+        self.drain_pending_rollout_weight_sync()
 
         self.env.stop().wait()
         self.rollout.stop().wait()

--- a/rlinf/runners/async_ppo_embodied_runner.py
+++ b/rlinf/runners/async_ppo_embodied_runner.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 from omegaconf.omegaconf import DictConfig
 
+from rlinf.runners.async_weight_sync_mixin import AsyncWeightSyncMixin
 from rlinf.runners.embodied_runner import EmbodiedRunner
 from rlinf.scheduler import Channel
 from rlinf.scheduler import WorkerGroupFuncResult as Handle
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
     )
 
 
-class AsyncPPOEmbodiedRunner(EmbodiedRunner):
+class AsyncPPOEmbodiedRunner(AsyncWeightSyncMixin, EmbodiedRunner):
     """Runner for async PPO with long-running env and rollout workers."""
 
     def __init__(
@@ -51,6 +52,7 @@ class AsyncPPOEmbodiedRunner(EmbodiedRunner):
         self.recompute_logprobs = bool(
             self.cfg.rollout.get("recompute_logprobs", False)
         )
+        self.init_weight_sync_state()
 
         if self.cfg.runner.val_check_interval > 0:
             self.logger.warning(
@@ -100,11 +102,6 @@ class AsyncPPOEmbodiedRunner(EmbodiedRunner):
             ranked_time_metrics_list,
             ranked_env_metrics_list,
         )
-
-    def update_rollout_weights(self) -> None:
-        rollout_handle = self.rollout.sync_model_from_actor()
-        self.actor.sync_model_to_rollout().wait()
-        rollout_handle.wait()
 
     def run(self) -> None:
         start_step = self.global_step
@@ -159,8 +156,11 @@ class AsyncPPOEmbodiedRunner(EmbodiedRunner):
                 self.global_step += 1
                 self.actor.set_global_step(self.global_step).wait()
                 with self.timer("update_rollout_weights"):
-                    self.update_rollout_weights()
-                self.rollout.set_global_step(self.global_step).wait()
+                    self.update_rollout_weights(no_wait=self.sync_weight_no_wait)
+                # No rollout.set_global_step here: applying the weights already
+                # sets it from the version they carry, which is this same step.
+                # Setting it from the runner would claim the new step before a
+                # non-blocking sync has landed.
 
             time_metrics = self.timer.consume_durations()
             time_metrics = {f"time/{k}": v for k, v in time_metrics.items()}
@@ -268,6 +268,9 @@ class AsyncPPOEmbodiedRunner(EmbodiedRunner):
 
             if profiled_step is not None:
                 self._close_profiling_window(profiled_step)
+
+        # Let any in-flight non-blocking sync land before the workers go away.
+        self.drain_pending_rollout_weight_sync()
 
         self.metric_logger.finish()
 

--- a/rlinf/runners/async_weight_sync_mixin.py
+++ b/rlinf/runners/async_weight_sync_mixin.py
@@ -1,0 +1,108 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Non-blocking actor-to-rollout weight synchronization for async runners."""
+
+from rlinf.scheduler import WorkerGroupFuncResult as Handle
+
+
+class AsyncWeightSyncMixin:
+    """Overlap actor-to-rollout weight sync with the next step's work.
+
+    The blocking path waits for the sync to land before the runner moves on,
+    which idles the actor for as long as the transfer takes. Async runners can
+    instead issue the sync and carry on, since a rollout worker that is one
+    update behind is already expected under off-policy training.
+
+    Mix into a runner that has ``actor`` / ``rollout`` worker groups and a
+    ``logger``, ahead of the runner base class in the MRO::
+
+        class AsyncEmbodiedRunner(AsyncWeightSyncMixin, EmbodiedRunner): ...
+
+    Call :meth:`init_weight_sync_state` from ``__init__``, pass
+    ``no_wait=self.sync_weight_no_wait`` to :meth:`update_rollout_weights`, and
+    call :meth:`drain_pending_rollout_weight_sync` before tearing workers down.
+
+    Only one sync is ever in flight: a request that arrives while the previous
+    one is still running is coalesced away rather than queued, so a slow
+    transfer cannot build up a backlog. Weights are dropped, never reordered —
+    the rollout worker either gets an update or keeps the ones it has.
+
+    ``sync_weight_no_wait`` defaults to ``False``, which routes every call
+    through the base class's blocking implementation and leaves behavior
+    unchanged.
+    """
+
+    def init_weight_sync_state(self) -> None:
+        """Set up sync bookkeeping. Call from the runner's ``__init__``."""
+        # Requires the rollout worker's background sync path, which is gated on
+        # the same config key.
+        # validate_embodied_cfg enforces that this requires weight_syncer.type=patch.
+        self.sync_weight_no_wait = self.cfg.actor.get("sync_weight_no_wait", False)
+        self._pending_rollout_weight_sync: tuple[Handle, Handle] | None = None
+        self._weight_sync_request_total = 0
+        self._weight_sync_coalesced_total = 0
+
+    def _cleanup_pending_rollout_weight_sync(self, no_wait: bool) -> bool:
+        """Retire the in-flight sync if it has landed.
+
+        Args:
+            no_wait: Return immediately when the sync is still running, instead
+                of blocking until it lands.
+
+        Returns:
+            Whether no sync remains in flight.
+        """
+        if self._pending_rollout_weight_sync is None:
+            return True
+
+        rollout_apply_handle, actor_handle = self._pending_rollout_weight_sync
+        if no_wait and (not rollout_apply_handle.done() or not actor_handle.done()):
+            return False
+
+        # request_actor_sync_model keeps its RPC alive until the rollout worker
+        # has applied the weights, not merely acknowledged the request.
+        rollout_apply_handle.wait()
+        actor_handle.wait()
+        self._pending_rollout_weight_sync = None
+        return True
+
+    def update_rollout_weights(self, no_wait: bool = False) -> None:
+        """Synchronize actor weights to the rollout workers.
+
+        Args:
+            no_wait: Issue the sync in the background instead of blocking. When
+                a previous sync is still in flight, this one is coalesced away.
+        """
+        if not no_wait:
+            self._cleanup_pending_rollout_weight_sync(no_wait=False)
+            return super().update_rollout_weights()
+
+        self._weight_sync_request_total += 1
+        if not self._cleanup_pending_rollout_weight_sync(no_wait=True):
+            self._weight_sync_coalesced_total += 1
+            self.logger.info(
+                f"Weight sync still in flight; coalesced this request "
+                f"({self._weight_sync_coalesced_total} coalesced / "
+                f"{self._weight_sync_request_total} requested)."
+            )
+            return
+
+        rollout_apply_handle: Handle = self.rollout.request_actor_sync_model()
+        actor_handle: Handle = self.actor.sync_model_to_rollout()
+        self._pending_rollout_weight_sync = (rollout_apply_handle, actor_handle)
+
+    def drain_pending_rollout_weight_sync(self) -> None:
+        """Wait out any in-flight sync. Call before stopping the workers."""
+        self._cleanup_pending_rollout_weight_sync(no_wait=False)

--- a/rlinf/workers/rollout/hf/async_huggingface_worker.py
+++ b/rlinf/workers/rollout/hf/async_huggingface_worker.py
@@ -127,28 +127,70 @@ class AsyncMultiStepRolloutWorker(MultiStepRolloutWorker):
         self._weight_sync_requested = False
         self._weight_sync_work = asyncio.create_task(self._recv_and_apply_actor_sync())
 
+    async def _finish_background_weight_sync(self, work: asyncio.Task) -> int:
+        """Await one apply task and retire it exactly once.
+
+        Both the poll loop and an outstanding request can await the same task,
+        so only the caller that still sees it as the active one retires it.
+        """
+        applied_version = await work
+        if self._weight_sync_work is work:
+            self._weight_sync_work = None
+            self._weight_sync_apply_total += 1
+            self._start_background_weight_sync_if_needed()
+        return applied_version
+
     @Worker.timer("rollout/poll_weight_sync")
     async def _poll_background_weight_sync(self):
         self._start_background_weight_sync_if_needed()
-        if self._weight_sync_work is None:
+        work = self._weight_sync_work
+        if work is None:
             return
 
-        if not self._weight_sync_work.done():
+        if not work.done():
             return
 
-        await self._weight_sync_work
-        self._weight_sync_work = None
-        self._weight_sync_apply_total += 1
-
-        self._start_background_weight_sync_if_needed()
+        await self._finish_background_weight_sync(work)
 
     @Worker.timer("rollout/request_weight_sync")
-    async def request_actor_sync_model(self):
+    async def request_actor_sync_model(self) -> int:
+        """Request a background sync and return once its weights are applied.
+
+        The RPC is still asynchronous to the runner: calling it returns a
+        ``WorkerGroupFuncResult`` immediately. Keeping this coroutine alive
+        until rollout-side application finishes is what makes that result a
+        truthful completion signal, which the runner relies on to coalesce
+        requests, to switch back to a blocking sync, and to drain at teardown.
+
+        Returns:
+            The model version applied by the time this request finishes.
+        """
+        assert self._background_weight_sync_active, (
+            "Background weight sync requires actor.sync_weight_no_wait=true."
+        )
         self._weight_sync_request_total += 1
         if self._weight_sync_requested or self._weight_sync_work is not None:
             self._weight_sync_coalesced_total += 1
-        self._weight_sync_requested = True
+
+        # Wait out the applies already owed: one for a task in flight, one for a
+        # request that has not started yet, plus this request when it is new.
+        pending_apply_count = int(self._weight_sync_work is not None) + int(
+            self._weight_sync_requested
+        )
+        if not self._weight_sync_requested:
+            self._weight_sync_requested = True
+            pending_apply_count += 1
+        target_apply_total = self._weight_sync_apply_total + pending_apply_count
+
         self._start_background_weight_sync_if_needed()
+        while self._weight_sync_apply_total < target_apply_total:
+            work = self._weight_sync_work
+            assert work is not None, (
+                "A requested background weight sync has no active apply task."
+            )
+            await self._finish_background_weight_sync(work)
+
+        return self.version
 
     async def decoupled_generate_one_epoch(
         self, input_channel: Channel, output_channel: Channel

--- a/tests/e2e_tests/embodied/maniskill_async_ppo_openpi.yaml
+++ b/tests/e2e_tests/embodied/maniskill_async_ppo_openpi.yaml
@@ -103,6 +103,7 @@ rollout:
 actor:
   group_name: "ActorGroup"
   training_backend: "fsdp"
+  sync_weight_no_wait: True
   micro_batch_size: 4
   global_batch_size: 8
   seed: 0

--- a/tests/unit_tests/test_async_weight_sync_mixin.py
+++ b/tests/unit_tests/test_async_weight_sync_mixin.py
@@ -1,0 +1,386 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import inspect
+import logging
+from types import MethodType
+from unittest.mock import MagicMock
+
+import pytest
+from omegaconf import OmegaConf
+
+from rlinf.config import validate_weight_sync_overlap_cfg
+from rlinf.runners.async_embodied_runner import AsyncEmbodiedRunner
+from rlinf.runners.async_ppo_embodied_runner import AsyncPPOEmbodiedRunner
+from rlinf.runners.async_weight_sync_mixin import AsyncWeightSyncMixin
+from rlinf.workers.rollout.hf.async_huggingface_worker import (
+    AsyncMultiStepRolloutWorker,
+)
+
+# Both async runners must pick the overlap up from the mixin, not from their own
+# copy of it.
+RUNNER_CLASSES = (AsyncEmbodiedRunner, AsyncPPOEmbodiedRunner)
+
+
+class _Handle:
+    def __init__(self, done: bool = False) -> None:
+        self.is_done = done
+        self.wait_calls = 0
+
+    def done(self) -> bool:
+        return self.is_done
+
+    def wait(self) -> None:
+        self.wait_calls += 1
+        self.is_done = True
+
+
+class _Actor:
+    def __init__(self, handles: list[_Handle]) -> None:
+        self.handles = handles
+        self.sync_calls = 0
+
+    def sync_model_to_rollout(self) -> _Handle:
+        handle = self.handles[self.sync_calls]
+        self.sync_calls += 1
+        return handle
+
+
+class _Rollout:
+    def __init__(
+        self,
+        blocking_handles: list[_Handle],
+        background_handles: list[_Handle],
+    ) -> None:
+        self.blocking_handles = blocking_handles
+        self.background_handles = background_handles
+        self.blocking_calls = 0
+        self.background_calls = 0
+
+    def sync_model_from_actor(self) -> _Handle:
+        handle = self.blocking_handles[self.blocking_calls]
+        self.blocking_calls += 1
+        return handle
+
+    def request_actor_sync_model(self) -> _Handle:
+        handle = self.background_handles[self.background_calls]
+        self.background_calls += 1
+        return handle
+
+
+def _make_runner(runner_cls, actor: _Actor, rollout: _Rollout, no_wait: bool = False):
+    """Build a runner with only the attributes the weight-sync path touches."""
+    runner = object.__new__(runner_cls)
+    runner.actor = actor
+    runner.rollout = rollout
+    runner.logger = logging.getLogger("test_async_weight_sync")
+    runner.sync_weight_no_wait = no_wait
+    runner._pending_rollout_weight_sync = None
+    runner._weight_sync_request_total = 0
+    runner._weight_sync_coalesced_total = 0
+    return runner
+
+
+class _LifecycleWorker:
+    """Worker-group stub for a zero-step runner lifecycle."""
+
+    def interact(self, **kwargs) -> _Handle:
+        return _Handle()
+
+    def generate(self, **kwargs) -> _Handle:
+        return _Handle()
+
+    def recv_rollout_trajectories(self, **kwargs) -> _Handle:
+        return _Handle()
+
+    def stop(self) -> _Handle:
+        return _Handle()
+
+
+def _make_async_rollout_worker(
+    apply_gates: list[asyncio.Event],
+) -> tuple[AsyncMultiStepRolloutWorker, list[asyncio.Event]]:
+    """Build only the rollout-side background-sync state machine."""
+    worker = object.__new__(AsyncMultiStepRolloutWorker)
+    worker._background_weight_sync_active = True
+    worker._weight_sync_requested = False
+    worker._weight_sync_work = None
+    worker._weight_sync_apply_total = 0
+    worker._weight_sync_coalesced_total = 0
+    worker._weight_sync_request_total = 0
+    worker.version = 0
+    apply_started = [asyncio.Event() for _ in apply_gates]
+
+    async def recv_and_apply(worker_self) -> int:
+        apply_index = worker_self.version
+        apply_started[apply_index].set()
+        await apply_gates[apply_index].wait()
+        worker_self.version += 1
+        return worker_self.version
+
+    worker._recv_and_apply_actor_sync = MethodType(recv_and_apply, worker)
+    return worker, apply_started
+
+
+async def _request_actor_sync_model(worker: AsyncMultiStepRolloutWorker) -> int:
+    """Call the undecorated worker method without constructing a Ray worker."""
+    request = inspect.unwrap(AsyncMultiStepRolloutWorker.request_actor_sync_model)
+    return await request(worker)
+
+
+def _weight_sync_cfg(no_wait: bool, syncer_type: str) -> OmegaConf:
+    return OmegaConf.create(
+        {
+            "actor": {"sync_weight_no_wait": no_wait},
+            "weight_syncer": {"type": syncer_type},
+        }
+    )
+
+
+@pytest.mark.parametrize("syncer_type", ["patch", "bucket"])
+def test_mixin_reads_the_flag_for_either_syncer(syncer_type) -> None:
+    """The mixin only reads the flag; the config layer rejects bad combos."""
+    runner = object.__new__(AsyncWeightSyncMixin)
+    runner.cfg = _weight_sync_cfg(no_wait=True, syncer_type=syncer_type)
+
+    runner.init_weight_sync_state()
+
+    assert runner.sync_weight_no_wait
+    assert runner._pending_rollout_weight_sync is None
+
+
+def test_nonblocking_weight_sync_requires_patch_syncer() -> None:
+    with pytest.raises(AssertionError, match="weight_syncer.type=patch"):
+        validate_weight_sync_overlap_cfg(
+            _weight_sync_cfg(no_wait=True, syncer_type="bucket")
+        )
+
+
+def test_nonblocking_weight_sync_accepts_patch_syncer() -> None:
+    validate_weight_sync_overlap_cfg(
+        _weight_sync_cfg(no_wait=True, syncer_type="patch")
+    )
+
+
+def test_blocking_weight_sync_allows_bucket_syncer() -> None:
+    validate_weight_sync_overlap_cfg(
+        _weight_sync_cfg(no_wait=False, syncer_type="bucket")
+    )
+
+
+def test_async_embodied_runner_startup_sync_is_blocking() -> None:
+    runner = object.__new__(AsyncEmbodiedRunner)
+    runner.global_step = 0
+    runner.max_steps = 0
+    runner.actor = _LifecycleWorker()
+    runner.rollout = _LifecycleWorker()
+    runner.env = _LifecycleWorker()
+    runner.reward = None
+    runner.env_channel = None
+    runner.rollout_channel = None
+    runner.reward_channel = None
+    runner.actor_channel = None
+    runner.env_metric_channel = None
+    runner.rollout_metric_channel = None
+    runner.update_rollout_weights = MagicMock()
+    runner.drain_pending_rollout_weight_sync = MagicMock()
+
+    runner.run()
+
+    runner.update_rollout_weights.assert_called_once_with()
+    runner.drain_pending_rollout_weight_sync.assert_called_once_with()
+
+
+def test_rollout_request_completes_only_after_weights_are_applied() -> None:
+    async def run_test() -> None:
+        apply_gate = asyncio.Event()
+        worker, apply_started = _make_async_rollout_worker([apply_gate])
+
+        request_task = asyncio.create_task(_request_actor_sync_model(worker))
+        await asyncio.wait_for(apply_started[0].wait(), timeout=5.0)
+        await asyncio.sleep(0)
+
+        assert not request_task.done()
+        assert worker._weight_sync_apply_total == 0
+        assert worker.version == 0
+
+        apply_gate.set()
+
+        assert await asyncio.wait_for(request_task, timeout=5.0) == 1
+        assert worker._weight_sync_apply_total == 1
+        assert worker._weight_sync_work is None
+        assert worker.version == 1
+
+    asyncio.run(run_test())
+
+
+def test_rollout_requests_coalesce_without_reordering_apply() -> None:
+    async def run_test() -> None:
+        first_apply_gate = asyncio.Event()
+        second_apply_gate = asyncio.Event()
+        worker, apply_started = _make_async_rollout_worker(
+            [first_apply_gate, second_apply_gate]
+        )
+
+        first_request = asyncio.create_task(_request_actor_sync_model(worker))
+        await asyncio.wait_for(apply_started[0].wait(), timeout=5.0)
+        second_request = asyncio.create_task(_request_actor_sync_model(worker))
+        await asyncio.sleep(0)
+
+        assert worker._weight_sync_coalesced_total == 1
+        assert not first_request.done()
+        assert not second_request.done()
+
+        first_apply_gate.set()
+        assert await asyncio.wait_for(first_request, timeout=5.0) == 1
+        await asyncio.wait_for(apply_started[1].wait(), timeout=5.0)
+        assert not second_request.done()
+        assert worker.version == 1
+
+        second_apply_gate.set()
+        assert await asyncio.wait_for(second_request, timeout=5.0) == 2
+        assert worker._weight_sync_apply_total == 2
+        assert worker._weight_sync_work is None
+        assert worker.version == 2
+
+    asyncio.run(run_test())
+
+
+@pytest.mark.parametrize("runner_cls", RUNNER_CLASSES)
+def test_runner_inherits_the_shared_mixin(runner_cls) -> None:
+    assert issubclass(runner_cls, AsyncWeightSyncMixin)
+    # The overlap must resolve to the mixin, i.e. no runner-local reimplementation.
+    assert (
+        runner_cls.update_rollout_weights is AsyncWeightSyncMixin.update_rollout_weights
+    )
+
+
+@pytest.mark.parametrize("runner_cls", RUNNER_CLASSES)
+def test_blocking_weight_sync_waits_for_both_sides(runner_cls) -> None:
+    actor_handle = _Handle()
+    rollout_handle = _Handle()
+    actor = _Actor([actor_handle])
+    rollout = _Rollout([rollout_handle], [])
+    runner = _make_runner(runner_cls, actor, rollout)
+
+    runner.update_rollout_weights()
+
+    assert actor.sync_calls == 1
+    assert rollout.blocking_calls == 1
+    assert rollout.background_calls == 0
+    assert actor_handle.wait_calls == 1
+    assert rollout_handle.wait_calls == 1
+    assert runner._pending_rollout_weight_sync is None
+
+
+@pytest.mark.parametrize("runner_cls", RUNNER_CLASSES)
+def test_nonblocking_weight_sync_does_not_wait(runner_cls) -> None:
+    actor_handle = _Handle()
+    rollout_handle = _Handle()
+    actor = _Actor([actor_handle])
+    rollout = _Rollout([], [rollout_handle])
+    runner = _make_runner(runner_cls, actor, rollout, no_wait=True)
+
+    runner.update_rollout_weights(no_wait=True)
+
+    assert rollout.background_calls == 1
+    assert actor.sync_calls == 1
+    assert actor_handle.wait_calls == 0
+    assert rollout_handle.wait_calls == 0
+    assert runner._pending_rollout_weight_sync == (rollout_handle, actor_handle)
+
+
+@pytest.mark.parametrize("runner_cls", RUNNER_CLASSES)
+def test_nonblocking_weight_sync_coalesces_until_previous_sync_finishes(
+    runner_cls,
+) -> None:
+    first_actor_handle = _Handle()
+    first_rollout_handle = _Handle(done=True)
+    second_actor_handle = _Handle()
+    second_rollout_handle = _Handle(done=True)
+    actor = _Actor([first_actor_handle, second_actor_handle])
+    rollout = _Rollout([], [first_rollout_handle, second_rollout_handle])
+    runner = _make_runner(runner_cls, actor, rollout, no_wait=True)
+
+    runner.update_rollout_weights(no_wait=True)
+    runner.update_rollout_weights(no_wait=True)
+
+    # The second request is dropped, not queued: still one sync in flight.
+    assert actor.sync_calls == 1
+    assert rollout.background_calls == 1
+    assert first_actor_handle.wait_calls == 0
+    assert first_rollout_handle.wait_calls == 0
+    assert runner._weight_sync_coalesced_total == 1
+    assert runner._weight_sync_request_total == 2
+
+    first_actor_handle.is_done = True
+    runner.update_rollout_weights(no_wait=True)
+
+    assert first_actor_handle.wait_calls == 1
+    assert first_rollout_handle.wait_calls == 1
+    assert actor.sync_calls == 2
+    assert rollout.background_calls == 2
+    assert runner._weight_sync_coalesced_total == 1
+    assert runner._weight_sync_request_total == 3
+    assert runner._pending_rollout_weight_sync == (
+        second_rollout_handle,
+        second_actor_handle,
+    )
+
+
+@pytest.mark.parametrize("runner_cls", RUNNER_CLASSES)
+def test_blocking_weight_sync_drains_an_inflight_background_sync(runner_cls) -> None:
+    pending_actor_handle = _Handle()
+    pending_rollout_handle = _Handle()
+    blocking_actor_handle = _Handle()
+    blocking_rollout_handle = _Handle()
+    actor = _Actor([blocking_actor_handle])
+    rollout = _Rollout([blocking_rollout_handle], [])
+    runner = _make_runner(runner_cls, actor, rollout)
+    runner._pending_rollout_weight_sync = (
+        pending_rollout_handle,
+        pending_actor_handle,
+    )
+
+    runner.update_rollout_weights(no_wait=False)
+
+    assert pending_actor_handle.wait_calls == 1
+    assert pending_rollout_handle.wait_calls == 1
+    assert blocking_actor_handle.wait_calls == 1
+    assert blocking_rollout_handle.wait_calls == 1
+    assert runner._pending_rollout_weight_sync is None
+
+
+@pytest.mark.parametrize("runner_cls", RUNNER_CLASSES)
+def test_teardown_drains_an_inflight_background_sync(runner_cls) -> None:
+    actor_handle = _Handle()
+    rollout_handle = _Handle()
+    runner = _make_runner(runner_cls, _Actor([]), _Rollout([], []))
+    runner._pending_rollout_weight_sync = (rollout_handle, actor_handle)
+
+    runner.drain_pending_rollout_weight_sync()
+
+    assert actor_handle.wait_calls == 1
+    assert rollout_handle.wait_calls == 1
+    assert runner._pending_rollout_weight_sync is None
+
+
+@pytest.mark.parametrize("runner_cls", RUNNER_CLASSES)
+def test_teardown_is_a_noop_without_a_pending_sync(runner_cls) -> None:
+    runner = _make_runner(runner_cls, _Actor([]), _Rollout([], []))
+
+    runner.drain_pending_rollout_weight_sync()
+
+    assert runner._pending_rollout_weight_sync is None


### PR DESCRIPTION
### Description
`actor.sync_weight_no_wait` previously affected only `AsyncEmbodiedRunner`.
`AsyncPPOEmbodiedRunner` is a sibling of that runner and always used the
blocking `EmbodiedRunner.update_rollout_weights()`, so the existing switch had
no effect for async PPO.

This change:

- adds an `AsyncWeightSyncMixin` shared by both async embodied runners;
- makes a background-sync handle complete only after rollout-side
  `WeightSyncer.apply(...)` has finished, rather than after the rollout worker
  merely acknowledges the request;
- keeps the initial actor-to-rollout sync blocking, drains an in-flight sync
  before a later blocking sync and normal teardown, and coalesces requests
  while one runner-level sync is in flight;
- permits no-wait synchronization only with the patch syncer. Bucket apply can
  yield between buckets, so allowing inference concurrently could expose a
  partially updated model;
- documents the behavior in English and Chinese and enables the no-wait path
  in the existing async-PPO ManiSkill e2e config.

The default remains `actor.sync_weight_no_wait=false`.

### Motivation and Context
Async PPO could not overlap actor-to-rollout weight transfer even though it
already exposed the same configuration as the other async embodied runner.
While sharing the implementation, two correctness gaps in the old async path
also needed to be closed: blocking transitions could race an outstanding
background apply, and normal teardown could stop workers before that apply had
finished.

Tracking rollout-side application is important for data correctness because
the applied model version is recorded on generated trajectories and used by
async PPO's staleness filtering.

### How has this been tested?
- `pytest -q tests/unit_tests/test_async_weight_sync.py`: **19 passed**. This
  covers both runner MROs, blocking/non-blocking behavior, runner and rollout
  coalescing, rollout-side apply completion, blocking and teardown drains,
  blocking startup, and the patch-only guard.
- selected patch/bucket round-trip cases from
  `tests/unit_tests/test_weight_syncer.py`: **5 passed**.
- `pre-commit run --files <changed files>`: Ruff lint, Ruff format, and
  committer signoff all passed.

GPU smoke test: one `rlinf-0` node with 4x NVIDIA H20 GPUs available; collocated
actor/env/rollout placement used GPU ranks 0-1. Pi0.5 + ManiSkill async PPO,
patch syncer, 4 environments, seed 0, 6 optimizer steps. The same config was
run with only `actor.sync_weight_no_wait` changed:

| | `false` | `true` |
| --- | ---: | ---: |
| Exit status | 0 | 0 |
| Actor versions | 1 through 6 | 1 through 6 |
| Maximum trajectory staleness observed | 2 | 2 |
| Discarded unused trajectories | 0 | 0 |
| Finite TensorBoard scalars | 274 / 274 | 285 / 285 |
| Mean runner-visible `update_rollout_weights` time | 2.621 s | 0.648 ms |

The no-wait run consumed trajectories tagged with rollout-applied versions
2-5 after initially consuming version 0, showing that applied versions—not
only actor-side counters—propagate into training data. This short run checks
the synchronization and staleness invariants plus numerical health; it is not
a convergence comparison.

### Additional information (optional, e.g., figures and logs):

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.