### PR TITLE
fix(runner): skip incomplete checkpoints during auto resume

### DIFF
--- a/rlinf/runners/reasoning_runner.py
+++ b/rlinf/runners/reasoning_runner.py
@@ -307,17 +307,21 @@ class ReasoningRunner:
                     and os.path.isdir(os.path.join(checkpoints_dir, d))
                 ]
 
-            if checkpoint_steps:
-                max_step = max(checkpoint_steps)
-                self.cfg.runner.resume_dir = os.path.join(
-                    checkpoints_dir, f"global_step_{max_step}"
+            resume_dir = None
+            for step in sorted(checkpoint_steps, reverse=True):
+                candidate = os.path.join(checkpoints_dir, f"global_step_{step}")
+                if self._is_complete_checkpoint(candidate):
+                    resume_dir = candidate
+                    break
+                logging.warning(
+                    f"Skipping incomplete checkpoint {candidate} during auto resume."
                 )
-                logging.info(
-                    f"Auto resume from checkpoint: {self.cfg.runner.resume_dir}"
-                )
+
+            self.cfg.runner.resume_dir = resume_dir
+            if resume_dir is not None:
+                logging.info(f"Auto resume from checkpoint: {resume_dir}")
             else:
-                self.cfg.runner.resume_dir = None
-                logging.info("No checkpoints found, starting from scratch")
+                logging.info("No complete checkpoints found, starting from scratch")
         self.init_rollout_workers()
         self.init_actor_critic_workers()
 
@@ -358,6 +362,21 @@ class ReasoningRunner:
 
         return flops_metrics
 
+    def _is_complete_checkpoint(self, checkpoint_dir: str) -> bool:
+        """Return whether a ``global_step_<N>`` directory finished writing.
+
+        ``_save_checkpoint`` writes the actor, then the optional critic, and
+        publishes the dataloader state last with an atomic rename, so the
+        presence of ``data/data.pt`` marks the whole checkpoint as complete.
+        """
+        if not os.path.isdir(os.path.join(checkpoint_dir, "actor")):
+            return False
+        if self.critic is not None and not os.path.isdir(
+            os.path.join(checkpoint_dir, "critic")
+        ):
+            return False
+        return os.path.isfile(os.path.join(checkpoint_dir, "data", "data.pt"))
+
     def _save_checkpoint(self):
         base_output_dir = os.path.join(
             self.cfg.runner.output_dir,
@@ -378,8 +397,17 @@ class ReasoningRunner:
         data_save_path = os.path.join(base_output_dir, "data")
         local_mkdir_safe(data_save_path)
         dataloader_local_path = os.path.join(data_save_path, "data.pt")
+        dataloader_tmp_path = f"{dataloader_local_path}.tmp"
         dataloader_state_dict = self.train_dataloader.state_dict()
-        torch.save(dataloader_state_dict, dataloader_local_path)
+        # Publish atomically so an interrupted save cannot leave a truncated
+        # data.pt behind, which auto resume reads as a complete checkpoint.
+        try:
+            torch.save(dataloader_state_dict, dataloader_tmp_path)
+            os.replace(dataloader_tmp_path, dataloader_local_path)
+        except BaseException:
+            if os.path.exists(dataloader_tmp_path):
+                os.remove(dataloader_tmp_path)
+            raise
 
     def _set_max_steps(self):
         self.num_steps_per_epoch = len(self.train_dataloader)

--- a/tests/unit_tests/test_auto_resume_checkpoint.py
+++ b/tests/unit_tests/test_auto_resume_checkpoint.py
@@ -1,0 +1,165 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for reasoning checkpoint auto-resume selection."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from rlinf.runners.reasoning_runner import ReasoningRunner
+
+
+class _StubRunner:
+    """Expose only the checkpoint helpers and state used by these tests."""
+
+    def __init__(self, critic=None):
+        self.critic = critic
+
+    _is_complete_checkpoint = ReasoningRunner._is_complete_checkpoint
+
+
+class _ImmediateHandle:
+    def wait(self):
+        return None
+
+
+class _Actor:
+    def save_checkpoint(self, path: str, _step: int):
+        os.makedirs(path, exist_ok=True)
+        return _ImmediateHandle()
+
+
+class _Dataloader:
+    def state_dict(self):
+        return {"offset": 3}
+
+
+def _write_checkpoint(
+    root: Path, step: int, *, complete: bool, with_critic: bool = False
+) -> Path:
+    checkpoint_dir = root / f"global_step_{step}"
+    (checkpoint_dir / "actor").mkdir(parents=True)
+    if with_critic:
+        (checkpoint_dir / "critic").mkdir()
+    if complete:
+        data_dir = checkpoint_dir / "data"
+        data_dir.mkdir()
+        (data_dir / "data.pt").write_bytes(b"dataloader-state")
+    return checkpoint_dir
+
+
+def _resolve_auto_resume(log_path: Path, *, critic=None) -> str | None:
+    cfg = OmegaConf.create(
+        {"runner": {"resume_dir": "auto", "logger": {"log_path": str(log_path)}}}
+    )
+    runner = _StubRunner(critic=critic)
+    runner.cfg = cfg
+    runner.init_rollout_workers = lambda: None
+    runner.init_actor_critic_workers = lambda: None
+
+    ReasoningRunner.init_workers(runner)
+    return cfg.runner.resume_dir
+
+
+def _saving_runner(tmp_path: Path) -> _StubRunner:
+    runner = _StubRunner()
+    runner.cfg = OmegaConf.create(
+        {
+            "runner": {
+                "output_dir": str(tmp_path),
+                "experiment_name": "experiment",
+            }
+        }
+    )
+    runner.global_steps = 8
+    runner.actor = _Actor()
+    runner.train_dataloader = _Dataloader()
+    return runner
+
+
+@pytest.mark.parametrize(
+    "completeness,expected_step",
+    [
+        pytest.param({40: True, 80: False}, 40, id="skips-the-incomplete-newest"),
+        pytest.param({40: True, 80: True}, 80, id="takes-the-newest-complete"),
+        pytest.param({40: False}, None, id="starts-fresh-when-none-is-complete"),
+    ],
+)
+def test_auto_resume_selects_the_newest_complete_checkpoint(
+    tmp_path, completeness, expected_step
+):
+    checkpoints_dir = tmp_path / "checkpoints"
+    checkpoints_dir.mkdir()
+    for step, complete in completeness.items():
+        _write_checkpoint(checkpoints_dir, step, complete=complete)
+
+    expected = (
+        None
+        if expected_step is None
+        else str(checkpoints_dir / f"global_step_{expected_step}")
+    )
+    assert _resolve_auto_resume(tmp_path) == expected
+
+
+def test_checkpoint_requires_the_critic_only_when_configured(tmp_path):
+    checkpoints_dir = tmp_path / "checkpoints"
+    checkpoints_dir.mkdir()
+    checkpoint = _write_checkpoint(checkpoints_dir, 40, complete=True)
+
+    assert _StubRunner()._is_complete_checkpoint(str(checkpoint))
+    assert not _StubRunner(critic=object())._is_complete_checkpoint(str(checkpoint))
+
+
+def test_dataloader_state_is_published_atomically(tmp_path, monkeypatch):
+    runner = _saving_runner(tmp_path)
+    written_paths = []
+
+    def save(_state, path):
+        written_paths.append(path)
+        Path(path).write_bytes(b"complete")
+
+    monkeypatch.setattr("rlinf.runners.reasoning_runner.torch.save", save)
+
+    ReasoningRunner._save_checkpoint(runner)
+
+    checkpoint = tmp_path / "experiment" / "checkpoints" / "global_step_8"
+    final_path = checkpoint / "data" / "data.pt"
+    assert written_paths == [f"{final_path}.tmp"]
+    assert final_path.read_bytes() == b"complete"
+    assert not Path(f"{final_path}.tmp").exists()
+    assert runner._is_complete_checkpoint(str(checkpoint))
+
+
+def test_interrupted_dataloader_save_does_not_publish_completion(tmp_path, monkeypatch):
+    runner = _saving_runner(tmp_path)
+
+    def interrupted_save(_state, path):
+        Path(path).write_bytes(b"partial")
+        raise RuntimeError("interrupted")
+
+    monkeypatch.setattr("rlinf.runners.reasoning_runner.torch.save", interrupted_save)
+
+    with pytest.raises(RuntimeError, match="interrupted"):
+        ReasoningRunner._save_checkpoint(runner)
+
+    checkpoint = tmp_path / "experiment" / "checkpoints" / "global_step_8"
+    final_path = checkpoint / "data" / "data.pt"
+    assert not final_path.exists()
+    assert not Path(f"{final_path}.tmp").exists()
+    assert not runner._is_complete_checkpoint(str(checkpoint))


### PR DESCRIPTION
### Description

With `runner.resume_dir: auto`, `ReasoningRunner.init_workers` picked the highest
`global_step_<N>` directory under `checkpoints/`, without checking whether that
checkpoint had finished writing. A run killed midway through `_save_checkpoint`
leaves a directory that looks newest but is incomplete, and the next launch resumes
from it.

`_save_checkpoint` writes the actor first, then the optional critic, then the
dataloader state. This PR publishes the dataloader state through a temporary file
and an atomic rename, so `data/data.pt` exists only once the whole checkpoint has
been written, and auto resume walks the checkpoints newest-first and takes the first
one whose actor, optional critic, and dataloader state are all present. Skipped
candidates are logged at warning level.

### Motivation and Context

Resuming from a half-written checkpoint fails in ways that are easy to misread: a
missing `critic/` directory surfaces as a load error, a truncated `data/data.pt`
fails to deserialize, and a `data/data.pt` that was never written at all only warns
before restarting the data stream from the beginning — so the resumed run quietly
retrains on samples it had already consumed.

### How has this been tested?

New unit tests, run on CPU with Python 3.12:

```bash
pytest tests/unit_tests/test_auto_resume_checkpoint.py
# 6 passed
```

They cover: auto resume skipping an incomplete newest checkpoint, taking the newest
complete one, and starting from scratch when none is complete; the critic being
required only when a critic is configured; the dataloader state being written to a
temporary path and renamed into place; and an interrupted save publishing neither
`data.pt` nor a leftover `data.pt.tmp`.

`ruff check` and `ruff format --check` are clean.

### Additional information (optional, e.g., figures and logs):

Worth flagging for review: `data/data.pt` is used as the completion marker, so a
checkpoint directory that has an actor but no dataloader state is now skipped by
auto resume, whereas before it would have been selected and resumed with the data
stream reset. Explicit `runner.resume_dir: <path>` is unaffected — the check applies
only to `auto`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.