### PR TITLE
fix(metrics): isolate per-worker runs and drain metric tables on exit

### DIFF
--- a/docs/source-en/rst_source/guides/logger.rst
+++ b/docs/source-en/rst_source/guides/logger.rst
@@ -96,3 +96,9 @@ metrics. You can check the metrics through your dashboard.
 
    All three loggers run **in parallel**; feel free to mix and match.
 
+.. note::
+
+   ``runner.per_worker_log`` can create separate TensorBoard logs and W&B runs
+   for individual workers. W&B requires version 0.19.10 or newer for concurrent
+   runs in one process. SwanLab supports only one active run per process, so it
+   cannot be combined with ``runner.per_worker_log``.

--- a/docs/source-zh/rst_source/guides/logger.rst
+++ b/docs/source-zh/rst_source/guides/logger.rst
@@ -94,3 +94,10 @@ SwanLab
 .. tip::
 
    三个 logger 可以 **并行运行**；你可以自由组合使用。
+
+.. note::
+
+   ``runner.per_worker_log`` 可以为各个 worker 创建独立的 TensorBoard 日志和
+   W&B run。在同一进程中并行使用多个 run 需要 W&B 0.19.10 或更高版本。
+   SwanLab 在单个进程中只支持一个 active run，因此不能与
+   ``runner.per_worker_log`` 同时启用。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "icmplib",
 
     # Logging
-    "wandb<0.25.1",
+    "wandb>=0.19.10,<0.25.1",
     "swanlab>=0.6.11",
     "tensorboard",
 

--- a/rlinf/runners/async_embodied_runner.py
+++ b/rlinf/runners/async_embodied_runner.py
@@ -308,6 +308,8 @@ class AsyncEmbodiedRunner(EmbodiedRunner):
             if profiled_step is not None:
                 self._close_profiling_window(profiled_step)
 
+        self._finish_run()
+
         self.env.stop().wait()
         self.rollout.stop().wait()
         self.actor.stop().wait()

--- a/rlinf/runners/async_ppo_embodied_runner.py
+++ b/rlinf/runners/async_ppo_embodied_runner.py
@@ -269,11 +269,7 @@ class AsyncPPOEmbodiedRunner(EmbodiedRunner):
             if profiled_step is not None:
                 self._close_profiling_window(profiled_step)
 
-        self.metric_logger.finish()
-
-        self.stop_logging = True
-        self.log_queue.join()
-        self.log_thread.join(timeout=1.0)
+        self._finish_run()
 
         self.env.stop().wait()
         self.rollout.stop().wait()

--- a/rlinf/runners/embodied_runner.py
+++ b/rlinf/runners/embodied_runner.py
@@ -14,8 +14,6 @@
 
 import logging
 import os
-import queue
-import threading
 import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Union
@@ -28,7 +26,7 @@ from rlinf.utils.distributed import ScopedTimer
 from rlinf.utils.logging import get_logger
 from rlinf.utils.metric_logger import MetricLogger
 from rlinf.utils.metric_utils import compute_evaluate_metrics, print_metrics_table
-from rlinf.utils.runner_utils import check_progress
+from rlinf.utils.runner_utils import AsyncMetricTableLogger, check_progress
 from rlinf.utils.timers import Timer
 
 logger = logging.getLogger(__name__)
@@ -117,25 +115,7 @@ class EmbodiedRunner:
             self.cfg.runner.get("per_worker_log", False)
         )
 
-        # Async logging setup
-        self.stop_logging = False
-        self.log_queue = queue.Queue()
-        self.log_thread = threading.Thread(target=self._log_worker, daemon=True)
-        self.log_thread.start()
-
-    def _log_worker(self):
-        """Background thread for processing log messages."""
-        while not self.stop_logging:
-            try:
-                # Wait for log message with timeout
-                log_func, args = self.log_queue.get(timeout=0.1)
-                log_func(*args)
-                self.log_queue.task_done()
-            except queue.Empty:
-                continue
-            except Exception as e:
-                print(f"Logging error: {e}")
-                continue
+        self.metric_table_logger = AsyncMetricTableLogger(self.logger)
 
     def print_metrics_table_async(
         self,
@@ -146,18 +126,14 @@ class EmbodiedRunner:
         start_step: int = 0,
     ):
         """Async version that puts table printing in queue."""
-        self.log_queue.put(
-            (
-                print_metrics_table,
-                (
-                    step,
-                    total_steps,
-                    start_time,
-                    metrics,
-                    start_step,
-                    self.metric_logger.log_path,
-                ),
-            )
+        self.metric_table_logger.submit(
+            print_metrics_table,
+            step,
+            total_steps,
+            start_time,
+            metrics,
+            start_step,
+            self.metric_logger.log_path,
         )
 
     def init_workers(self):
@@ -449,12 +425,11 @@ class EmbodiedRunner:
         )
 
     def _finish_run(self) -> None:
-        self.metric_logger.finish()
-
-        # Stop logging thread
-        self.stop_logging = True
-        self.log_queue.join()  # Wait for all queued logs to be processed
-        self.log_thread.join(timeout=1.0)
+        """Flush the pending metric tables before closing the metric backends."""
+        try:
+            self.metric_table_logger.shutdown()
+        finally:
+            self.metric_logger.finish()
 
     def _should_profile_step(self, step_idx: int) -> bool:
         return self._profile_all_steps or (

--- a/rlinf/runners/offline_runner.py
+++ b/rlinf/runners/offline_runner.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import os
-import queue
-import threading
 import time
 from collections import defaultdict
 from typing import Any
@@ -27,7 +25,7 @@ from rlinf.utils.distributed import ScopedTimer
 from rlinf.utils.logging import get_logger
 from rlinf.utils.metric_logger import MetricLogger
 from rlinf.utils.metric_utils import compute_evaluate_metrics, print_metrics_table
-from rlinf.utils.runner_utils import check_progress
+from rlinf.utils.runner_utils import AsyncMetricTableLogger, check_progress
 
 
 class OfflineRunner:
@@ -61,25 +59,7 @@ class OfflineRunner:
             self.cfg.runner.get("per_worker_log", False)
         )
 
-        # Async logging setup
-        self.stop_logging = False
-        self.log_queue = queue.Queue()
-        self.log_thread = threading.Thread(target=self._log_worker, daemon=True)
-        self.log_thread.start()
-
-    def _log_worker(self):
-        """Background thread for processing log messages."""
-        while not self.stop_logging:
-            try:
-                # Wait for log message with timeout
-                log_func, args = self.log_queue.get(timeout=0.1)
-                log_func(*args)
-                self.log_queue.task_done()
-            except queue.Empty:
-                continue
-            except Exception as e:
-                self.logger.error("Logging error: %s", e)
-                continue
+        self.metric_table_logger = AsyncMetricTableLogger(self.logger)
 
     def print_metrics_table_async(
         self,
@@ -90,18 +70,14 @@ class OfflineRunner:
         start_step: int = 0,
     ):
         """Async version that puts table printing in queue."""
-        self.log_queue.put(
-            (
-                print_metrics_table,
-                (
-                    step,
-                    total_steps,
-                    start_time,
-                    metrics,
-                    start_step,
-                    self.metric_logger.log_path,
-                ),
-            )
+        self.metric_table_logger.submit(
+            print_metrics_table,
+            step,
+            total_steps,
+            start_time,
+            metrics,
+            start_step,
+            self.metric_logger.log_path,
         )
 
     def init_workers(self):
@@ -348,12 +324,14 @@ class OfflineRunner:
                     _step - 1, self.max_steps, start_time, logging_metrics, start_step
                 )
 
-        self.metric_logger.finish()
+        self._finish_run()
 
-        # Stop logging thread
-        self.stop_logging = True
-        self.log_queue.join()  # Wait for all queued logs to be processed
-        self.log_thread.join(timeout=1.0)
+    def _finish_run(self) -> None:
+        """Flush the pending metric tables before closing the metric backends."""
+        try:
+            self.metric_table_logger.shutdown()
+        finally:
+            self.metric_logger.finish()
 
     def _save_checkpoint(self):
         self.logger.info(f"Saving checkpoint at step {self.global_step}.")

--- a/rlinf/utils/metric_logger.py
+++ b/rlinf/utils/metric_logger.py
@@ -13,28 +13,85 @@
 # limitations under the License.
 
 import os
+from collections.abc import Iterable
 
 from omegaconf import DictConfig, OmegaConf
 
 
-class _TensorboardLogger:
+class _Backend:
+    """A metric backend whose teardown runs at most once."""
+
+    def __init__(self):
+        self._finished = False
+
+    def finish(self) -> None:
+        if not self._finished:
+            self._close()
+            self._finished = True
+
+    def _close(self) -> None:
+        raise NotImplementedError
+
+
+class _TensorboardLogger(_Backend):
     def __init__(self, log_path):
         from torch.utils.tensorboard import SummaryWriter
 
+        super().__init__()
         self.writer = SummaryWriter(log_path)
 
     def log(self, data: dict[str, float], step: int) -> None:
         for key, value in data.items():
             self.writer.add_scalar(key, value, step)
 
-    def finish(self):
+    def _close(self) -> None:
         self.writer.close()
+
+
+class _RunLogger(_Backend):
+    """A backend bound to the run object its ``init`` returned.
+
+    Logging through the run instead of the module keeps concurrently active
+    runs of the same backend from writing into whichever one was created last.
+    """
+
+    def __init__(self, run):
+        super().__init__()
+        self.run = run
+
+    def log(self, data: dict, step: int) -> None:
+        self.run.log(data, step=step)
+
+    def _close(self) -> None:
+        self.run.finish()
+
+
+class _WandbLogger(_RunLogger):
+    def __init__(self, module, run):
+        super().__init__(run)
+        self.module = module
+
+    def log_table(self, df_data, name: str, step: int) -> None:
+        self.run.log({name: self.module.Table(dataframe=df_data)}, step=step)
+
+
+def _finish_backends(backends: Iterable[_Backend]) -> None:
+    """Close every backend, re-raising the first failure once all are closed."""
+    first_error = None
+    for backend in backends:
+        try:
+            backend.finish()
+        except Exception as exc:  # noqa: BLE001 - close the remaining backends
+            first_error = first_error or exc
+    if first_error is not None:
+        raise first_error
 
 
 class MetricLogger:
     supported_logger = ["wandb", "swanlab", "tensorboard"]
 
     def __init__(self, cfg: DictConfig):
+        self._all_loggers = []
         self.cfg = cfg
         logger_cfg = cfg.runner.logger
 
@@ -61,9 +118,13 @@ class MetricLogger:
             assert all(
                 backend in self.supported_logger for backend in self.logger_backends
             ), f"Unsupported logger backend: {self.logger_backends}"
+        if self.per_worker_log and "swanlab" in self.logger_backends:
+            raise ValueError(
+                "SwanLab supports only one active run per process; "
+                "disable runner.per_worker_log or drop the swanlab backend."
+            )
 
         self.config = OmegaConf.to_container(cfg, resolve=True)
-        self._all_loggers = []
         self._worker_loggers: dict[tuple[str, int], dict] = {}
         self.logger = self._create_logger_bundle(
             log_path=self.log_path,
@@ -75,51 +136,65 @@ class MetricLogger:
         self, log_path: str, experiment_name: str, log_path_suffix: str = ""
     ) -> dict:
         logger = {}
-        if "wandb" in self.logger_backends:
-            import wandb
+        try:
+            if "wandb" in self.logger_backends:
+                import wandb
 
-            wandb_log_path = os.path.join(log_path, "wandb", log_path_suffix)
-            os.makedirs(wandb_log_path, exist_ok=True)
+                wandb_log_path = os.path.join(log_path, "wandb", log_path_suffix)
+                os.makedirs(wandb_log_path, exist_ok=True)
 
-            settings = None
-            if self.wandb_proxy:
-                settings = wandb.Settings(https_proxy=self.wandb_proxy)
-            wandb.init(
-                entity=self.wandb_entity,
-                project=self.project_name,
-                name=experiment_name,
-                config=self.config,
-                settings=settings,
-                dir=wandb_log_path,
-                reinit=True,
-            )
-            logger["wandb"] = wandb
+                settings = None
+                if self.wandb_proxy:
+                    settings = wandb.Settings(https_proxy=self.wandb_proxy)
+                run = wandb.init(
+                    entity=self.wandb_entity,
+                    project=self.project_name,
+                    name=experiment_name,
+                    config=self.config,
+                    settings=settings,
+                    dir=wandb_log_path,
+                    # "create_new" keeps per-worker runs alive side by side; it
+                    # needs wandb >= 0.19.10.
+                    reinit="create_new" if self.per_worker_log else True,
+                )
+                if run is None:
+                    raise RuntimeError("wandb.init() returned no run to log to")
+                logger["wandb"] = _WandbLogger(wandb, run)
 
-        if "swanlab" in self.logger_backends:
-            import swanlab
+            if "swanlab" in self.logger_backends:
+                import swanlab
 
-            swanlab_log_path = os.path.join(log_path, "swanlab", log_path_suffix)
-            os.makedirs(swanlab_log_path, exist_ok=True)
+                swanlab_log_path = os.path.join(log_path, "swanlab", log_path_suffix)
+                os.makedirs(swanlab_log_path, exist_ok=True)
 
-            swanlab.init(
-                project=self.project_name,
-                experiment_name=experiment_name,
-                config=self.config,
-                logdir=swanlab_log_path,
-                mode=self.swanlab_mode,
-            )
-            logger["swanlab"] = swanlab
+                run = swanlab.init(
+                    project=self.project_name,
+                    experiment_name=experiment_name,
+                    config=self.config,
+                    logdir=swanlab_log_path,
+                    mode=self.swanlab_mode,
+                )
+                if run is None:
+                    raise RuntimeError("swanlab.init() returned no run to log to")
+                logger["swanlab"] = _RunLogger(run)
 
-        if "tensorboard" in self.logger_backends:
-            tensorboard_log_path = os.path.join(
-                log_path, "tensorboard", log_path_suffix
-            )
-            os.makedirs(tensorboard_log_path, exist_ok=True)
+            if "tensorboard" in self.logger_backends:
+                tensorboard_log_path = os.path.join(
+                    log_path, "tensorboard", log_path_suffix
+                )
+                os.makedirs(tensorboard_log_path, exist_ok=True)
 
-            config_yaml_path = os.path.join(tensorboard_log_path, "config.yaml")
-            OmegaConf.save(self.cfg, config_yaml_path, resolve=True)
+                config_yaml_path = os.path.join(tensorboard_log_path, "config.yaml")
+                OmegaConf.save(self.cfg, config_yaml_path, resolve=True)
 
-            logger["tensorboard"] = _TensorboardLogger(tensorboard_log_path)
+                logger["tensorboard"] = _TensorboardLogger(tensorboard_log_path)
+        except BaseException:
+            try:
+                _finish_backends(logger.values())
+            except Exception:  # noqa: BLE001 - keep the construction failure
+                pass
+            raise
+
         self._all_loggers.append(logger)
         return logger
 
@@ -163,15 +238,18 @@ class MetricLogger:
 
     def log_table(self, df_data, name, step):
         if "wandb" in self.logger_backends:
-            table = self.logger["wandb"].Table(dataframe=df_data)
-            self.logger["wandb"].log({name: table}, step=step)
+            self.logger["wandb"].log_table(df_data=df_data, name=name, step=step)
         else:
             raise ValueError(f"Unsupported log table for {self.logger_backends}")
 
     def __del__(self):
-        self.finish()
+        try:
+            self.finish()
+        except Exception:  # noqa: BLE001 - a destructor must not raise
+            pass
 
     def finish(self):
-        for logger in self._all_loggers:
-            for logger_instance in logger.values():
-                logger_instance.finish()
+        """Close every backend. Safe to call more than once."""
+        _finish_backends(
+            backend for logger in self._all_loggers for backend in logger.values()
+        )

--- a/rlinf/utils/runner_utils.py
+++ b/rlinf/utils/runner_utils.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import os
+import queue
 import tempfile
+import threading
+from collections.abc import Callable
 from typing import Any, Union
 
 from rlinf.utils.logging import get_logger
@@ -84,6 +87,56 @@ def local_mkdir_safe(path):
         os.makedirs(path, exist_ok=True)
 
     return path
+
+
+class AsyncMetricTableLogger:
+    """Run metric-table rendering on a background thread.
+
+    Rendering a table also uploads it to the metric backends, so runners submit
+    it instead of blocking their training loop on it. ``shutdown`` drains the
+    entries queued so far, which keeps the final step's table from being lost.
+    """
+
+    _STOP = object()
+
+    def __init__(self, log: Any, shutdown_timeout_s: float = 60.0) -> None:
+        self._log = log
+        self._shutdown_timeout_s = shutdown_timeout_s
+        self._queue: queue.Queue = queue.Queue()
+        self._stop_requested = False
+        self._thread = threading.Thread(target=self._worker, daemon=True)
+        self._thread.start()
+
+    def submit(self, func: Callable[..., None], *args: Any) -> None:
+        """Queue ``func(*args)`` for the background thread."""
+        self._queue.put((func, args))
+
+    def shutdown(self) -> None:
+        """Drain the queued entries, then stop the background thread."""
+        if not self._stop_requested:
+            self._stop_requested = True
+            # The queue is FIFO, so the sentinel is dequeued last.
+            self._queue.put(self._STOP)
+
+        self._thread.join(timeout=self._shutdown_timeout_s)
+        if self._thread.is_alive():
+            self._log.warning(
+                "Metric-table logging did not stop within %.1f seconds.",
+                self._shutdown_timeout_s,
+            )
+
+    def _worker(self) -> None:
+        while True:
+            item = self._queue.get()
+            try:
+                if item is self._STOP:
+                    return
+                func, args = item
+                func(*args)
+            except Exception as exc:  # noqa: BLE001 - keep the thread alive
+                self._log.error("Metric-table logging failed: %s", exc)
+            finally:
+                self._queue.task_done()
 
 
 class EarlyStopController:

--- a/tests/unit_tests/test_async_metric_table_logger.py
+++ b/tests/unit_tests/test_async_metric_table_logger.py
@@ -1,0 +1,190 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for asynchronous metric-table logging teardown."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from rlinf.runners.async_embodied_runner import AsyncEmbodiedRunner
+from rlinf.runners.async_ppo_embodied_runner import AsyncPPOEmbodiedRunner
+from rlinf.runners.embodied_runner import EmbodiedRunner
+from rlinf.runners.offline_runner import OfflineRunner
+from rlinf.utils.runner_utils import AsyncMetricTableLogger
+
+
+@pytest.fixture
+def table_logger():
+    logger = AsyncMetricTableLogger(logging.getLogger("test-metric-table"))
+    yield logger
+    logger.shutdown()
+
+
+def _assert_queue_drained(table_logger, timeout=2.0):
+    """Every dequeued entry must be acknowledged, or ``join`` would hang."""
+    joined = threading.Event()
+    threading.Thread(
+        target=lambda: (table_logger._queue.join(), joined.set()), daemon=True
+    ).start()
+    assert joined.wait(timeout), "queue bookkeeping did not reach zero"
+
+
+def test_a_failing_entry_is_acknowledged_and_keeps_the_thread_alive(
+    table_logger, caplog
+):
+    following_entry_ran = threading.Event()
+
+    def fail():
+        raise RuntimeError("render failed")
+
+    with caplog.at_level(logging.ERROR):
+        table_logger.submit(fail)
+        table_logger.submit(following_entry_ran.set)
+        assert following_entry_ran.wait(2.0)
+        table_logger.shutdown()
+
+    assert "Metric-table logging failed: render failed" in caplog.text
+    _assert_queue_drained(table_logger)
+
+
+def test_shutdown_drains_queued_entries_in_fifo_order(table_logger):
+    first_started = threading.Event()
+    release_first = threading.Event()
+    order = []
+
+    def first():
+        first_started.set()
+        release_first.wait()
+        order.append(0)
+
+    table_logger.submit(first)
+    table_logger.submit(order.append, 1)
+    table_logger.submit(order.append, 2)
+    assert first_started.wait(2.0)
+
+    done = threading.Event()
+    threading.Thread(
+        target=lambda: (table_logger.shutdown(), done.set()), daemon=True
+    ).start()
+    try:
+        assert not done.wait(0.05), "shutdown returned before the queue was drained"
+    finally:
+        release_first.set()
+
+    assert done.wait(2.0)
+    assert order == [0, 1, 2]
+    _assert_queue_drained(table_logger)
+
+
+def test_shutdown_is_bounded_when_an_entry_hangs(caplog):
+    table_logger = AsyncMetricTableLogger(
+        logging.getLogger("test-metric-table"), shutdown_timeout_s=0.05
+    )
+    entry_started = threading.Event()
+    release_entry = threading.Event()
+
+    table_logger.submit(lambda: (entry_started.set(), release_entry.wait()))
+    assert entry_started.wait(2.0)
+
+    try:
+        started = time.monotonic()
+        with caplog.at_level(logging.WARNING):
+            table_logger.shutdown()
+        assert time.monotonic() - started < 1.0
+        assert "did not stop within 0.1 seconds" in caplog.text
+    finally:
+        release_entry.set()
+
+    _assert_queue_drained(table_logger)
+
+
+@pytest.mark.parametrize("runner_cls", [EmbodiedRunner, OfflineRunner])
+def test_finish_run_flushes_tables_before_closing_backends(runner_cls):
+    order = []
+    runner = object.__new__(runner_cls)
+    runner.metric_table_logger = SimpleNamespace(
+        shutdown=lambda: order.append("shutdown")
+    )
+    runner.metric_logger = SimpleNamespace(finish=lambda: order.append("finish"))
+
+    runner._finish_run()
+
+    assert order == ["shutdown", "finish"]
+
+
+@pytest.mark.parametrize(
+    "run_method,update_weights,expected_stops",
+    [
+        pytest.param(
+            AsyncEmbodiedRunner.run,
+            lambda no_wait: None,
+            ["stop-env", "stop-rollout", "stop-actor"],
+            id="async-embodied",
+        ),
+        pytest.param(
+            AsyncPPOEmbodiedRunner.run,
+            lambda: None,
+            ["stop-env", "stop-rollout"],
+            id="async-ppo",
+        ),
+    ],
+)
+def test_async_runners_finish_logging_before_stopping_workers(
+    run_method, update_weights, expected_stops
+):
+    events = []
+
+    class _Handle:
+        def wait(self):
+            return None
+
+    class _WorkerGroup:
+        def __init__(self, name):
+            self.name = name
+
+        def __getattr__(self, _name):
+            return lambda *_args, **_kwargs: _Handle()
+
+        def stop(self):
+            events.append(f"stop-{self.name}")
+            return _Handle()
+
+    runner = SimpleNamespace(
+        global_step=0,
+        max_steps=0,
+        actor=_WorkerGroup("actor"),
+        rollout=_WorkerGroup("rollout"),
+        env=_WorkerGroup("env"),
+        reward=None,
+        actor_channel=object(),
+        rollout_channel=object(),
+        env_channel=object(),
+        reward_channel=None,
+        env_metric_channel=object(),
+        rollout_metric_channel=object(),
+        sync_weight_no_wait=False,
+        update_rollout_weights=update_weights,
+        _finish_run=lambda: events.append("finish"),
+    )
+
+    run_method(runner)
+
+    assert events[0] == "finish"
+    assert events[1:] == expected_stops

--- a/tests/unit_tests/test_metric_logger_reliability.py
+++ b/tests/unit_tests/test_metric_logger_reliability.py
@@ -1,0 +1,200 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metric backend ownership and teardown regression tests."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+from omegaconf import OmegaConf
+
+from rlinf.utils.metric_logger import MetricLogger, _RunLogger
+
+
+class _FakeRun:
+    def __init__(self, name: str):
+        self.name = name
+        self.logged = []
+        self.finish_count = 0
+
+    def log(self, data, step=None):
+        self.logged.append((data, step))
+
+    def finish(self):
+        self.finish_count += 1
+
+
+class _FailingRun(_FakeRun):
+    def finish(self):
+        super().finish()
+        raise RuntimeError("finish failed")
+
+
+class _FakeWandb(ModuleType):
+    class Table:
+        def __init__(self, dataframe=None):
+            self.dataframe = dataframe
+
+    def __init__(self):
+        super().__init__("wandb")
+        self.init_calls = []
+        self.runs = []
+
+    def init(self, **kwargs):
+        self.init_calls.append(kwargs)
+        run = _FakeRun(kwargs["name"])
+        self.runs.append(run)
+        return run
+
+
+class _FakeSwanlab(ModuleType):
+    def __init__(self, *, init_error: BaseException | None = None):
+        super().__init__("swanlab")
+        self.init_error = init_error
+        self.init_calls = []
+        self.runs = []
+
+    def init(self, **kwargs):
+        self.init_calls.append(kwargs)
+        if self.init_error is not None:
+            raise self.init_error
+        run = _FakeRun(kwargs["experiment_name"])
+        self.runs.append(run)
+        return run
+
+
+def _cfg(tmp_path, backends, *, per_worker: bool = False):
+    return OmegaConf.create(
+        {
+            "runner": {
+                "per_worker_log": per_worker,
+                "logger": {
+                    "log_path": str(tmp_path),
+                    "project_name": "test-project",
+                    "experiment_name": "aggregate",
+                    "logger_backends": backends,
+                },
+            }
+        }
+    )
+
+
+def test_per_worker_wandb_logs_stay_with_their_owning_runs(tmp_path, monkeypatch):
+    wandb = _FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", wandb)
+    logger = MetricLogger(_cfg(tmp_path, ["wandb"], per_worker=True))
+
+    logger.log({"loss": 3.0}, step=1)
+    logger.log({"loss": 2.0}, step=1, worker_group_name="actor", rank=0)
+    logger.log({"loss": 1.0}, step=1, worker_group_name="actor", rank=1)
+
+    assert [call["reinit"] for call in wandb.init_calls] == ["create_new"] * 3
+    assert [run.logged for run in wandb.runs] == [
+        [({"loss": 3.0}, 1)],
+        [({"loss": 2.0}, 1)],
+        [({"loss": 1.0}, 1)],
+    ]
+
+    logger.log_table([[1]], "samples", step=2)
+    table_data, table_step = wandb.runs[0].logged[-1]
+    assert table_step == 2
+    assert table_data["samples"].dataframe == [[1]]
+
+    logger.finish()
+    logger.finish()
+    logger.__del__()
+    assert [run.finish_count for run in wandb.runs] == [1, 1, 1]
+
+
+def test_single_wandb_run_preserves_existing_reinit_behavior(tmp_path, monkeypatch):
+    wandb = _FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", wandb)
+
+    MetricLogger(_cfg(tmp_path, ["wandb"]))
+
+    assert wandb.init_calls[0]["reinit"] is True
+
+
+def test_per_worker_swanlab_is_rejected_before_initialization(tmp_path, monkeypatch):
+    swanlab = _FakeSwanlab()
+    monkeypatch.setitem(sys.modules, "swanlab", swanlab)
+
+    with pytest.raises(ValueError, match="one active run per process"):
+        MetricLogger(_cfg(tmp_path, ["swanlab"], per_worker=True))
+
+    assert swanlab.init_calls == []
+
+
+def test_single_swanlab_run_uses_its_returned_handle(tmp_path, monkeypatch):
+    swanlab = _FakeSwanlab()
+    monkeypatch.setitem(sys.modules, "swanlab", swanlab)
+    logger = MetricLogger(_cfg(tmp_path, ["swanlab"]))
+
+    logger.log({"reward": 0.5}, step=4)
+    logger.finish()
+    logger.finish()
+
+    assert swanlab.runs[0].logged == [({"reward": 0.5}, 4)]
+    assert swanlab.runs[0].finish_count == 1
+
+
+@pytest.mark.parametrize(
+    "init_error", [RuntimeError("swanlab init failed"), KeyboardInterrupt()]
+)
+def test_failed_backend_construction_closes_initialized_runs(
+    tmp_path, monkeypatch, init_error
+):
+    wandb = _FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", wandb)
+    monkeypatch.setitem(sys.modules, "swanlab", _FakeSwanlab(init_error=init_error))
+
+    with pytest.raises(type(init_error)):
+        MetricLogger(_cfg(tmp_path, ["wandb", "swanlab"]))
+
+    assert wandb.runs[0].finish_count == 1
+
+
+def test_backend_teardown_runs_once_but_retries_after_a_failure():
+    healthy = _RunLogger(_FakeRun("healthy"))
+    healthy.finish()
+    healthy.finish()
+    assert healthy.run.finish_count == 1
+
+    failing = _RunLogger(_FailingRun("failing"))
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="finish failed"):
+            failing.finish()
+    assert failing.run.finish_count == 2
+
+
+def test_finish_closes_every_backend_before_reporting_a_failure(tmp_path):
+    logger = MetricLogger(_cfg(tmp_path, []))
+    failing = _RunLogger(_FailingRun("failing"))
+    healthy = _RunLogger(_FakeRun("healthy"))
+    logger.logger.update(failing=failing, healthy=healthy)
+
+    with pytest.raises(RuntimeError, match="finish failed"):
+        logger.finish()
+
+    assert healthy.run.finish_count == 1
+
+    logger.__del__()  # swallows the still-failing backend
+    assert healthy.run.finish_count == 1
+
+
+def test_destructor_is_safe_for_an_uninitialized_metric_logger():
+    MetricLogger.__new__(MetricLogger).__del__()


### PR DESCRIPTION
### Description

**1. `fix(metrics): bind each metric backend to the run it created`**

`_create_logger_bundle` stored the imported `wandb` / `swanlab` **module**, so every
logger logged through the process-global run — whichever was initialized last. Bundles
now hold the run object returned by `init`, per-worker W&B runs are created with
`reinit="create_new"` so concurrent runs stay independent, and `per_worker_log` with
SwanLab is rejected up front, since SwanLab allows only one active run per process.

Teardown is hardened along the way: a bundle that fails halfway through construction
closes what it already opened, `finish()` closes every backend before re-raising the
first failure instead of stopping at it, and repeated calls (as from `__del__`) are safe.

**2. `fix(runner): drain queued metric tables before shutting down`**

The embodied and offline runners render metric tables on a background thread. That
thread skipped `task_done()` when a callback raised, so the `log_queue.join()` in
teardown blocked forever after a single rendering error; it also exited as soon as
`stop_logging` was set, which could leave queued entries unacknowledged and hang the
same `join()`.

It is now stopped with a FIFO sentinel so entries queued before shutdown are still
rendered, dequeued work is always acknowledged, and the join is bounded with a warning
if a callback hangs. Both runners carried a verbatim copy of the thread, so it moved
into `AsyncMetricTableLogger` (`rlinf/utils/runner_utils.py`). Two call sites were wrong
as well: `AsyncPPOEmbodiedRunner` finished the metric logger *before* draining the queue,
logging the last tables into an already-finished W&B run, and `AsyncEmbodiedRunner` never
finished the logger or the thread at all. Both now go through `_finish_run()`.

### Motivation and Context

`runner.per_worker_log` does not currently produce usable per-worker metrics: all workers
write into one run. Separately, any exception raised while rendering a metric table
deadlocks the end of training, and runs that finish normally can still lose their final
tables or leave the W&B run unfinished (shown as crashed in the UI).

### How has this been tested?

New unit tests covering run ownership, backend construction and teardown failures, table
entries that raise or hang, FIFO drain order, and both async embodied runners finishing
logging before stopping workers. Run on CPU with Python 3.12:

```bash
pytest tests/unit_tests/test_metric_logger_reliability.py tests/unit_tests/test_async_metric_table_logger.py
# 16 passed
```

`ruff check` and `ruff format --check` are clean.

### Additional information (optional, e.g., figures and logs):

Behavior changes worth flagging for review:

- `pyproject.toml` raises the W&B floor to `wandb>=0.19.10,<0.25.1`; `reinit="create_new"`
  was added in 0.19.10.
- `runner.per_worker_log` together with the `swanlab` backend now raises at startup instead
  of silently funnelling all workers into one run. Documented in
  `docs/source-{en,zh}/rst_source/guides/logger.rst`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.