### PR TITLE
feat(robotwin): expose native environment capabilities

### DIFF
--- a/rlinf/envs/robotwin/robotwin_env.py
+++ b/rlinf/envs/robotwin/robotwin_env.py
@@ -14,7 +14,7 @@
 
 import json
 import os
-from typing import Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import gymnasium as gym
 import numpy as np
@@ -25,6 +25,50 @@ from PIL import Image
 
 from rlinf.envs.robotwin.seed_utils import partition_success_seeds
 from rlinf.envs.utils import center_crop_image, list_of_dict_to_dict_of_list
+
+
+def _camera_depth(camera: Any) -> np.ndarray:
+    position = camera.get_picture("Position")
+    invalid = position[..., 3] >= 1
+    depth = (-position[..., 2]).astype(np.float32)
+    depth[invalid] = np.nan
+    return depth
+
+
+def _camera_meta(camera: Any) -> dict[str, Any]:
+    return {
+        "intrinsic_K": np.asarray(camera.get_intrinsic_matrix()),
+        "extrinsic_cv": np.asarray(camera.get_extrinsic_matrix()),
+        "cam2world_gl": np.asarray(camera.get_model_matrix()),
+        "width": int(camera.get_width()),
+        "height": int(camera.get_height()),
+    }
+
+
+def _validate_actions(
+    actions: Any, *, action_type: Literal["qpos", "ee"]
+) -> np.ndarray:
+    if action_type not in ("qpos", "ee"):
+        raise ValueError("action_type must be 'qpos' or 'ee'")
+    array = np.asarray(actions, dtype=np.float64)
+    if array.ndim == 1:
+        array = array[None, :]
+    expected_dim = 14 if action_type == "qpos" else 16
+    if array.ndim != 2 or array.shape[0] < 1 or array.shape[1] != expected_dim:
+        raise ValueError(
+            f"{action_type} actions must have shape [N,{expected_dim}], N >= 1"
+        )
+    if not np.isfinite(array).all():
+        raise ValueError(f"{action_type} actions must contain only finite values")
+    return array
+
+
+def _execution_should_stop(status: dict[str, Any]) -> bool:
+    step_limit = status["step_lim"]
+    return status["eval_success"] or (
+        step_limit is not None and status["take_action_cnt"] >= step_limit
+    )
+
 
 __all__ = ["RoboTwinEnv"]
 
@@ -90,6 +134,213 @@ class RoboTwinEnv(gym.Env):
             n_envs=self.num_envs,
             env_seeds=env_seeds,
         )
+
+    def _sub_env(self, env_id: int) -> Any:
+        if not 0 <= env_id < len(self.venv.envs):
+            raise IndexError(f"invalid RoboTwin env_id: {env_id}")
+        return self.venv.envs[env_id]
+
+    def _read_episode_status(self, sub_env: Any) -> dict[str, Any]:
+        """Read native status; the caller must hold ``sub_env.lock``."""
+        task = sub_env.task
+        step_limit = getattr(task, "step_lim", None)
+        if step_limit is None:
+            task_args = getattr(sub_env, "args", None)
+            if isinstance(task_args, dict):
+                step_limit = task_args.get("step_lim")
+            elif task_args is not None:
+                step_limit = getattr(task_args, "step_lim", None)
+        if step_limit is None:
+            cfg_get = getattr(self.cfg, "get", None)
+            step_limit = (
+                cfg_get("max_episode_steps", None)
+                if callable(cfg_get)
+                else getattr(self.cfg, "max_episode_steps", None)
+            )
+        actual_seed = getattr(task, "ep_num", None)
+        if actual_seed is None:
+            actual_seed = getattr(sub_env, "env_seed", None)
+        return {
+            "eval_success": bool(getattr(task, "eval_success", False)),
+            "take_action_cnt": int(getattr(task, "take_action_cnt", 0)),
+            "step_lim": int(step_limit) if step_limit is not None else None,
+            "actual_seed": int(actual_seed),
+        }
+
+    def execute_action_chunk(
+        self,
+        actions: Any,
+        *,
+        action_type: Literal["qpos", "ee"],
+        env_id: int = 0,
+    ) -> dict[str, Any]:
+        array = _validate_actions(actions, action_type=action_type)
+        sub_env = self._sub_env(env_id)
+        executed = 0
+        with sub_env.lock:
+            for action in array:
+                status = self._read_episode_status(sub_env)
+                if _execution_should_stop(status):
+                    break
+                before = status["take_action_cnt"]
+                sub_env.task.take_action(action, action_type=action_type)
+                after = int(getattr(sub_env.task, "take_action_cnt", 0))
+                if after > before:
+                    executed += 1
+            episode_status = self._read_episode_status(sub_env)
+        return {
+            "action_type": action_type,
+            "requested_actions": int(len(array)),
+            "executed_actions": executed,
+            "episode_status": episode_status,
+        }
+
+    def _get_camera(self, sub_env: Any, camera_name: str) -> Any:
+        """Resolve a native camera; the caller must hold ``sub_env.lock``."""
+        cameras = sub_env.task.cameras
+        result: dict[str, Any] = {}
+        for camera, name in zip(cameras.static_camera_list, cameras.static_camera_name):
+            if name == "head_camera":
+                result["head"] = camera
+                break
+        if bool(getattr(cameras, "collect_wrist_camera", False)):
+            result["left_wrist"] = cameras.left_camera
+            result["right_wrist"] = cameras.right_camera
+        try:
+            return result[camera_name]
+        except KeyError as error:
+            available = sorted(result)
+            raise ValueError(
+                f"unknown RoboTwin camera {camera_name!r}; available={available}"
+            ) from error
+
+    def render_camera(
+        self,
+        camera_name: str,
+        *,
+        depth: bool = False,
+        env_id: int = 0,
+    ) -> Any:
+        sub_env = self._sub_env(env_id)
+        with sub_env.lock:
+            native_observation = sub_env.task.get_obs()["observation"]
+            camera_keys = {
+                "head": "head_camera",
+                "left_wrist": "left_camera",
+                "right_wrist": "right_camera",
+            }
+            camera = self._get_camera(sub_env, camera_name)
+            rgb = native_observation[camera_keys[camera_name]]["rgb"]
+            if not depth:
+                return rgb
+            return rgb, _camera_depth(camera)
+
+    def get_camera_meta(self, camera_name: str, env_id: int = 0) -> dict[str, Any]:
+        sub_env = self._sub_env(env_id)
+        with sub_env.lock:
+            return _camera_meta(self._get_camera(sub_env, camera_name))
+
+    def get_task_language(self, env_id: int = 0) -> str:
+        sub_env = self._sub_env(env_id)
+        with sub_env.lock:
+            return str(sub_env.task.get_instruction())
+
+    def get_robot_state(self, env_id: int = 0) -> dict[str, Any]:
+        sub_env = self._sub_env(env_id)
+        with sub_env.lock:
+            robot = sub_env.task.robot
+            left_target = robot.get_left_arm_jointState()
+            right_target = robot.get_right_arm_jointState()
+            left_real = robot.get_left_arm_real_jointState()
+            right_real = robot.get_right_arm_real_jointState()
+            return {
+                "left_eef_pose": np.asarray(robot.get_left_ee_pose(), dtype=np.float64),
+                "right_eef_pose": np.asarray(
+                    robot.get_right_ee_pose(), dtype=np.float64
+                ),
+                "left_tcp_pose": np.asarray(
+                    robot.get_left_tcp_pose(), dtype=np.float64
+                ),
+                "right_tcp_pose": np.asarray(
+                    robot.get_right_tcp_pose(), dtype=np.float64
+                ),
+                "left_gripper": float(robot.get_left_gripper_val()),
+                "right_gripper": float(robot.get_right_gripper_val()),
+                "qpos_target14": np.asarray(
+                    left_target + right_target, dtype=np.float64
+                ),
+                "arm_qpos_real12": np.asarray(
+                    left_real[:-1] + right_real[:-1], dtype=np.float64
+                ),
+            }
+
+    def get_episode_status(self, env_id: int = 0) -> dict[str, Any]:
+        sub_env = self._sub_env(env_id)
+        with sub_env.lock:
+            return self._read_episode_status(sub_env)
+
+    def plan_arm_path(
+        self,
+        env_id: int,
+        arm: Literal["left", "right"],
+        target_pose: Any,
+    ) -> dict[str, Any]:
+        if arm not in ("left", "right"):
+            raise ValueError("arm must be 'left' or 'right'")
+        target = np.asarray(target_pose, dtype=np.float64)
+        if target.shape != (7,):
+            raise ValueError("target_pose must have shape (7,)")
+        if not np.isfinite(target).all():
+            raise ValueError("target_pose must contain only finite values")
+        sub_env = self._sub_env(env_id)
+        with sub_env.lock:
+            planner = (
+                sub_env.task.robot.left_plan_path
+                if arm == "left"
+                else sub_env.task.robot.right_plan_path
+            )
+            result = planner(target.tolist())
+            return {
+                "status": result.get("status", "Unknown"),
+                "position": (
+                    np.asarray(result["position"], dtype=np.float64)
+                    if result.get("position") is not None
+                    else None
+                ),
+                "velocity": (
+                    np.asarray(result["velocity"], dtype=np.float64)
+                    if result.get("velocity") is not None
+                    else None
+                ),
+            }
+
+    def reset_exact(
+        self, env_id: int, seed: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Reset native state and synchronize RLinf training bookkeeping."""
+        requested_seed = int(seed)
+        sub_env = self._sub_env(env_id)
+        self.venv.reset(env_idx=[env_id], env_seeds=[requested_seed])
+        with sub_env.lock:
+            instruction = sub_env.task.get_instruction()
+            native_status = self._read_episode_status(sub_env)
+            actual_seed = native_status["actual_seed"]
+        if actual_seed != requested_seed:
+            raise RuntimeError(
+                "RoboTwin exact seed mismatch: "
+                f"requested {requested_seed}, initialized {actual_seed}"
+            )
+        result = {
+            "requested_seed": requested_seed,
+            "actual_seed": actual_seed,
+            "instruction": instruction,
+            "episode_status": native_status,
+        }
+        self.reset_state_ids[env_id] = actual_seed
+        self._is_start = False
+        self._reset_metrics([env_id])
+        observation = self._extract_obs_image(self.venv.get_obs())
+        return observation, result
 
     @property
     def device(self):


### PR DESCRIPTION
### Description

Expose stable RoboTwin native environment capabilities for downstream runtimes while preserving the existing training paths.

- Execute native RoboTwin action chunks with qpos14 or EEF16 actions.
- Expose robot state, native episode status, and arm path planning.
- Expose raw RGB/depth rendering, camera calibration metadata, and task language.
- Support exact-seed reset while synchronizing RLinf training bookkeeping.

### Motivation and Context

Downstream integrations should use stable RLinf environment APIs instead of accessing private RoboTwin task, robot, camera, or planner objects directly.

RLinf remains the owner of the native RoboTwin environment and simulator-specific capabilities. Higher-level Agent observation assembly, primitive composition, and episode lifecycle handling are owned by downstream runtimes such as RPent.

### How has this been tested?

- Ruff, format, compilation, and deterministic API contract checks.
- RoboTwin common reset/step/chunk execution and exact-seed reset.
- Raw RGB/depth rendering and camera metadata checks.
- Native qpos14 and EEF16 action execution, robot-state access, episode status, and arm planning.
- End-to-end RPent integration smoke with LingBot-VLA and clean process shutdown.
- Latest source-overlay integration run completed 25 cases across 5 RoboTwin tasks and verified task-specific native action budgets.

### Additional information

The existing training `reset()`, `step()`, and `chunk_step()` paths are unchanged.

Episode-level terminal tracking and higher-level Agent lifecycle handling are intentionally kept outside RLinf.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.