### PR TITLE
feat(docs): add docs check harness

### DIFF
--- a/.claude/skills/docs-check/SKILL.md
+++ b/.claude/skills/docs-check/SKILL.md
@@ -15,6 +15,17 @@ Use this skill when documentation changes may introduce mismatches with:
 
 Always read `reference.md` first, then run the workflow below.
 
+Two harnesses in this folder do the mechanical part; run them before reasoning
+about content:
+
+```bash
+# Does the page still build? Both Read the Docs projects use fail_on_warning.
+python3 .claude/skills/docs-check/build_docs.py            # en + zh
+
+# Does CJK punctuation break inline markup, loudly or silently?
+python3 .claude/skills/docs-check/check_rst_markup.py      # needs docutils
+```
+
 ## Inputs
 
 Collect these inputs before reviewing:
@@ -33,25 +44,36 @@ If scope is unclear, default to checking:
 ## Workflow
 
 1. Read `reference.md` and extract the relevant checklist items.
-2. Verify doc-to-code correctness:
+2. Run the build harness for **both** languages and fix every warning:
+   - `python3 .claude/skills/docs-check/build_docs.py` (add `--lang zh` to
+     iterate faster on a Chinese-only failure).
+   - The two Read the Docs projects build independently with
+     `fail_on_warning: true`, so an English-clean page can still turn
+     `docs/readthedocs.org:rlinf-cn` red. Never conclude "docs are fine"
+     from one language.
+   - Then `python3 .claude/skills/docs-check/check_rst_markup.py` for the
+     inline-markup defects that render wrong *without* warning.
+3. Verify doc-to-code correctness:
    - Commands exist and are runnable in principle.
    - Script/module paths in docs exist.
    - Config keys and values match real code/config names.
    - Model/env names match `SupportedModel` and `SupportedEnvType` string values.
-3. Verify doc-to-doc consistency within one language:
+4. Verify doc-to-doc consistency within one language:
    - Terminology is consistent across start/tutorials/examples/API pages.
    - New page is linked in the correct index/toctree.
    - No conflicting instructions between related pages.
    - Internal doc links use stable `:doc:`/relative links, not hardcoded ReadTheDocs URLs.
-4. Verify EN-ZH parity:
+5. Verify EN-ZH parity:
    - Same topic coverage and section structure.
    - Same commands, config keys, and model/env identifiers.
    - Translations preserve technical meaning (do not rename code symbols).
    - Corresponding EN/ZH pages use equivalent stable internal links.
-5. Report findings with severity and concrete fixes.
+6. Report findings with severity and concrete fixes.
 
 ## Severity Rules
 
+- `Critical`: A Sphinx warning in either language — Read the Docs fails the
+  build, so the page does not ship at all.
 - `Critical`: Wrong command/path/key/value that can break user workflow.
 - `Major`: Inconsistent docs that likely mislead users.
 - `Minor`: Wording/terminology drift without immediate breakage.
@@ -102,6 +124,13 @@ Use this regex scan to detect unstable hardcoded RLinf docs links:
 
 - `readthedocs\.io/(en|zh-cn)/latest/rst_source/`
 
+Chinese pages: `` `` `` or `**` sitting directly against `（`, `《` or a CJK
+character is the single most common way to break `rlinf-cn`. Grep for
+```` ``（ ```` and ```` **（ ```` as a first pass, then run
+`check_rst_markup.py` for the full rule.
+
 ## Additional Resource
 
 - Detailed checklist and paths: [reference.md](reference.md)
+- Local Read the Docs gate for both languages: [build_docs.py](build_docs.py)
+- Inline-markup checker: [check_rst_markup.py](check_rst_markup.py)

--- a/.claude/skills/docs-check/build_docs.py
+++ b/.claude/skills/docs-check/build_docs.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reproduce the Read the Docs build gate locally, for both languages.
+
+``docs/source-en/.readthedocs.yaml`` and ``docs/source-zh/.readthedocs.yaml``
+both set ``fail_on_warning: true``, so *any* Sphinx warning turns the
+``docs/readthedocs.org:rlinf`` or ``:rlinf-cn`` check red.  The two projects
+build independently, so a warning that only the Chinese page triggers — a
+CJK punctuation problem, a missing ZH counterpart, a broken ``:doc:`` target
+— fails ``rlinf-cn`` while ``rlinf`` stays green.  Always build **both**.
+
+This script provisions a docs-only virtualenv from
+``requirements/docs/requirements.txt``, builds each language, and reports the
+warnings that would fail Read the Docs.  Autodoc import failures are filtered
+by default: the docs venv deliberately does not install torch, so every
+``.. autoclass::`` fails locally in a way it never does on Read the Docs.
+Pass ``--strict-autodoc`` (in a full environment) to see them.
+
+Usage::
+
+    python3 .claude/skills/docs-check/build_docs.py             # en + zh
+    python3 .claude/skills/docs-check/build_docs.py --lang zh
+    python3 .claude/skills/docs-check/build_docs.py --keep-output
+
+Exit code is 1 when either language reports a warning, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Emitted for every autodoc target when the package itself is not installed.
+AUTODOC_NOISE = re.compile(
+    r"WARNING: autodoc: failed to import .*"
+    r"|^No module named .*\[autodoc\.import_object\]"
+    r"|^\s*the following exception was raised:",
+    re.MULTILINE,
+)
+# A warning record starts at "<path>:<line>: WARNING" or a bare "WARNING:".
+RECORD_START = re.compile(r"^(?:\S+:\d+: )?(?:WARNING|ERROR|SEVERE)[:\s]")
+
+
+def repo_root() -> Path:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(out.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+def ensure_venv(venv: Path, requirements: Path) -> Path:
+    """Create the docs venv if needed and return its python."""
+    python = venv / "bin" / "python"
+    if python.exists():
+        probe = subprocess.run(
+            [str(python), "-c", "import sphinx"], capture_output=True
+        )
+        if probe.returncode == 0:
+            return python
+    else:
+        print(f"[build_docs] creating {venv}")
+        if shutil.which("uv"):
+            subprocess.run(["uv", "venv", str(venv), "--python", "3.11"], check=True)
+        else:
+            subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
+
+    print(f"[build_docs] installing {requirements.name}")
+    env = {**os.environ, "UV_HTTP_TIMEOUT": "180"}
+    if shutil.which("uv"):
+        subprocess.run(
+            ["uv", "pip", "install", "--python", str(python), "-r", str(requirements)],
+            check=True,
+            env=env,
+        )
+    else:
+        subprocess.run(
+            [str(python), "-m", "pip", "install", "-q", "-r", str(requirements)],
+            check=True,
+        )
+    return python
+
+
+def split_records(stderr: str) -> list[str]:
+    """Group Sphinx's stderr into one string per warning."""
+    records: list[str] = []
+    for line in stderr.splitlines():
+        if RECORD_START.match(line) or not records:
+            records.append(line)
+        else:
+            records[-1] += "\n" + line
+    return [r for r in records if r.strip()]
+
+
+def build(python: Path, source: Path, output: Path, strict_autodoc: bool) -> list[str]:
+    """Build one language and return the warnings that matter."""
+    result = subprocess.run(
+        [
+            str(python.parent / "sphinx-build"),
+            "-b",
+            "html",
+            "-q",
+            str(source),
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
+    )
+    records = split_records(result.stderr)
+    if not strict_autodoc:
+        records = [r for r in records if not AUTODOC_NOISE.search(r)]
+    if result.returncode != 0 and not records:
+        records.append(
+            f"sphinx-build exited {result.returncode}\n{result.stdout[-2000:]}"
+        )
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--lang", choices=("en", "zh", "both"), default="both")
+    parser.add_argument(
+        "--venv",
+        type=Path,
+        default=os.environ.get("DOCS_VENV"),
+        help="virtualenv to build in (default: <repo>/.docs-venv)",
+    )
+    parser.add_argument(
+        "--strict-autodoc",
+        action="store_true",
+        help="keep autodoc import warnings (only useful in a full env)",
+    )
+    parser.add_argument(
+        "--keep-output", action="store_true", help="keep the generated HTML"
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    venv = args.venv or root / ".docs-venv"
+    python = ensure_venv(venv, root / "requirements" / "docs" / "requirements.txt")
+
+    languages = ("en", "zh") if args.lang == "both" else (args.lang,)
+    destination = (
+        root / "docs" / "build" / "check"
+        if args.keep_output
+        else Path(tempfile.mkdtemp(prefix="rlinf-docs-"))
+    )
+
+    total = 0
+    for language in languages:
+        source = root / "docs" / f"source-{language}"
+        print(f"[build_docs] building {source.name}")
+        records = build(python, source, destination / language, args.strict_autodoc)
+        total += len(records)
+        for record in records:
+            print(record)
+        print(f"[build_docs] {source.name}: {len(records)} warning(s)")
+
+    if not args.keep_output:
+        shutil.rmtree(destination, ignore_errors=True)
+
+    if total:
+        print(
+            f"\n{total} warning(s) — Read the Docs builds with fail_on_warning, "
+            f"so this fails the docs check.",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nBoth builds are clean." if len(languages) > 1 else "\nBuild is clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/docs-check/check_rst_markup.py
+++ b/.claude/skills/docs-check/check_rst_markup.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check RST inline markup against the docutils recognition rules.
+
+docutils only recognises inline markup when the start-string is preceded by
+whitespace, an *opener* or a *delimiter*, and the end-string is followed by
+whitespace, a *closer* or a *delimiter*.  Full-width CJK punctuation splits
+across those classes in ways that are easy to get wrong:
+
+    （《        openers  -> fine before markup, NOT allowed after it
+    ）》”’      closers  -> fine after markup
+    ，、：；。—  delimiters -> fine on either side
+
+So a Chinese page that writes ``` ``KEY``（说明） ``` produces
+
+    WARNING: Inline literal start-string without end-string. [docutils]
+
+which fails the build because both Read the Docs projects set
+``fail_on_warning: true`` — and the English page with ASCII parentheses is
+unaffected, so the failure shows up as "only the CN docs are broken".
+
+The nastier variant is silent: when a *later* end-string candidate in the same
+paragraph does satisfy the suffix rule, docutils closes the literal there and
+swallows the intervening prose into the code span.  No warning, wrong page.
+
+This script reports both, plus start-strings that CJK text renders inert
+(``通常**并不是**`` renders as literal asterisks).  The fix in every case is an
+escaped space — ``\\ `` — between the markup and the adjacent character, the
+convention already used across ``docs/source-zh``.
+
+Requires ``docutils`` (``pip install docutils``), whose own punctuation tables
+drive the check so it cannot drift from the parser.
+
+Usage::
+
+    python3 .claude/skills/docs-check/check_rst_markup.py            # all docs
+    python3 .claude/skills/docs-check/check_rst_markup.py FILE...    # subset
+    python3 .claude/skills/docs-check/check_rst_markup.py --errors-only
+
+Exit code is 1 when any ERROR is reported, 0 otherwise (warnings pass).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_ROOTS = ("docs/source-en", "docs/source-zh")
+
+# Directives whose body is verbatim text, not RST.
+LITERAL_DIRECTIVES = frozenset(
+    {
+        "code",
+        "code-block",
+        "highlight",
+        "literalinclude",
+        "math",
+        "parsed-literal",
+        "raw",
+        "sourcecode",
+    }
+)
+
+
+def _character_classes() -> tuple[re.Pattern[str], re.Pattern[str]]:
+    """Build the character classes docutils uses around inline markup.
+
+    ``Inliner.init_customizations`` interpolates the ``punctuation_chars``
+    tables straight into a regex character class, which is not the same as
+    membership in those tables — the tables contain ``-`` and so form ranges.
+    Reusing the exact expressions keeps this check faithful to the parser.
+    """
+    try:
+        from docutils.utils import punctuation_chars as pc
+    except ImportError:  # pragma: no cover - environment problem, not a finding
+        sys.exit("error: this check needs docutils; run 'pip install docutils'")
+
+    prefix = re.compile("[\\s%s%s]" % (pc.openers, pc.delimiters))
+    suffix = re.compile(
+        "[\\s\x00%s%s%s]" % (pc.closing_delimiters, pc.delimiters, pc.closers)
+    )
+    return prefix, suffix
+
+
+START_PREFIX_RE, END_SUFFIX_RE = _character_classes()
+
+
+@dataclass
+class Finding:
+    path: Path
+    line: int
+    level: str  # "ERROR" or "WARNING"
+    marker: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line}: {self.level}: {self.message}"
+
+
+@dataclass
+class Block:
+    """A paragraph of prose, flattened to one string with a line map."""
+
+    text: str
+    starts: list[int]  # index in `text` where each source line begins
+    lines: list[int]  # 1-based source line number of each source line
+
+    def line_of(self, index: int) -> int:
+        line = self.lines[0]
+        for start, number in zip(self.starts, self.lines):
+            if start > index:
+                break
+            line = number
+        return line
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def prose_blocks(source: str) -> list[Block]:
+    """Split a document into paragraphs, dropping verbatim blocks.
+
+    Skipped: comments, the bodies of literal directives, literal blocks
+    introduced by a trailing ``::``, and doctest blocks.
+    """
+    lines = source.splitlines()
+    blocks: list[Block] = []
+    buffer: list[tuple[int, str]] = []
+    skip_above: int | None = None  # skip lines indented deeper than this
+    pending_literal = False
+
+    def flush() -> None:
+        nonlocal buffer
+        if not buffer:
+            return
+        text_parts, starts, numbers, cursor = [], [], [], 0
+        for number, line in buffer:
+            starts.append(cursor)
+            numbers.append(number)
+            text_parts.append(line)
+            cursor += len(line) + 1
+        blocks.append(Block("\n".join(text_parts), starts, numbers))
+        buffer = []
+
+    for number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+
+        if skip_above is not None:
+            if not stripped or _indent(line) > skip_above:
+                continue
+            skip_above = None
+
+        if not stripped:
+            flush()
+            if pending_literal:
+                skip_above = _indent(lines[number - 2]) if number >= 2 else 0
+                pending_literal = False
+            continue
+
+        if stripped.startswith(".."):
+            flush()
+            name = stripped[2:].strip().split("::", 1)[0].strip()
+            is_comment = "::" not in stripped[2:]
+            if is_comment or name in LITERAL_DIRECTIVES:
+                skip_above = _indent(line)
+            continue
+
+        if stripped.startswith(">>>"):
+            flush()
+            skip_above = _indent(line)
+            continue
+
+        buffer.append((number, line))
+        # A trailing "::" introduces a literal block after the blank line.
+        pending_literal = stripped.endswith("::")
+
+    flush()
+    return blocks
+
+
+def _escaped(text: str, index: int) -> bool:
+    backslashes = 0
+    while index - backslashes - 1 >= 0 and text[index - backslashes - 1] == "\\":
+        backslashes += 1
+    return backslashes % 2 == 1
+
+
+def _occurrences(text: str, marker: str) -> list[int]:
+    found, index = [], text.find(marker)
+    while index != -1:
+        if not _escaped(text, index):
+            found.append(index)
+        index = text.find(marker, index + len(marker))
+    return found
+
+
+def _valid_start(text: str, index: int, marker: str) -> bool:
+    after = index + len(marker)
+    if after >= len(text) or text[after].isspace():
+        return False
+    if index == 0:
+        return True
+    return START_PREFIX_RE.match(text[index - 1]) is not None
+
+
+def _valid_end(text: str, index: int, marker: str) -> bool:
+    if index == 0 or text[index - 1].isspace():
+        return False
+    after = index + len(marker)
+    if after >= len(text):
+        return True
+    return END_SUFFIX_RE.match(text[after]) is not None
+
+
+def _describe(char: str) -> str:
+    name = unicodedata.name(char, "unnamed")
+    return f"{char!r} (U+{ord(char):04X} {name})"
+
+
+MARKERS = {"``": "Inline literal", "**": "Strong emphasis"}
+
+
+def _markers_in(text: str) -> list[tuple[int, str]]:
+    """All unescaped marker occurrences, in document order."""
+    found: list[tuple[int, str]] = []
+    for marker in MARKERS:
+        for index in _occurrences(text, marker):
+            if marker == "**" and text[index : index + 3] == "***":
+                continue  # docutils never reads "***" as strong
+            found.append((index, marker))
+    return sorted(found)
+
+
+def check_block(path: Path, block: Block) -> list[Finding]:
+    """Emulate the docutils inline scan over one paragraph.
+
+    RST inline markup does not nest: whatever sits between a start-string and
+    its end-string is the construct's text, so the scan jumps over a matched
+    span instead of looking inside it.  That is what makes
+    ``**stuck in ``reach``**`` legal — the backticks are literal characters
+    inside the strong, not a literal of their own.
+    """
+    text = block.text
+    findings: list[Finding] = []
+    occurrences = _markers_in(text)
+    cursor = 0
+
+    for order, (index, marker) in enumerate(occurrences):
+        if index < cursor:
+            continue
+        later = [p for p, m in occurrences[order + 1 :] if m == marker]
+
+        if not _valid_start(text, index, marker):
+            # Worth reporting only when the author clearly meant markup, and
+            # only for a non-ASCII neighbour: "2**3" is prose, "个**粗体**"
+            # is a Chinese page whose bold silently became asterisks.
+            partner = next((p for p in later if not text[p - 1].isspace()), None)
+            if partner is not None and index > 0 and ord(text[index - 1]) > 0x7F:
+                findings.append(
+                    Finding(
+                        path,
+                        block.line_of(index),
+                        "WARNING",
+                        marker,
+                        f"{label(marker)} start-string is preceded by "
+                        f"{_describe(text[index - 1])}, so docutils does not see "
+                        f"markup here and renders {marker!r} literally; "
+                        f"insert an escaped space (backslash-space) before it",
+                    )
+                )
+                cursor = partner + len(marker)
+            continue
+
+        candidates = [p for p in later if not text[p - 1].isspace()]
+        if not candidates:
+            continue
+        valid = [p for p in candidates if _valid_end(text, p, marker)]
+
+        if not valid:
+            offender = candidates[0] + len(marker)
+            suffix = (
+                _describe(text[offender]) if offender < len(text) else "end of block"
+            )
+            findings.append(
+                Finding(
+                    path,
+                    block.line_of(index),
+                    "ERROR",
+                    marker,
+                    f"{label(marker)} start-string without end-string: the closing "
+                    f"{marker!r} is followed by {suffix}, which docutils does not "
+                    f"accept; insert an escaped space (backslash-space) after it",
+                )
+            )
+            cursor = candidates[0] + len(marker)
+            continue
+
+        if valid[0] != candidates[0]:
+            offender = candidates[0] + len(marker)
+            swallowed = text[candidates[0] + len(marker) : valid[0]].replace("\n", " ")
+            findings.append(
+                Finding(
+                    path,
+                    block.line_of(index),
+                    "WARNING",
+                    marker,
+                    f"{label(marker)} closes late and silently swallows "
+                    f"{swallowed.strip()!r}: the intended closing {marker!r} is "
+                    f"followed by {_describe(text[offender])}; insert an escaped "
+                    f"space (backslash-space) after it",
+                )
+            )
+        cursor = valid[0] + len(marker)
+
+    return findings
+
+
+def label(marker: str) -> str:
+    return MARKERS[marker]
+
+
+def check_file(path: Path) -> list[Finding]:
+    source = path.read_text(encoding="utf-8")
+    findings: list[Finding] = []
+    for block in prose_blocks(source):
+        findings += check_block(path, block)
+    return sorted(findings, key=lambda f: (f.line, f.level))
+
+
+def collect(targets: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for target in targets:
+        candidate = Path(target)
+        if candidate.is_dir():
+            paths += sorted(candidate.rglob("*.rst"))
+        elif candidate.is_file():
+            paths.append(candidate)
+        else:
+            print(f"warning: {target} does not exist", file=sys.stderr)
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        default=list(DEFAULT_ROOTS),
+        help="RST files or directories (default: docs/source-en docs/source-zh)",
+    )
+    parser.add_argument(
+        "--errors-only",
+        action="store_true",
+        help="report only build-breaking findings, not silent mis-renders",
+    )
+    args = parser.parse_args()
+
+    findings: list[Finding] = []
+    for path in collect(args.targets or list(DEFAULT_ROOTS)):
+        findings += check_file(path)
+    if args.errors_only:
+        findings = [f for f in findings if f.level == "ERROR"]
+
+    for finding in findings:
+        print(finding.format())
+
+    errors = sum(1 for f in findings if f.level == "ERROR")
+    warnings = len(findings) - errors
+    if findings:
+        print(
+            f"\n{errors} error(s) that fail the Sphinx build, "
+            f"{warnings} warning(s) that silently mis-render.",
+            file=sys.stderr,
+        )
+    else:
+        print("No inline-markup problems found.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/docs-check/reference.md
+++ b/.claude/skills/docs-check/reference.md
@@ -34,7 +34,85 @@ owns its pages directly; the legacy `tutorials/`, `apis/`, `blog/`, and
 
 ---
 
+## The build gate
+
+Both languages are separate Read the Docs projects, configured by
+`docs/source-en/.readthedocs.yaml` and `docs/source-zh/.readthedocs.yaml`, and
+both set `fail_on_warning: true`. A single Sphinx warning turns
+`docs/readthedocs.org:rlinf` or `docs/readthedocs.org:rlinf-cn` red. They build
+independently, so "the English build is green" says nothing about the Chinese
+one — always reproduce both with `build_docs.py`.
+
+To read a failed Read the Docs check without leaving the terminal:
+
+```bash
+gh api repos/RLinf/RLinf/commits/<sha>/status \
+  --jq '.statuses[] | "\(.context) \(.state) \(.target_url)"'
+```
+
+---
+
+## Inline markup next to CJK punctuation
+
+docutils only recognises inline markup when the *start*-string is preceded by
+whitespace, an opener or a delimiter, and the *end*-string is followed by
+whitespace, a closer or a delimiter. Full-width punctuation splits across those
+classes:
+
+| Character | docutils class | Before markup | After markup |
+|-----------|----------------|---------------|--------------|
+| `（` `《` `“` | opener | ok | **rejected** |
+| `）` `》` `”` | closer | **rejected** | ok |
+| `，` `、` `：` `；` `。` `！` `？` `—` | delimiter | ok | ok |
+| any CJK ideograph | none | **rejected** | **rejected** |
+
+Two distinct failures follow, and only the first is visible in CI:
+
+1. **Build break.** No later end-string candidate satisfies the rule, so Sphinx
+   emits `WARNING: Inline literal start-string without end-string. [docutils]`
+   and the CN build fails.
+
+   ```rst
+   导出为 ``MUJOCO_EGL_DEVICE_ID``（MuJoCo）和 ``EGL_DEVICE_ID``（其他）。
+   ```
+
+2. **Silent mis-render.** A *later* ` `` ` in the same paragraph does satisfy
+   the rule, so docutils closes the literal there and swallows the prose in
+   between into the code span. No warning, wrong page.
+
+   ```rst
+   镜像提供两者：``reason``（SGLang，默认激活）与 ``reason-vllm``。
+   ..                 ^ renders as one literal: "reason``（SGLang，默认激活）与 ``reason-vllm"
+   ```
+
+   The same happens to `**粗体**` written directly against a Chinese character:
+   docutils sees no markup and prints the asterisks.
+
+The fix in every case is an escaped space — a backslash followed by a space —
+between the markup and the adjacent character. It suppresses the space in the
+output, so Chinese typography is unaffected:
+
+```rst
+导出为 ``MUJOCO_EGL_DEVICE_ID``\ （MuJoCo）和 ``EGL_DEVICE_ID``\ （其他）。
+CUDA 设备 0 通常\ **并不是** EGL 设备 0。
+```
+
+`check_rst_markup.py` reports both classes: `ERROR` for the build break,
+`WARNING` for the silent mis-render. Only the first blocks a PR, but a doc PR
+touching a Chinese page should leave no new warnings either.
+
+Note that inline markup does **not** nest — `` **stuck in ``reach``** `` is a
+strong containing literal backtick characters, not a nested literal, and is
+perfectly legal.
+
+---
+
 ## Checklist summary
+
+### Build
+- [ ] `python3 .claude/skills/docs-check/build_docs.py` is clean for **both** `en` and `zh`
+- [ ] `python3 .claude/skills/docs-check/check_rst_markup.py` reports no new findings
+- [ ] Changed ZH pages have no ` `` ` or `**` touching `（`, `《` or a CJK character
 
 ### Doc vs Code
 - [ ] Every config name in docs exists under `examples/embodiment/config/` or `env/`

--- a/.codex/skills/docs-check/SKILL.md
+++ b/.codex/skills/docs-check/SKILL.md
@@ -15,6 +15,17 @@ Use this skill when documentation changes may introduce mismatches with:
 
 Always read `reference.md` first, then run the workflow below.
 
+Two harnesses in this folder do the mechanical part; run them before reasoning
+about content:
+
+```bash
+# Does the page still build? Both Read the Docs projects use fail_on_warning.
+python3 .codex/skills/docs-check/build_docs.py            # en + zh
+
+# Does CJK punctuation break inline markup, loudly or silently?
+python3 .codex/skills/docs-check/check_rst_markup.py      # needs docutils
+```
+
 ## Inputs
 
 Collect these inputs before reviewing:
@@ -33,25 +44,36 @@ If scope is unclear, default to checking:
 ## Workflow
 
 1. Read `reference.md` and extract the relevant checklist items.
-2. Verify doc-to-code correctness:
+2. Run the build harness for **both** languages and fix every warning:
+   - `python3 .codex/skills/docs-check/build_docs.py` (add `--lang zh` to
+     iterate faster on a Chinese-only failure).
+   - The two Read the Docs projects build independently with
+     `fail_on_warning: true`, so an English-clean page can still turn
+     `docs/readthedocs.org:rlinf-cn` red. Never conclude "docs are fine"
+     from one language.
+   - Then `python3 .codex/skills/docs-check/check_rst_markup.py` for the
+     inline-markup defects that render wrong *without* warning.
+3. Verify doc-to-code correctness:
    - Commands exist and are runnable in principle.
    - Script/module paths in docs exist.
    - Config keys and values match real code/config names.
    - Model/env names match `SupportedModel` and `SupportedEnvType` string values.
-3. Verify doc-to-doc consistency within one language:
+4. Verify doc-to-doc consistency within one language:
    - Terminology is consistent across start/tutorials/examples/API pages.
    - New page is linked in the correct index/toctree.
    - No conflicting instructions between related pages.
    - Internal doc links use stable `:doc:`/relative links, not hardcoded ReadTheDocs URLs.
-4. Verify EN-ZH parity:
+5. Verify EN-ZH parity:
    - Same topic coverage and section structure.
    - Same commands, config keys, and model/env identifiers.
    - Translations preserve technical meaning (do not rename code symbols).
    - Corresponding EN/ZH pages use equivalent stable internal links.
-5. Report findings with severity and concrete fixes.
+6. Report findings with severity and concrete fixes.
 
 ## Severity Rules
 
+- `Critical`: A Sphinx warning in either language — Read the Docs fails the
+  build, so the page does not ship at all.
 - `Critical`: Wrong command/path/key/value that can break user workflow.
 - `Major`: Inconsistent docs that likely mislead users.
 - `Minor`: Wording/terminology drift without immediate breakage.
@@ -102,6 +124,13 @@ Use this regex scan to detect unstable hardcoded RLinf docs links:
 
 - `readthedocs\.io/(en|zh-cn)/latest/rst_source/`
 
+Chinese pages: `` `` `` or `**` sitting directly against `（`, `《` or a CJK
+character is the single most common way to break `rlinf-cn`. Grep for
+```` ``（ ```` and ```` **（ ```` as a first pass, then run
+`check_rst_markup.py` for the full rule.
+
 ## Additional Resource
 
 - Detailed checklist and paths: [reference.md](reference.md)
+- Local Read the Docs gate for both languages: [build_docs.py](build_docs.py)
+- Inline-markup checker: [check_rst_markup.py](check_rst_markup.py)

--- a/.codex/skills/docs-check/build_docs.py
+++ b/.codex/skills/docs-check/build_docs.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reproduce the Read the Docs build gate locally, for both languages.
+
+``docs/source-en/.readthedocs.yaml`` and ``docs/source-zh/.readthedocs.yaml``
+both set ``fail_on_warning: true``, so *any* Sphinx warning turns the
+``docs/readthedocs.org:rlinf`` or ``:rlinf-cn`` check red.  The two projects
+build independently, so a warning that only the Chinese page triggers — a
+CJK punctuation problem, a missing ZH counterpart, a broken ``:doc:`` target
+— fails ``rlinf-cn`` while ``rlinf`` stays green.  Always build **both**.
+
+This script provisions a docs-only virtualenv from
+``requirements/docs/requirements.txt``, builds each language, and reports the
+warnings that would fail Read the Docs.  Autodoc import failures are filtered
+by default: the docs venv deliberately does not install torch, so every
+``.. autoclass::`` fails locally in a way it never does on Read the Docs.
+Pass ``--strict-autodoc`` (in a full environment) to see them.
+
+Usage::
+
+    python3 .codex/skills/docs-check/build_docs.py             # en + zh
+    python3 .codex/skills/docs-check/build_docs.py --lang zh
+    python3 .codex/skills/docs-check/build_docs.py --keep-output
+
+Exit code is 1 when either language reports a warning, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Emitted for every autodoc target when the package itself is not installed.
+AUTODOC_NOISE = re.compile(
+    r"WARNING: autodoc: failed to import .*"
+    r"|^No module named .*\[autodoc\.import_object\]"
+    r"|^\s*the following exception was raised:",
+    re.MULTILINE,
+)
+# A warning record starts at "<path>:<line>: WARNING" or a bare "WARNING:".
+RECORD_START = re.compile(r"^(?:\S+:\d+: )?(?:WARNING|ERROR|SEVERE)[:\s]")
+
+
+def repo_root() -> Path:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(out.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+def ensure_venv(venv: Path, requirements: Path) -> Path:
+    """Create the docs venv if needed and return its python."""
+    python = venv / "bin" / "python"
+    if python.exists():
+        probe = subprocess.run(
+            [str(python), "-c", "import sphinx"], capture_output=True
+        )
+        if probe.returncode == 0:
+            return python
+    else:
+        print(f"[build_docs] creating {venv}")
+        if shutil.which("uv"):
+            subprocess.run(["uv", "venv", str(venv), "--python", "3.11"], check=True)
+        else:
+            subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
+
+    print(f"[build_docs] installing {requirements.name}")
+    env = {**os.environ, "UV_HTTP_TIMEOUT": "180"}
+    if shutil.which("uv"):
+        subprocess.run(
+            ["uv", "pip", "install", "--python", str(python), "-r", str(requirements)],
+            check=True,
+            env=env,
+        )
+    else:
+        subprocess.run(
+            [str(python), "-m", "pip", "install", "-q", "-r", str(requirements)],
+            check=True,
+        )
+    return python
+
+
+def split_records(stderr: str) -> list[str]:
+    """Group Sphinx's stderr into one string per warning."""
+    records: list[str] = []
+    for line in stderr.splitlines():
+        if RECORD_START.match(line) or not records:
+            records.append(line)
+        else:
+            records[-1] += "\n" + line
+    return [r for r in records if r.strip()]
+
+
+def build(python: Path, source: Path, output: Path, strict_autodoc: bool) -> list[str]:
+    """Build one language and return the warnings that matter."""
+    result = subprocess.run(
+        [
+            str(python.parent / "sphinx-build"),
+            "-b",
+            "html",
+            "-q",
+            str(source),
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
+    )
+    records = split_records(result.stderr)
+    if not strict_autodoc:
+        records = [r for r in records if not AUTODOC_NOISE.search(r)]
+    if result.returncode != 0 and not records:
+        records.append(
+            f"sphinx-build exited {result.returncode}\n{result.stdout[-2000:]}"
+        )
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--lang", choices=("en", "zh", "both"), default="both")
+    parser.add_argument(
+        "--venv",
+        type=Path,
+        default=os.environ.get("DOCS_VENV"),
+        help="virtualenv to build in (default: <repo>/.docs-venv)",
+    )
+    parser.add_argument(
+        "--strict-autodoc",
+        action="store_true",
+        help="keep autodoc import warnings (only useful in a full env)",
+    )
+    parser.add_argument(
+        "--keep-output", action="store_true", help="keep the generated HTML"
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    venv = args.venv or root / ".docs-venv"
+    python = ensure_venv(venv, root / "requirements" / "docs" / "requirements.txt")
+
+    languages = ("en", "zh") if args.lang == "both" else (args.lang,)
+    destination = (
+        root / "docs" / "build" / "check"
+        if args.keep_output
+        else Path(tempfile.mkdtemp(prefix="rlinf-docs-"))
+    )
+
+    total = 0
+    for language in languages:
+        source = root / "docs" / f"source-{language}"
+        print(f"[build_docs] building {source.name}")
+        records = build(python, source, destination / language, args.strict_autodoc)
+        total += len(records)
+        for record in records:
+            print(record)
+        print(f"[build_docs] {source.name}: {len(records)} warning(s)")
+
+    if not args.keep_output:
+        shutil.rmtree(destination, ignore_errors=True)
+
+    if total:
+        print(
+            f"\n{total} warning(s) — Read the Docs builds with fail_on_warning, "
+            f"so this fails the docs check.",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nBoth builds are clean." if len(languages) > 1 else "\nBuild is clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/docs-check/check_rst_markup.py
+++ b/.codex/skills/docs-check/check_rst_markup.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check RST inline markup against the docutils recognition rules.
+
+docutils only recognises inline markup when the start-string is preceded by
+whitespace, an *opener* or a *delimiter*, and the end-string is followed by
+whitespace, a *closer* or a *delimiter*.  Full-width CJK punctuation splits
+across those classes in ways that are easy to get wrong:
+
+    （《        openers  -> fine before markup, NOT allowed after it
+    ）》”’      closers  -> fine after markup
+    ，、：；。—  delimiters -> fine on either side
+
+So a Chinese page that writes ``` ``KEY``（说明） ``` produces
+
+    WARNING: Inline literal start-string without end-string. [docutils]
+
+which fails the build because both Read the Docs projects set
+``fail_on_warning: true`` — and the English page with ASCII parentheses is
+unaffected, so the failure shows up as "only the CN docs are broken".
+
+The nastier variant is silent: when a *later* end-string candidate in the same
+paragraph does satisfy the suffix rule, docutils closes the literal there and
+swallows the intervening prose into the code span.  No warning, wrong page.
+
+This script reports both, plus start-strings that CJK text renders inert
+(``通常**并不是**`` renders as literal asterisks).  The fix in every case is an
+escaped space — ``\\ `` — between the markup and the adjacent character, the
+convention already used across ``docs/source-zh``.
+
+Requires ``docutils`` (``pip install docutils``), whose own punctuation tables
+drive the check so it cannot drift from the parser.
+
+Usage::
+
+    python3 .codex/skills/docs-check/check_rst_markup.py            # all docs
+    python3 .codex/skills/docs-check/check_rst_markup.py FILE...    # subset
+    python3 .codex/skills/docs-check/check_rst_markup.py --errors-only
+
+Exit code is 1 when any ERROR is reported, 0 otherwise (warnings pass).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_ROOTS = ("docs/source-en", "docs/source-zh")
+
+# Directives whose body is verbatim text, not RST.
+LITERAL_DIRECTIVES = frozenset(
+    {
+        "code",
+        "code-block",
+        "highlight",
+        "literalinclude",
+        "math",
+        "parsed-literal",
+        "raw",
+        "sourcecode",
+    }
+)
+
+
+def _character_classes() -> tuple[re.Pattern[str], re.Pattern[str]]:
+    """Build the character classes docutils uses around inline markup.
+
+    ``Inliner.init_customizations`` interpolates the ``punctuation_chars``
+    tables straight into a regex character class, which is not the same as
+    membership in those tables — the tables contain ``-`` and so form ranges.
+    Reusing the exact expressions keeps this check faithful to the parser.
+    """
+    try:
+        from docutils.utils import punctuation_chars as pc
+    except ImportError:  # pragma: no cover - environment problem, not a finding
+        sys.exit("error: this check needs docutils; run 'pip install docutils'")
+
+    prefix = re.compile("[\\s%s%s]" % (pc.openers, pc.delimiters))
+    suffix = re.compile(
+        "[\\s\x00%s%s%s]" % (pc.closing_delimiters, pc.delimiters, pc.closers)
+    )
+    return prefix, suffix
+
+
+START_PREFIX_RE, END_SUFFIX_RE = _character_classes()
+
+
+@dataclass
+class Finding:
+    path: Path
+    line: int
+    level: str  # "ERROR" or "WARNING"
+    marker: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line}: {self.level}: {self.message}"
+
+
+@dataclass
+class Block:
+    """A paragraph of prose, flattened to one string with a line map."""
+
+    text: str
+    starts: list[int]  # index in `text` where each source line begins
+    lines: list[int]  # 1-based source line number of each source line
+
+    def line_of(self, index: int) -> int:
+        line = self.lines[0]
+        for start, number in zip(self.starts, self.lines):
+            if start > index:
+                break
+            line = number
+        return line
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def prose_blocks(source: str) -> list[Block]:
+    """Split a document into paragraphs, dropping verbatim blocks.
+
+    Skipped: comments, the bodies of literal directives, literal blocks
+    introduced by a trailing ``::``, and doctest blocks.
+    """
+    lines = source.splitlines()
+    blocks: list[Block] = []
+    buffer: list[tuple[int, str]] = []
+    skip_above: int | None = None  # skip lines indented deeper than this
+    pending_literal = False
+
+    def flush() -> None:
+        nonlocal buffer
+        if not buffer:
+            return
+        text_parts, starts, numbers, cursor = [], [], [], 0
+        for number, line in buffer:
+            starts.append(cursor)
+            numbers.append(number)
+            text_parts.append(line)
+            cursor += len(line) + 1
+        blocks.append(Block("\n".join(text_parts), starts, numbers))
+        buffer = []
+
+    for number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+
+        if skip_above is not None:
+            if not stripped or _indent(line) > skip_above:
+                continue
+            skip_above = None
+
+        if not stripped:
+            flush()
+            if pending_literal:
+                skip_above = _indent(lines[number - 2]) if number >= 2 else 0
+                pending_literal = False
+            continue
+
+        if stripped.startswith(".."):
+            flush()
+            name = stripped[2:].strip().split("::", 1)[0].strip()
+            is_comment = "::" not in stripped[2:]
+            if is_comment or name in LITERAL_DIRECTIVES:
+                skip_above = _indent(line)
+            continue
+
+        if stripped.startswith(">>>"):
+            flush()
+            skip_above = _indent(line)
+            continue
+
+        buffer.append((number, line))
+        # A trailing "::" introduces a literal block after the blank line.
+        pending_literal = stripped.endswith("::")
+
+    flush()
+    return blocks
+
+
+def _escaped(text: str, index: int) -> bool:
+    backslashes = 0
+    while index - backslashes - 1 >= 0 and text[index - backslashes - 1] == "\\":
+        backslashes += 1
+    return backslashes % 2 == 1
+
+
+def _occurrences(text: str, marker: str) -> list[int]:
+    found, index = [], text.find(marker)
+    while index != -1:
+        if not _escaped(text, index):
+            found.append(index)
+        index = text.find(marker, index + len(marker))
+    return found
+
+
+def _valid_start(text: str, index: int, marker: str) -> bool:
+    after = index + len(marker)
+    if after >= len(text) or text[after].isspace():
+        return False
+    if index == 0:
+        return True
+    return START_PREFIX_RE.match(text[index - 1]) is not None
+
+
+def _valid_end(text: str, index: int, marker: str) -> bool:
+    if index == 0 or text[index - 1].isspace():
+        return False
+    after = index + len(marker)
+    if after >= len(text):
+        return True
+    return END_SUFFIX_RE.match(text[after]) is not None
+
+
+def _describe(char: str) -> str:
+    name = unicodedata.name(char, "unnamed")
+    return f"{char!r} (U+{ord(char):04X} {name})"
+
+
+MARKERS = {"``": "Inline literal", "**": "Strong emphasis"}
+
+
+def _markers_in(text: str) -> list[tuple[int, str]]:
+    """All unescaped marker occurrences, in document order."""
+    found: list[tuple[int, str]] = []
+    for marker in MARKERS:
+        for index in _occurrences(text, marker):
+            if marker == "**" and text[index : index + 3] == "***":
+                continue  # docutils never reads "***" as strong
+            found.append((index, marker))
+    return sorted(found)
+
+
+def check_block(path: Path, block: Block) -> list[Finding]:
+    """Emulate the docutils inline scan over one paragraph.
+
+    RST inline markup does not nest: whatever sits between a start-string and
+    its end-string is the construct's text, so the scan jumps over a matched
+    span instead of looking inside it.  That is what makes
+    ``**stuck in ``reach``**`` legal — the backticks are literal characters
+    inside the strong, not a literal of their own.
+    """
+    text = block.text
+    findings: list[Finding] = []
+    occurrences = _markers_in(text)
+    cursor = 0
+
+    for order, (index, marker) in enumerate(occurrences):
+        if index < cursor:
+            continue
+        later = [p for p, m in occurrences[order + 1 :] if m == marker]
+
+        if not _valid_start(text, index, marker):
+            # Worth reporting only when the author clearly meant markup, and
+            # only for a non-ASCII neighbour: "2**3" is prose, "个**粗体**"
+            # is a Chinese page whose bold silently became asterisks.
+            partner = next((p for p in later if not text[p - 1].isspace()), None)
+            if partner is not None and index > 0 and ord(text[index - 1]) > 0x7F:
+                findings.append(
+                    Finding(
+                        path,
+                        block.line_of(index),
+                        "WARNING",
+                        marker,
+                        f"{label(marker)} start-string is preceded by "
+                        f"{_describe(text[index - 1])}, so docutils does not see "
+                        f"markup here and renders {marker!r} literally; "
+                        f"insert an escaped space (backslash-space) before it",
+                    )
+                )
+                cursor = partner + len(marker)
+            continue
+
+        candidates = [p for p in later if not text[p - 1].isspace()]
+        if not candidates:
+            continue
+        valid = [p for p in candidates if _valid_end(text, p, marker)]
+
+        if not valid:
+            offender = candidates[0] + len(marker)
+            suffix = (
+                _describe(text[offender]) if offender < len(text) else "end of block"
+            )
+            findings.append(
+                Finding(
+                    path,
+                    block.line_of(index),
+                    "ERROR",
+                    marker,
+                    f"{label(marker)} start-string without end-string: the closing "
+                    f"{marker!r} is followed by {suffix}, which docutils does not "
+                    f"accept; insert an escaped space (backslash-space) after it",
+                )
+            )
+            cursor = candidates[0] + len(marker)
+            continue
+
+        if valid[0] != candidates[0]:
+            offender = candidates[0] + len(marker)
+            swallowed = text[candidates[0] + len(marker) : valid[0]].replace("\n", " ")
+            findings.append(
+                Finding(
+                    path,
+                    block.line_of(index),
+                    "WARNING",
+                    marker,
+                    f"{label(marker)} closes late and silently swallows "
+                    f"{swallowed.strip()!r}: the intended closing {marker!r} is "
+                    f"followed by {_describe(text[offender])}; insert an escaped "
+                    f"space (backslash-space) after it",
+                )
+            )
+        cursor = valid[0] + len(marker)
+
+    return findings
+
+
+def label(marker: str) -> str:
+    return MARKERS[marker]
+
+
+def check_file(path: Path) -> list[Finding]:
+    source = path.read_text(encoding="utf-8")
+    findings: list[Finding] = []
+    for block in prose_blocks(source):
+        findings += check_block(path, block)
+    return sorted(findings, key=lambda f: (f.line, f.level))
+
+
+def collect(targets: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for target in targets:
+        candidate = Path(target)
+        if candidate.is_dir():
+            paths += sorted(candidate.rglob("*.rst"))
+        elif candidate.is_file():
+            paths.append(candidate)
+        else:
+            print(f"warning: {target} does not exist", file=sys.stderr)
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        default=list(DEFAULT_ROOTS),
+        help="RST files or directories (default: docs/source-en docs/source-zh)",
+    )
+    parser.add_argument(
+        "--errors-only",
+        action="store_true",
+        help="report only build-breaking findings, not silent mis-renders",
+    )
+    args = parser.parse_args()
+
+    findings: list[Finding] = []
+    for path in collect(args.targets or list(DEFAULT_ROOTS)):
+        findings += check_file(path)
+    if args.errors_only:
+        findings = [f for f in findings if f.level == "ERROR"]
+
+    for finding in findings:
+        print(finding.format())
+
+    errors = sum(1 for f in findings if f.level == "ERROR")
+    warnings = len(findings) - errors
+    if findings:
+        print(
+            f"\n{errors} error(s) that fail the Sphinx build, "
+            f"{warnings} warning(s) that silently mis-render.",
+            file=sys.stderr,
+        )
+    else:
+        print("No inline-markup problems found.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/docs-check/reference.md
+++ b/.codex/skills/docs-check/reference.md
@@ -34,7 +34,85 @@ owns its pages directly; the legacy `tutorials/`, `apis/`, `blog/`, and
 
 ---
 
+## The build gate
+
+Both languages are separate Read the Docs projects, configured by
+`docs/source-en/.readthedocs.yaml` and `docs/source-zh/.readthedocs.yaml`, and
+both set `fail_on_warning: true`. A single Sphinx warning turns
+`docs/readthedocs.org:rlinf` or `docs/readthedocs.org:rlinf-cn` red. They build
+independently, so "the English build is green" says nothing about the Chinese
+one — always reproduce both with `build_docs.py`.
+
+To read a failed Read the Docs check without leaving the terminal:
+
+```bash
+gh api repos/RLinf/RLinf/commits/<sha>/status \
+  --jq '.statuses[] | "\(.context) \(.state) \(.target_url)"'
+```
+
+---
+
+## Inline markup next to CJK punctuation
+
+docutils only recognises inline markup when the *start*-string is preceded by
+whitespace, an opener or a delimiter, and the *end*-string is followed by
+whitespace, a closer or a delimiter. Full-width punctuation splits across those
+classes:
+
+| Character | docutils class | Before markup | After markup |
+|-----------|----------------|---------------|--------------|
+| `（` `《` `“` | opener | ok | **rejected** |
+| `）` `》` `”` | closer | **rejected** | ok |
+| `，` `、` `：` `；` `。` `！` `？` `—` | delimiter | ok | ok |
+| any CJK ideograph | none | **rejected** | **rejected** |
+
+Two distinct failures follow, and only the first is visible in CI:
+
+1. **Build break.** No later end-string candidate satisfies the rule, so Sphinx
+   emits `WARNING: Inline literal start-string without end-string. [docutils]`
+   and the CN build fails.
+
+   ```rst
+   导出为 ``MUJOCO_EGL_DEVICE_ID``（MuJoCo）和 ``EGL_DEVICE_ID``（其他）。
+   ```
+
+2. **Silent mis-render.** A *later* ` `` ` in the same paragraph does satisfy
+   the rule, so docutils closes the literal there and swallows the prose in
+   between into the code span. No warning, wrong page.
+
+   ```rst
+   镜像提供两者：``reason``（SGLang，默认激活）与 ``reason-vllm``。
+   ..                 ^ renders as one literal: "reason``（SGLang，默认激活）与 ``reason-vllm"
+   ```
+
+   The same happens to `**粗体**` written directly against a Chinese character:
+   docutils sees no markup and prints the asterisks.
+
+The fix in every case is an escaped space — a backslash followed by a space —
+between the markup and the adjacent character. It suppresses the space in the
+output, so Chinese typography is unaffected:
+
+```rst
+导出为 ``MUJOCO_EGL_DEVICE_ID``\ （MuJoCo）和 ``EGL_DEVICE_ID``\ （其他）。
+CUDA 设备 0 通常\ **并不是** EGL 设备 0。
+```
+
+`check_rst_markup.py` reports both classes: `ERROR` for the build break,
+`WARNING` for the silent mis-render. Only the first blocks a PR, but a doc PR
+touching a Chinese page should leave no new warnings either.
+
+Note that inline markup does **not** nest — `` **stuck in ``reach``** `` is a
+strong containing literal backtick characters, not a nested literal, and is
+perfectly legal.
+
+---
+
 ## Checklist summary
+
+### Build
+- [ ] `python3 .codex/skills/docs-check/build_docs.py` is clean for **both** `en` and `zh`
+- [ ] `python3 .codex/skills/docs-check/check_rst_markup.py` reports no new findings
+- [ ] Changed ZH pages have no ` `` ` or `**` touching `（`, `《` or a CJK character
 
 ### Doc vs Code
 - [ ] Every config name in docs exists under `examples/embodiment/config/` or `env/`

--- a/.cursor/skills/docs-check/SKILL.md
+++ b/.cursor/skills/docs-check/SKILL.md
@@ -15,6 +15,17 @@ Use this skill when documentation changes may introduce mismatches with:
 
 Always read `reference.md` first, then run the workflow below.
 
+Two harnesses in this folder do the mechanical part; run them before reasoning
+about content:
+
+```bash
+# Does the page still build? Both Read the Docs projects use fail_on_warning.
+python3 .cursor/skills/docs-check/build_docs.py            # en + zh
+
+# Does CJK punctuation break inline markup, loudly or silently?
+python3 .cursor/skills/docs-check/check_rst_markup.py      # needs docutils
+```
+
 ## Inputs
 
 Collect these inputs before reviewing:
@@ -33,25 +44,36 @@ If scope is unclear, default to checking:
 ## Workflow
 
 1. Read `reference.md` and extract the relevant checklist items.
-2. Verify doc-to-code correctness:
+2. Run the build harness for **both** languages and fix every warning:
+   - `python3 .cursor/skills/docs-check/build_docs.py` (add `--lang zh` to
+     iterate faster on a Chinese-only failure).
+   - The two Read the Docs projects build independently with
+     `fail_on_warning: true`, so an English-clean page can still turn
+     `docs/readthedocs.org:rlinf-cn` red. Never conclude "docs are fine"
+     from one language.
+   - Then `python3 .cursor/skills/docs-check/check_rst_markup.py` for the
+     inline-markup defects that render wrong *without* warning.
+3. Verify doc-to-code correctness:
    - Commands exist and are runnable in principle.
    - Script/module paths in docs exist.
    - Config keys and values match real code/config names.
    - Model/env names match `SupportedModel` and `SupportedEnvType` string values.
-3. Verify doc-to-doc consistency within one language:
+4. Verify doc-to-doc consistency within one language:
    - Terminology is consistent across start/tutorials/examples/API pages.
    - New page is linked in the correct index/toctree.
    - No conflicting instructions between related pages.
    - Internal doc links use stable `:doc:`/relative links, not hardcoded ReadTheDocs URLs.
-4. Verify EN-ZH parity:
+5. Verify EN-ZH parity:
    - Same topic coverage and section structure.
    - Same commands, config keys, and model/env identifiers.
    - Translations preserve technical meaning (do not rename code symbols).
    - Corresponding EN/ZH pages use equivalent stable internal links.
-5. Report findings with severity and concrete fixes.
+6. Report findings with severity and concrete fixes.
 
 ## Severity Rules
 
+- `Critical`: A Sphinx warning in either language — Read the Docs fails the
+  build, so the page does not ship at all.
 - `Critical`: Wrong command/path/key/value that can break user workflow.
 - `Major`: Inconsistent docs that likely mislead users.
 - `Minor`: Wording/terminology drift without immediate breakage.
@@ -102,6 +124,13 @@ Use this regex scan to detect unstable hardcoded RLinf docs links:
 
 - `readthedocs\.io/(en|zh-cn)/latest/rst_source/`
 
+Chinese pages: `` `` `` or `**` sitting directly against `（`, `《` or a CJK
+character is the single most common way to break `rlinf-cn`. Grep for
+```` ``（ ```` and ```` **（ ```` as a first pass, then run
+`check_rst_markup.py` for the full rule.
+
 ## Additional Resource
 
 - Detailed checklist and paths: [reference.md](reference.md)
+- Local Read the Docs gate for both languages: [build_docs.py](build_docs.py)
+- Inline-markup checker: [check_rst_markup.py](check_rst_markup.py)

--- a/.cursor/skills/docs-check/build_docs.py
+++ b/.cursor/skills/docs-check/build_docs.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reproduce the Read the Docs build gate locally, for both languages.
+
+``docs/source-en/.readthedocs.yaml`` and ``docs/source-zh/.readthedocs.yaml``
+both set ``fail_on_warning: true``, so *any* Sphinx warning turns the
+``docs/readthedocs.org:rlinf`` or ``:rlinf-cn`` check red.  The two projects
+build independently, so a warning that only the Chinese page triggers — a
+CJK punctuation problem, a missing ZH counterpart, a broken ``:doc:`` target
+— fails ``rlinf-cn`` while ``rlinf`` stays green.  Always build **both**.
+
+This script provisions a docs-only virtualenv from
+``requirements/docs/requirements.txt``, builds each language, and reports the
+warnings that would fail Read the Docs.  Autodoc import failures are filtered
+by default: the docs venv deliberately does not install torch, so every
+``.. autoclass::`` fails locally in a way it never does on Read the Docs.
+Pass ``--strict-autodoc`` (in a full environment) to see them.
+
+Usage::
+
+    python3 .cursor/skills/docs-check/build_docs.py             # en + zh
+    python3 .cursor/skills/docs-check/build_docs.py --lang zh
+    python3 .cursor/skills/docs-check/build_docs.py --keep-output
+
+Exit code is 1 when either language reports a warning, 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Emitted for every autodoc target when the package itself is not installed.
+AUTODOC_NOISE = re.compile(
+    r"WARNING: autodoc: failed to import .*"
+    r"|^No module named .*\[autodoc\.import_object\]"
+    r"|^\s*the following exception was raised:",
+    re.MULTILINE,
+)
+# A warning record starts at "<path>:<line>: WARNING" or a bare "WARNING:".
+RECORD_START = re.compile(r"^(?:\S+:\d+: )?(?:WARNING|ERROR|SEVERE)[:\s]")
+
+
+def repo_root() -> Path:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(out.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+def ensure_venv(venv: Path, requirements: Path) -> Path:
+    """Create the docs venv if needed and return its python."""
+    python = venv / "bin" / "python"
+    if python.exists():
+        probe = subprocess.run(
+            [str(python), "-c", "import sphinx"], capture_output=True
+        )
+        if probe.returncode == 0:
+            return python
+    else:
+        print(f"[build_docs] creating {venv}")
+        if shutil.which("uv"):
+            subprocess.run(["uv", "venv", str(venv), "--python", "3.11"], check=True)
+        else:
+            subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
+
+    print(f"[build_docs] installing {requirements.name}")
+    env = {**os.environ, "UV_HTTP_TIMEOUT": "180"}
+    if shutil.which("uv"):
+        subprocess.run(
+            ["uv", "pip", "install", "--python", str(python), "-r", str(requirements)],
+            check=True,
+            env=env,
+        )
+    else:
+        subprocess.run(
+            [str(python), "-m", "pip", "install", "-q", "-r", str(requirements)],
+            check=True,
+        )
+    return python
+
+
+def split_records(stderr: str) -> list[str]:
+    """Group Sphinx's stderr into one string per warning."""
+    records: list[str] = []
+    for line in stderr.splitlines():
+        if RECORD_START.match(line) or not records:
+            records.append(line)
+        else:
+            records[-1] += "\n" + line
+    return [r for r in records if r.strip()]
+
+
+def build(python: Path, source: Path, output: Path, strict_autodoc: bool) -> list[str]:
+    """Build one language and return the warnings that matter."""
+    result = subprocess.run(
+        [
+            str(python.parent / "sphinx-build"),
+            "-b",
+            "html",
+            "-q",
+            str(source),
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "LC_ALL": "C.UTF-8", "LANG": "C.UTF-8"},
+    )
+    records = split_records(result.stderr)
+    if not strict_autodoc:
+        records = [r for r in records if not AUTODOC_NOISE.search(r)]
+    if result.returncode != 0 and not records:
+        records.append(
+            f"sphinx-build exited {result.returncode}\n{result.stdout[-2000:]}"
+        )
+    return records
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--lang", choices=("en", "zh", "both"), default="both")
+    parser.add_argument(
+        "--venv",
+        type=Path,
+        default=os.environ.get("DOCS_VENV"),
+        help="virtualenv to build in (default: <repo>/.docs-venv)",
+    )
+    parser.add_argument(
+        "--strict-autodoc",
+        action="store_true",
+        help="keep autodoc import warnings (only useful in a full env)",
+    )
+    parser.add_argument(
+        "--keep-output", action="store_true", help="keep the generated HTML"
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    venv = args.venv or root / ".docs-venv"
+    python = ensure_venv(venv, root / "requirements" / "docs" / "requirements.txt")
+
+    languages = ("en", "zh") if args.lang == "both" else (args.lang,)
+    destination = (
+        root / "docs" / "build" / "check"
+        if args.keep_output
+        else Path(tempfile.mkdtemp(prefix="rlinf-docs-"))
+    )
+
+    total = 0
+    for language in languages:
+        source = root / "docs" / f"source-{language}"
+        print(f"[build_docs] building {source.name}")
+        records = build(python, source, destination / language, args.strict_autodoc)
+        total += len(records)
+        for record in records:
+            print(record)
+        print(f"[build_docs] {source.name}: {len(records)} warning(s)")
+
+    if not args.keep_output:
+        shutil.rmtree(destination, ignore_errors=True)
+
+    if total:
+        print(
+            f"\n{total} warning(s) — Read the Docs builds with fail_on_warning, "
+            f"so this fails the docs check.",
+            file=sys.stderr,
+        )
+        return 1
+    print("\nBoth builds are clean." if len(languages) > 1 else "\nBuild is clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/docs-check/check_rst_markup.py
+++ b/.cursor/skills/docs-check/check_rst_markup.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check RST inline markup against the docutils recognition rules.
+
+docutils only recognises inline markup when the start-string is preceded by
+whitespace, an *opener* or a *delimiter*, and the end-string is followed by
+whitespace, a *closer* or a *delimiter*.  Full-width CJK punctuation splits
+across those classes in ways that are easy to get wrong:
+
+    （《        openers  -> fine before markup, NOT allowed after it
+    ）》”’      closers  -> fine after markup
+    ，、：；。—  delimiters -> fine on either side
+
+So a Chinese page that writes ``` ``KEY``（说明） ``` produces
+
+    WARNING: Inline literal start-string without end-string. [docutils]
+
+which fails the build because both Read the Docs projects set
+``fail_on_warning: true`` — and the English page with ASCII parentheses is
+unaffected, so the failure shows up as "only the CN docs are broken".
+
+The nastier variant is silent: when a *later* end-string candidate in the same
+paragraph does satisfy the suffix rule, docutils closes the literal there and
+swallows the intervening prose into the code span.  No warning, wrong page.
+
+This script reports both, plus start-strings that CJK text renders inert
+(``通常**并不是**`` renders as literal asterisks).  The fix in every case is an
+escaped space — ``\\ `` — between the markup and the adjacent character, the
+convention already used across ``docs/source-zh``.
+
+Requires ``docutils`` (``pip install docutils``), whose own punctuation tables
+drive the check so it cannot drift from the parser.
+
+Usage::
+
+    python3 .cursor/skills/docs-check/check_rst_markup.py            # all docs
+    python3 .cursor/skills/docs-check/check_rst_markup.py FILE...    # subset
+    python3 .cursor/skills/docs-check/check_rst_markup.py --errors-only
+
+Exit code is 1 when any ERROR is reported, 0 otherwise (warnings pass).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_ROOTS = ("docs/source-en", "docs/source-zh")
+
+# Directives whose body is verbatim text, not RST.
+LITERAL_DIRECTIVES = frozenset(
+    {
+        "code",
+        "code-block",
+        "highlight",
+        "literalinclude",
+        "math",
+        "parsed-literal",
+        "raw",
+        "sourcecode",
+    }
+)
+
+
+def _character_classes() -> tuple[re.Pattern[str], re.Pattern[str]]:
+    """Build the character classes docutils uses around inline markup.
+
+    ``Inliner.init_customizations`` interpolates the ``punctuation_chars``
+    tables straight into a regex character class, which is not the same as
+    membership in those tables — the tables contain ``-`` and so form ranges.
+    Reusing the exact expressions keeps this check faithful to the parser.
+    """
+    try:
+        from docutils.utils import punctuation_chars as pc
+    except ImportError:  # pragma: no cover - environment problem, not a finding
+        sys.exit("error: this check needs docutils; run 'pip install docutils'")
+
+    prefix = re.compile("[\\s%s%s]" % (pc.openers, pc.delimiters))
+    suffix = re.compile(
+        "[\\s\x00%s%s%s]" % (pc.closing_delimiters, pc.delimiters, pc.closers)
+    )
+    return prefix, suffix
+
+
+START_PREFIX_RE, END_SUFFIX_RE = _character_classes()
+
+
+@dataclass
+class Finding:
+    path: Path
+    line: int
+    level: str  # "ERROR" or "WARNING"
+    marker: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line}: {self.level}: {self.message}"
+
+
+@dataclass
+class Block:
+    """A paragraph of prose, flattened to one string with a line map."""
+
+    text: str
+    starts: list[int]  # index in `text` where each source line begins
+    lines: list[int]  # 1-based source line number of each source line
+
+    def line_of(self, index: int) -> int:
+        line = self.lines[0]
+        for start, number in zip(self.starts, self.lines):
+            if start > index:
+                break
+            line = number
+        return line
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def prose_blocks(source: str) -> list[Block]:
+    """Split a document into paragraphs, dropping verbatim blocks.
+
+    Skipped: comments, the bodies of literal directives, literal blocks
+    introduced by a trailing ``::``, and doctest blocks.
+    """
+    lines = source.splitlines()
+    blocks: list[Block] = []
+    buffer: list[tuple[int, str]] = []
+    skip_above: int | None = None  # skip lines indented deeper than this
+    pending_literal = False
+
+    def flush() -> None:
+        nonlocal buffer
+        if not buffer:
+            return
+        text_parts, starts, numbers, cursor = [], [], [], 0
+        for number, line in buffer:
+            starts.append(cursor)
+            numbers.append(number)
+            text_parts.append(line)
+            cursor += len(line) + 1
+        blocks.append(Block("\n".join(text_parts), starts, numbers))
+        buffer = []
+
+    for number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+
+        if skip_above is not None:
+            if not stripped or _indent(line) > skip_above:
+                continue
+            skip_above = None
+
+        if not stripped:
+            flush()
+            if pending_literal:
+                skip_above = _indent(lines[number - 2]) if number >= 2 else 0
+                pending_literal = False
+            continue
+
+        if stripped.startswith(".."):
+            flush()
+            name = stripped[2:].strip().split("::", 1)[0].strip()
+            is_comment = "::" not in stripped[2:]
+            if is_comment or name in LITERAL_DIRECTIVES:
+                skip_above = _indent(line)
+            continue
+
+        if stripped.startswith(">>>"):
+            flush()
+            skip_above = _indent(line)
+            continue
+
+        buffer.append((number, line))
+        # A trailing "::" introduces a literal block after the blank line.
+        pending_literal = stripped.endswith("::")
+
+    flush()
+    return blocks
+
+
+def _escaped(text: str, index: int) -> bool:
+    backslashes = 0
+    while index - backslashes - 1 >= 0 and text[index - backslashes - 1] == "\\":
+        backslashes += 1
+    return backslashes % 2 == 1
+
+
+def _occurrences(text: str, marker: str) -> list[int]:
+    found, index = [], text.find(marker)
+    while index != -1:
+        if not _escaped(text, index):
+            found.append(index)
+        index = text.find(marker, index + len(marker))
+    return found
+
+
+def _valid_start(text: str, index: int, marker: str) -> bool:
+    after = index + len(marker)
+    if after >= len(text) or text[after].isspace():
+        return False
+    if index == 0:
+        return True
+    return START_PREFIX_RE.match(text[index - 1]) is not None
+
+
+def _valid_end(text: str, index: int, marker: str) -> bool:
+    if index == 0 or text[index - 1].isspace():
+        return False
+    after = index + len(marker)
+    if after >= len(text):
+        return True
+    return END_SUFFIX_RE.match(text[after]) is not None
+
+
+def _describe(char: str) -> str:
+    name = unicodedata.name(char, "unnamed")
+    return f"{char!r} (U+{ord(char):04X} {name})"
+
+
+MARKERS = {"``": "Inline literal", "**": "Strong emphasis"}
+
+
+def _markers_in(text: str) -> list[tuple[int, str]]:
+    """All unescaped marker occurrences, in document order."""
+    found: list[tuple[int, str]] = []
+    for marker in MARKERS:
+        for index in _occurrences(text, marker):
+            if marker == "**" and text[index : index + 3] == "***":
+                continue  # docutils never reads "***" as strong
+            found.append((index, marker))
+    return sorted(found)
+
+
+def check_block(path: Path, block: Block) -> list[Finding]:
+    """Emulate the docutils inline scan over one paragraph.
+
+    RST inline markup does not nest: whatever sits between a start-string and
+    its end-string is the construct's text, so the scan jumps over a matched
+    span instead of looking inside it.  That is what makes
+    ``**stuck in ``reach``**`` legal — the backticks are literal characters
+    inside the strong, not a literal of their own.
+    """
+    text = block.text
+    findings: list[Finding] = []
+    occurrences = _markers_in(text)
+    cursor = 0
+
+    for order, (index, marker) in enumerate(occurrences):
+        if index < cursor:
+            continue
+        later = [p for p, m in occurrences[order + 1 :] if m == marker]
+
+        if not _valid_start(text, index, marker):
+            # Worth reporting only when the author clearly meant markup, and
+            # only for a non-ASCII neighbour: "2**3" is prose, "个**粗体**"
+            # is a Chinese page whose bold silently became asterisks.
+            partner = next((p for p in later if not text[p - 1].isspace()), None)
+            if partner is not None and index > 0 and ord(text[index - 1]) > 0x7F:
+                findings.append(
+                    Finding(
+                        path,
+                        block.line_of(index),
+                        "WARNING",
+                        marker,
+                        f"{label(marker)} start-string is preceded by "
+                        f"{_describe(text[index - 1])}, so docutils does not see "
+                        f"markup here and renders {marker!r} literally; "
+                        f"insert an escaped space (backslash-space) before it",
+                    )
+                )
+                cursor = partner + len(marker)
+            continue
+
+        candidates = [p for p in later if not text[p - 1].isspace()]
+        if not candidates:
+            continue
+        valid = [p for p in candidates if _valid_end(text, p, marker)]
+
+        if not valid:
+            offender = candidates[0] + len(marker)
+            suffix = (
+                _describe(text[offender]) if offender < len(text) else "end of block"
+            )
+            findings.append(
+                Finding(
+                    path,
+                    block.line_of(index),
+                    "ERROR",
+                    marker,
+                    f"{label(marker)} start-string without end-string: the closing "
+                    f"{marker!r} is followed by {suffix}, which docutils does not "
+                    f"accept; insert an escaped space (backslash-space) after it",
+                )
+            )
+            cursor = candidates[0] + len(marker)
+            continue
+
+        if valid[0] != candidates[0]:
+            offender = candidates[0] + len(marker)
+            swallowed = text[candidates[0] + len(marker) : valid[0]].replace("\n", " ")
+            findings.append(
+                Finding(
+                    path,
+                    block.line_of(index),
+                    "WARNING",
+                    marker,
+                    f"{label(marker)} closes late and silently swallows "
+                    f"{swallowed.strip()!r}: the intended closing {marker!r} is "
+                    f"followed by {_describe(text[offender])}; insert an escaped "
+                    f"space (backslash-space) after it",
+                )
+            )
+        cursor = valid[0] + len(marker)
+
+    return findings
+
+
+def label(marker: str) -> str:
+    return MARKERS[marker]
+
+
+def check_file(path: Path) -> list[Finding]:
+    source = path.read_text(encoding="utf-8")
+    findings: list[Finding] = []
+    for block in prose_blocks(source):
+        findings += check_block(path, block)
+    return sorted(findings, key=lambda f: (f.line, f.level))
+
+
+def collect(targets: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for target in targets:
+        candidate = Path(target)
+        if candidate.is_dir():
+            paths += sorted(candidate.rglob("*.rst"))
+        elif candidate.is_file():
+            paths.append(candidate)
+        else:
+            print(f"warning: {target} does not exist", file=sys.stderr)
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        default=list(DEFAULT_ROOTS),
+        help="RST files or directories (default: docs/source-en docs/source-zh)",
+    )
+    parser.add_argument(
+        "--errors-only",
+        action="store_true",
+        help="report only build-breaking findings, not silent mis-renders",
+    )
+    args = parser.parse_args()
+
+    findings: list[Finding] = []
+    for path in collect(args.targets or list(DEFAULT_ROOTS)):
+        findings += check_file(path)
+    if args.errors_only:
+        findings = [f for f in findings if f.level == "ERROR"]
+
+    for finding in findings:
+        print(finding.format())
+
+    errors = sum(1 for f in findings if f.level == "ERROR")
+    warnings = len(findings) - errors
+    if findings:
+        print(
+            f"\n{errors} error(s) that fail the Sphinx build, "
+            f"{warnings} warning(s) that silently mis-render.",
+            file=sys.stderr,
+        )
+    else:
+        print("No inline-markup problems found.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/skills/docs-check/reference.md
+++ b/.cursor/skills/docs-check/reference.md
@@ -34,7 +34,85 @@ owns its pages directly; the legacy `tutorials/`, `apis/`, `blog/`, and
 
 ---
 
+## The build gate
+
+Both languages are separate Read the Docs projects, configured by
+`docs/source-en/.readthedocs.yaml` and `docs/source-zh/.readthedocs.yaml`, and
+both set `fail_on_warning: true`. A single Sphinx warning turns
+`docs/readthedocs.org:rlinf` or `docs/readthedocs.org:rlinf-cn` red. They build
+independently, so "the English build is green" says nothing about the Chinese
+one — always reproduce both with `build_docs.py`.
+
+To read a failed Read the Docs check without leaving the terminal:
+
+```bash
+gh api repos/RLinf/RLinf/commits/<sha>/status \
+  --jq '.statuses[] | "\(.context) \(.state) \(.target_url)"'
+```
+
+---
+
+## Inline markup next to CJK punctuation
+
+docutils only recognises inline markup when the *start*-string is preceded by
+whitespace, an opener or a delimiter, and the *end*-string is followed by
+whitespace, a closer or a delimiter. Full-width punctuation splits across those
+classes:
+
+| Character | docutils class | Before markup | After markup |
+|-----------|----------------|---------------|--------------|
+| `（` `《` `“` | opener | ok | **rejected** |
+| `）` `》` `”` | closer | **rejected** | ok |
+| `，` `、` `：` `；` `。` `！` `？` `—` | delimiter | ok | ok |
+| any CJK ideograph | none | **rejected** | **rejected** |
+
+Two distinct failures follow, and only the first is visible in CI:
+
+1. **Build break.** No later end-string candidate satisfies the rule, so Sphinx
+   emits `WARNING: Inline literal start-string without end-string. [docutils]`
+   and the CN build fails.
+
+   ```rst
+   导出为 ``MUJOCO_EGL_DEVICE_ID``（MuJoCo）和 ``EGL_DEVICE_ID``（其他）。
+   ```
+
+2. **Silent mis-render.** A *later* ` `` ` in the same paragraph does satisfy
+   the rule, so docutils closes the literal there and swallows the prose in
+   between into the code span. No warning, wrong page.
+
+   ```rst
+   镜像提供两者：``reason``（SGLang，默认激活）与 ``reason-vllm``。
+   ..                 ^ renders as one literal: "reason``（SGLang，默认激活）与 ``reason-vllm"
+   ```
+
+   The same happens to `**粗体**` written directly against a Chinese character:
+   docutils sees no markup and prints the asterisks.
+
+The fix in every case is an escaped space — a backslash followed by a space —
+between the markup and the adjacent character. It suppresses the space in the
+output, so Chinese typography is unaffected:
+
+```rst
+导出为 ``MUJOCO_EGL_DEVICE_ID``\ （MuJoCo）和 ``EGL_DEVICE_ID``\ （其他）。
+CUDA 设备 0 通常\ **并不是** EGL 设备 0。
+```
+
+`check_rst_markup.py` reports both classes: `ERROR` for the build break,
+`WARNING` for the silent mis-render. Only the first blocks a PR, but a doc PR
+touching a Chinese page should leave no new warnings either.
+
+Note that inline markup does **not** nest — `` **stuck in ``reach``** `` is a
+strong containing literal backtick characters, not a nested literal, and is
+perfectly legal.
+
+---
+
 ## Checklist summary
+
+### Build
+- [ ] `python3 .cursor/skills/docs-check/build_docs.py` is clean for **both** `en` and `zh`
+- [ ] `python3 .cursor/skills/docs-check/check_rst_markup.py` reports no new findings
+- [ ] Changed ZH pages have no ` `` ` or `**` touching `（`, `《` or a CJK character
 
 ### Doc vs Code
 - [ ] Every config name in docs exists under `examples/embodiment/config/` or `env/`


### PR DESCRIPTION
### Description

adds local documentation validation harnesses to the `docs-check` skill and keeps the Claude, Cursor, and Codex copies synchronized.

- Build English and Chinese Sphinx docs with Read the Docs warning semantics.
- Detect build-breaking and silently mis-rendered RST inline markup around CJK text.
- Document the harness workflow, severity, and remediation guidance.

### Motivation and Context

Read the Docs builds English and Chinese independently with `fail_on_warning`, while malformed inline markup around CJK punctuation can either fail only the Chinese build or render incorrectly without a warning. The skill needs reproducible local checks, including the same support under `.codex`.

### How has this been tested?

- `python3 .codex/skills/docs-check/build_docs.py` built both languages with zero warnings.
- `python3 .claude/skills/docs-check/build_docs.py --lang en` and `python3 .cursor/skills/docs-check/build_docs.py --lang zh` passed.
- `.docs-venv/bin/python .codex/skills/docs-check/check_rst_markup.py --errors-only` reported no build-breaking findings; the complete scan reported 65 pre-existing non-blocking findings.
- `uvx pre-commit run --files <all changed skill files>` passed Ruff, Ruff format, and signoff checks.

### Additional information (optional, e.g., figures and logs):

The markup checker intentionally exits successfully for warnings that identify silent mis-rendering; only build-breaking errors return a nonzero status.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
