### PR TITLE
fix(sac): validate CrossQ q-head config

### DIFF
--- a/docs/source-en/rst_source/reference/algorithms/crossq.rst
+++ b/docs/source-en/rst_source/reference/algorithms/crossq.rst
@@ -67,7 +67,11 @@ This ensures the BN statistics are computed over a mixture of current and replay
 4. Configuration
 --------------------
 
-CrossQ shares a nearly identical configuration with SAC. A single parameter, `q_head_type`, can be used to toggle between the CrossQ and standard SAC architectures.
+CrossQ shares a nearly identical configuration with SAC. Set ``q_head_type`` in
+both ``algorithm`` and ``actor.model``: the algorithm field selects the CrossQ
+training path, while the model field constructs the CrossQ critic head. The two
+values must match. CrossQ currently supports ``actor.model.model_type`` values
+``"mlp_policy"`` and ``"cnn_policy"``.
 
 .. code-block:: yaml
 
@@ -101,3 +105,9 @@ CrossQ shares a nearly identical configuration with SAC. A single parameter, `q_
          cache_size: 6000  # number of trajectories cached in memory
          sample_window_size: 6000  # number of latest trajectories to sample from for replay buffer
          min_buffer_size: 2  # Minimum buffer size before training starts (in number of trajectories)
+
+   actor:
+      model:
+         model_type: "mlp_policy"
+         add_q_head: True
+         q_head_type: "crossq"

--- a/docs/source-zh/rst_source/reference/algorithms/crossq.rst
+++ b/docs/source-zh/rst_source/reference/algorithms/crossq.rst
@@ -70,7 +70,10 @@ CrossQ 引入了三个关键的设计：
 4. 配置
 ----------
 
-CrossQ与SAC使用几乎相同的配置。参数 `q_head_type` 可用于在CrossQ和标准SAC架构之间切换。
+CrossQ 与 SAC 使用几乎相同的配置。需要同时在 ``algorithm`` 和
+``actor.model`` 下设置 ``q_head_type``：algorithm 字段选择 CrossQ 训练路径，
+model 字段构造 CrossQ critic head，并且两个值必须一致。CrossQ 当前支持的
+``actor.model.model_type`` 为 ``"mlp_policy"`` 和 ``"cnn_policy"``。
 
 .. code-block:: yaml
 
@@ -102,3 +105,9 @@ CrossQ与SAC使用几乎相同的配置。参数 `q_head_type` 可用于在Cross
          cache_size: 6000 # 内存缓存的轨迹数量
          sample_window_size: 6000 # 滑动采样窗口大小
          min_buffer_size: 2  # 开始更新策略时缓冲区数据量最小值（以Trajectory为单位）
+
+   actor:
+      model:
+         model_type: "mlp_policy"
+         add_q_head: True
+         q_head_type: "crossq"

--- a/rlinf/algorithms/sac_policy_utils.py
+++ b/rlinf/algorithms/sac_policy_utils.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Mapping
+
+SAC_CROSSQ_MODEL_TYPES = frozenset({"cnn_policy", "mlp_policy"})
+SAC_Q_HEAD_TYPES = frozenset({"crossq", "default"})
+
+
+def _validate_sac_q_head_type(field_name: str, q_head_type: object) -> None:
+    if q_head_type is None:
+        return
+    if not isinstance(q_head_type, str) or q_head_type not in SAC_Q_HEAD_TYPES:
+        supported_types = ", ".join(sorted(SAC_Q_HEAD_TYPES))
+        raise ValueError(
+            f"{field_name} must be one of {supported_types}, got {q_head_type!r}."
+        )
+
+
+def resolve_sac_q_head_type(
+    algorithm_cfg: Mapping[str, object],
+    model_cfg: Mapping[str, object],
+) -> str:
+    """Resolve the SAC Q-head type after validating its duplicated config.
+
+    CrossQ changes both the training forward path and the model architecture,
+    which are configured in separate sections. Both fields must therefore be
+    explicitly set to ``crossq`` before CrossQ can be enabled.
+
+    Args:
+        algorithm_cfg: SAC algorithm configuration.
+        model_cfg: Actor model configuration.
+
+    Returns:
+        The resolved Q-head type, either ``default`` or ``crossq``.
+
+    Raises:
+        ValueError: If either field is invalid, the fields disagree, or the
+            selected model cannot construct a CrossQ critic.
+    """
+    algorithm_q_head_type = algorithm_cfg.get("q_head_type")
+    model_q_head_type = model_cfg.get("q_head_type")
+    _validate_sac_q_head_type("algorithm.q_head_type", algorithm_q_head_type)
+    _validate_sac_q_head_type("actor.model.q_head_type", model_q_head_type)
+
+    if algorithm_q_head_type is not None and model_q_head_type is not None:
+        if algorithm_q_head_type != model_q_head_type:
+            raise ValueError(
+                "algorithm.q_head_type and actor.model.q_head_type must match "
+                f"when both are set, got {algorithm_q_head_type!r} and "
+                f"{model_q_head_type!r}."
+            )
+        q_head_type = algorithm_q_head_type
+    elif algorithm_q_head_type is not None:
+        if algorithm_q_head_type == "crossq":
+            raise ValueError(
+                "actor.model.q_head_type must be set to 'crossq' when "
+                "algorithm.q_head_type is 'crossq', because CrossQ changes "
+                "the critic model architecture."
+            )
+        q_head_type = algorithm_q_head_type
+    elif model_q_head_type is not None:
+        if model_q_head_type == "crossq":
+            raise ValueError(
+                "algorithm.q_head_type must be set to 'crossq' when "
+                "actor.model.q_head_type is 'crossq', because CrossQ changes "
+                "the SAC training path."
+            )
+        q_head_type = model_q_head_type
+    else:
+        q_head_type = "default"
+
+    if q_head_type == "crossq":
+        model_type = model_cfg.get("model_type")
+        if model_type not in SAC_CROSSQ_MODEL_TYPES:
+            supported_models = ", ".join(sorted(SAC_CROSSQ_MODEL_TYPES))
+            raise ValueError(
+                f"CrossQ is not supported for actor.model.model_type={model_type!r}. "
+                f"Supported CrossQ model types: {supported_models}."
+            )
+
+    return q_head_type

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -24,6 +24,7 @@ import torch.nn.functional as F
 from omegaconf import OmegaConf, open_dict
 from omegaconf.dictconfig import DictConfig
 
+from rlinf.algorithms.sac_policy_utils import resolve_sac_q_head_type
 from rlinf.envs import SupportedEnvType
 from rlinf.scheduler.cluster import Cluster
 from rlinf.utils.placement import (
@@ -1447,6 +1448,18 @@ def validate_coding_online_rl_cfg(cfg: DictConfig) -> DictConfig:
     return cfg
 
 
+def _validate_embodied_sac_q_head_before_cluster(cfg: DictConfig) -> None:
+    """Validate the FSDP SAC Q-head before cluster startup."""
+    if cfg.runner.get("task_type") != "embodied":
+        return
+    if cfg.algorithm.get("loss_type") != "embodied_sac":
+        return
+    if cfg.actor.get("training_backend") != "fsdp":
+        return
+
+    resolve_sac_q_head_type(cfg.algorithm, cfg.actor.model)
+
+
 def validate_cfg(cfg: DictConfig) -> DictConfig:
     OmegaConf.set_struct(cfg, True)
 
@@ -1482,6 +1495,8 @@ def validate_cfg(cfg: DictConfig) -> DictConfig:
                 cfg.runner.logger.experiment_name,
                 "trace/trace_events.jsonl",
             )
+
+    _validate_embodied_sac_q_head_before_cluster(cfg)
 
     # Init cluster
     Cluster(

--- a/rlinf/workers/actor/fsdp_sac_policy_worker.py
+++ b/rlinf/workers/actor/fsdp_sac_policy_worker.py
@@ -22,6 +22,7 @@ import torch.nn.functional as F
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader
 
+from rlinf.algorithms.sac_policy_utils import resolve_sac_q_head_type
 from rlinf.config import SupportedModel
 from rlinf.data.schema.embodied_types import Trajectory
 from rlinf.data.storage.replay import (
@@ -58,6 +59,7 @@ class EmbodiedSACFSDPPolicy(EmbodiedFSDPActor):
         self.demo_buffer = None
         self.alpha_optimizer = None
         self.update_step = 0
+        self.use_crossq = False
         self.enable_drq = bool(getattr(self.cfg.actor, "enable_drq", False))
 
     def init_worker(self):
@@ -78,6 +80,14 @@ class EmbodiedSACFSDPPolicy(EmbodiedFSDPActor):
     def setup_model_and_optimizer(self, initialize_target=False) -> None:
         """Setup model, lr_scheduler, optimizer and grad_scaler."""
         """Add initializing target model logic."""
+        # RLT workers inherit this setup method but own a separate Q-head
+        # contract. Keep this resolver scoped to the embodied SAC worker path.
+        if self.cfg.algorithm.get("loss_type") == "embodied_sac":
+            self.use_crossq = (
+                resolve_sac_q_head_type(self.cfg.algorithm, self.cfg.actor.model)
+                == "crossq"
+            )
+
         module = self.model_provider_func()
         if initialize_target:
             target_module = self.model_provider_func()
@@ -345,7 +355,6 @@ class EmbodiedSACFSDPPolicy(EmbodiedFSDPActor):
 
     @Worker.timer("forward_critic")
     def forward_critic(self, batch):
-        use_crossq = self.cfg.algorithm.get("q_head_type", "default") == "crossq"
         bootstrap_type = self.cfg.algorithm.get("bootstrap_type", "standard")
         agg_q = self.cfg.algorithm.get("agg_q", "min")
         use_dsrl = self.cfg.actor.model.get("openpi", {}).get("use_dsrl", False)
@@ -381,7 +390,7 @@ class EmbodiedSACFSDPPolicy(EmbodiedFSDPActor):
             if next_state_log_pi.ndim == 1:
                 next_state_log_pi = next_state_log_pi.unsqueeze(-1)
             next_state_log_pi = next_state_log_pi.sum(dim=-1, keepdim=True)
-            if not use_crossq:
+            if not self.use_crossq:
                 dsrl_kwargs = {"train": True} if use_dsrl else {}
                 all_qf_next_target = self.target_model(
                     forward_type=ForwardType.SAC_Q,
@@ -428,7 +437,7 @@ class EmbodiedSACFSDPPolicy(EmbodiedFSDPActor):
                 else:
                     raise NotImplementedError(f"{bootstrap_type=} is not supported!")
 
-        if not use_crossq:
+        if not self.use_crossq:
             dsrl_kwargs = {"train": True} if use_dsrl else {}
             all_data_q_values = self.model(
                 forward_type=ForwardType.SAC_Q,
@@ -474,7 +483,6 @@ class EmbodiedSACFSDPPolicy(EmbodiedFSDPActor):
 
     @Worker.timer("forward_actor")
     def forward_actor(self, batch):
-        use_crossq = self.cfg.algorithm.get("q_head_type", "default") == "crossq"
         if "actor_agg_q" in self.cfg.algorithm:
             agg_q = self.cfg.algorithm["actor_agg_q"]
         else:
@@ -492,7 +500,7 @@ class EmbodiedSACFSDPPolicy(EmbodiedFSDPActor):
         if log_pi.ndim == 1:
             log_pi = log_pi.unsqueeze(-1)
         log_pi = log_pi.sum(dim=-1, keepdim=True)  # sum over the chunk dimension
-        if not use_crossq:
+        if not self.use_crossq:
             dsrl_kwargs = {"train": True} if self.use_dsrl else {}
             all_qf_pi = self.model(
                 forward_type=ForwardType.SAC_Q,

--- a/tests/unit_tests/test_crossq_config_validation.py
+++ b/tests/unit_tests/test_crossq_config_validation.py
@@ -1,0 +1,109 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+
+import rlinf.config as config_module
+
+
+class ClusterStartedError(RuntimeError):
+    """Raised when validation reaches cluster initialization."""
+
+
+def _reject_cluster_start(*args, **kwargs):
+    raise ClusterStartedError("Cluster started before CrossQ validation")
+
+
+def _minimal_fsdp_sac_cfg(
+    algorithm_q_head_type="default",
+    model_q_head_type="default",
+    model_type="mlp_policy",
+):
+    return OmegaConf.create(
+        {
+            "runner": {"task_type": "embodied"},
+            "cluster": {},
+            "algorithm": {
+                "loss_type": "embodied_sac",
+                "q_head_type": algorithm_q_head_type,
+            },
+            "actor": {
+                "training_backend": "fsdp",
+                "model": {
+                    "model_type": model_type,
+                    "q_head_type": model_q_head_type,
+                },
+            },
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("algorithm_q_head_type", "model_q_head_type"),
+    [("crossq", "default"), ("default", "crossq")],
+)
+def test_validate_cfg_rejects_crossq_mismatch_before_cluster(
+    monkeypatch, algorithm_q_head_type, model_q_head_type
+):
+    cfg = _minimal_fsdp_sac_cfg(
+        algorithm_q_head_type=algorithm_q_head_type,
+        model_q_head_type=model_q_head_type,
+    )
+    monkeypatch.setattr(config_module, "Cluster", _reject_cluster_start)
+
+    with pytest.raises(ValueError, match="q_head_type"):
+        config_module.validate_cfg(cfg)
+
+
+def test_validate_cfg_rejects_unsupported_crossq_model_before_cluster(monkeypatch):
+    cfg = _minimal_fsdp_sac_cfg(
+        algorithm_q_head_type="crossq",
+        model_q_head_type="crossq",
+        model_type="flow_policy",
+    )
+    monkeypatch.setattr(config_module, "Cluster", _reject_cluster_start)
+
+    with pytest.raises(ValueError, match="CrossQ.*flow_policy|flow_policy.*CrossQ"):
+        config_module.validate_cfg(cfg)
+
+
+def test_validate_cfg_does_not_apply_crossq_guard_to_other_losses(monkeypatch):
+    cfg = _minimal_fsdp_sac_cfg(
+        algorithm_q_head_type="crossq",
+        model_q_head_type="default",
+    )
+    cfg.algorithm.loss_type = "actor_critic"
+    monkeypatch.setattr(config_module, "Cluster", _reject_cluster_start)
+
+    with pytest.raises(ClusterStartedError, match="before CrossQ validation"):
+        config_module.validate_cfg(cfg)
+
+
+def test_composed_crossq_example_passes_precluster_validation(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[2]
+    embodiment_path = repo_root / "examples" / "embodiment"
+    monkeypatch.setenv("EMBODIED_PATH", str(embodiment_path))
+    monkeypatch.setattr(config_module, "Cluster", _reject_cluster_start)
+
+    with initialize_config_dir(
+        config_dir=str(embodiment_path / "config"), version_base="1.1"
+    ):
+        cfg = compose(config_name="maniskill_crossq_mlp")
+
+    with pytest.raises(ClusterStartedError, match="before CrossQ validation"):
+        config_module.validate_cfg(cfg)

--- a/tests/unit_tests/test_sac_policy_utils.py
+++ b/tests/unit_tests/test_sac_policy_utils.py
@@ -1,0 +1,82 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rlinf.algorithms.sac_policy_utils import resolve_sac_q_head_type
+
+
+def test_resolve_sac_q_head_type_defaults_to_standard_head():
+    assert resolve_sac_q_head_type({}, {}) == "default"
+
+
+@pytest.mark.parametrize(
+    ("algorithm_cfg", "model_cfg"),
+    [({"q_head_type": "default"}, {}), ({}, {"q_head_type": "default"})],
+)
+def test_resolve_sac_q_head_type_preserves_one_sided_standard_configs(
+    algorithm_cfg, model_cfg
+):
+    assert resolve_sac_q_head_type(algorithm_cfg, model_cfg) == "default"
+
+
+@pytest.mark.parametrize("model_type", ["mlp_policy", "cnn_policy"])
+def test_resolve_sac_q_head_type_accepts_supported_crossq_models(model_type):
+    assert (
+        resolve_sac_q_head_type(
+            {"q_head_type": "crossq"},
+            {"q_head_type": "crossq", "model_type": model_type},
+        )
+        == "crossq"
+    )
+
+
+@pytest.mark.parametrize(
+    ("algorithm_cfg", "model_cfg"),
+    [
+        ({"q_head_type": "crossq"}, {"model_type": "mlp_policy"}),
+        ({}, {"q_head_type": "crossq", "model_type": "mlp_policy"}),
+        (
+            {"q_head_type": "crossq"},
+            {"q_head_type": "default", "model_type": "mlp_policy"},
+        ),
+    ],
+)
+def test_resolve_sac_q_head_type_rejects_incomplete_or_divergent_crossq(
+    algorithm_cfg, model_cfg
+):
+    with pytest.raises(ValueError, match="q_head_type"):
+        resolve_sac_q_head_type(algorithm_cfg, model_cfg)
+
+
+@pytest.mark.parametrize(
+    ("algorithm_cfg", "model_cfg"),
+    [
+        ({"q_head_type": "invalid"}, {}),
+        ({}, {"q_head_type": "invalid"}),
+        ({"q_head_type": []}, {}),
+    ],
+)
+def test_resolve_sac_q_head_type_rejects_invalid_values(algorithm_cfg, model_cfg):
+    with pytest.raises(ValueError, match="q_head_type"):
+        resolve_sac_q_head_type(algorithm_cfg, model_cfg)
+
+
+@pytest.mark.parametrize("model_type", [None, "flow_policy"])
+def test_resolve_sac_q_head_type_rejects_unsupported_crossq_model(model_type):
+    with pytest.raises(ValueError, match="CrossQ.*model_type"):
+        resolve_sac_q_head_type(
+            {"q_head_type": "crossq"},
+            {"q_head_type": "crossq", "model_type": model_type},
+        )


### PR DESCRIPTION
### Description

Centralize the SAC Q-head decision so CrossQ cannot use different values in `algorithm.q_head_type` and `actor.model.q_head_type`.

This change:

- resolves and validates both fields through one pure helper
- rejects incomplete, divergent, invalid, or unsupported CrossQ configs before cluster startup
- caches the resolved CrossQ decision in the FSDP SAC worker
- keeps the worker-side guard scoped to `embodied_sac`, because RLT inherits the setup method but owns a separate Q-head contract
- documents the two required fields and supported MLP/CNN models in EN and ZH

### Motivation and Context

This is the small CrossQ-only follow-up suggested during review of #1184. It does not include EDAC, ignore-file changes, or unrelated cleanup.

CrossQ changes two independent things: the SAC forward path and the critic architecture. The former was selected from `algorithm.q_head_type`, while the latter was built from `actor.model.q_head_type`. The duplicated ownership was introduced with SAC/CrossQ support in `d34f91b6` (#464), but there was no invariant requiring the values to agree. A mismatch could therefore survive configuration loading and reach worker/model initialization with incompatible semantics.

`validate_cfg()` also initialized `Cluster` before task-specific validation, so the failure could allocate distributed resources before identifying the bad configuration. The new pure resolver is called at the pre-cluster boundary and again defensively when the SAC worker builds its model.

#### Minimal reproduction

Baseline: `9ad44393`, with only the regression test added.

```bash
PYTHONPATH=.:tests/unit_tests pytest -q tests/unit_tests/test_crossq_config_validation.py
```

Before the fix, both mismatch directions fail at `rlinf/config.py:1487` with:

```text
ClusterStartedError: Cluster started before CrossQ validation
```

The expected `q_head_type` configuration error is now raised before `Cluster` is constructed. The real Hydra-composed `maniskill_crossq_mlp` config is also covered as a positive regression.

### How has this been tested?

```bash
PYTHONPATH=.:tests/unit_tests pytest -q \
  tests/unit_tests/test_sac_policy_utils.py \
  tests/unit_tests/test_crossq_config_validation.py \
  tests/unit_tests/test_cluster_config.py
# 73 passed, 1 skipped (hardware-dependent)

pre-commit run --all-files

sphinx-build -W -b html docs/source-en <build-dir-en>
sphinx-build -W -b html docs/source-zh <build-dir-zh>
```

Both documentation trees completed with warnings treated as errors. A SAC worker import smoke and the custom-model registration tests also passed.

GPU training and embodied e2e tests were not run locally. The change is limited to startup validation and branch selection; it does not alter valid SAC/CrossQ losses or training math.

### Additional information (optional, e.g., figures and logs):

Deliberately out of scope: EDAC regularization, RLT Q-head validation, configuration schema migration, `.gitignore`, and unrelated documentation.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
