### PR TITLE
fix(sft): use bf16 model precision for maniskill rlt stage1

### DIFF
--- a/examples/sft/config/maniskill_rlt_stage1_sft_openpi_pi05.yaml
+++ b/examples/sft/config/maniskill_rlt_stage1_sft_openpi_pi05.yaml
@@ -41,7 +41,7 @@ actor:
   seed: 0
 
   model:
-    precision: fp32
+    precision: bf16
     model_path: "/path/to/pi05_base"
     model_type: "openpi_rlinf"
     num_action_chunks: 10

--- a/tests/e2e_tests/sft/maniskill_rlt_stage1_sft_openpi_pi05.yaml
+++ b/tests/e2e_tests/sft/maniskill_rlt_stage1_sft_openpi_pi05.yaml
@@ -41,7 +41,7 @@ actor:
   seed: 0
 
   model:
-    precision: fp32
+    precision: bf16
     model_path: "/workspace/dataset/pi05_base/"
     model_type: "openpi_rlinf"
     num_action_chunks: 10


### PR DESCRIPTION
### Motivation
When running Stage 1 SFT for OpenPI + RLT on ManiSkill after updating to `openpi_rlinf`, `actor.model.precision` was set to `fp32`, causing model parameters and intermediate memory allocation to double compared to `bf16`. This forced reducing `micro_batch_size` and altered convergence speed.

### Changes
Changed `actor.model.precision` from `fp32` to `bf16` in both `examples/sft/config/maniskill_rlt_stage1_sft_openpi_pi05.yaml` and `tests/e2e_tests/sft/maniskill_rlt_stage1_sft_openpi_pi05.yaml` to match `fsdp_config.mixed_precision.param_dtype: bf16`.

Addresses #1483

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
