### PR TITLE
feat(openpi): add policy and data tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ rlinf/envs/maniskill/assets
 PKG-INFO
 *.egg-info/
 .claude/settings.json
+/.sii

--- a/docs/source-en/rst_source/examples/embodied/sft_openpi.rst
+++ b/docs/source-en/rst_source/examples/embodied/sft_openpi.rst
@@ -120,17 +120,20 @@ When you train OpenPI on a newly collected LeRobot dataset, compute dataset
 normalization statistics before launching SFT. This is especially important for
 a real-world collected dataset.
 
-RLinf provides ``toolkits/lerobot/calculate_norm_stats.py`` to calculate norm_stats for ``state`` and ``actions``. You can use it like:
+RLinf provides ``toolkits/lerobot/calculate_norm_stats_fast.py`` to calculate
+normalization statistics for ``state`` and ``actions`` without reading or
+decoding image and video columns. It scans the full dataset, including the final
+partial batch. Use it as follows:
 
 .. code:: bash
 
    # Local dataset directory (contains meta/info.json):
-   python toolkits/lerobot/calculate_norm_stats.py \
+   python toolkits/lerobot/calculate_norm_stats_fast.py \
        --config-name pi0_realworld \
        --repo-id /path/to/realworld_franka_bin_relocation
 
    # Or a Hugging Face repo id cached under ~/.cache/huggingface/lerobot by default:
-   python toolkits/lerobot/calculate_norm_stats.py \
+   python toolkits/lerobot/calculate_norm_stats_fast.py \
        --config-name pi0_realworld \
        --repo-id realworld_franka_bin_relocation
 
@@ -139,9 +142,16 @@ RLinf provides ``toolkits/lerobot/calculate_norm_stats.py`` to calculate norm_st
    - ``--repo-id`` accepts a local dataset path or a LeRobot Hugging Face repo id.
    - Optionally set ``HF_LEROBOT_HOME`` to change the cache parent for repo ids (default: ``~/.cache/huggingface/lerobot``).
    - ``config_name`` must match your custom openpi dataconfig used by training.
+   - The default output is ``<resolved_dataset_root>/norm_stats_fast.json``. The
+     script refuses to overwrite an existing file unless ``--overwrite`` is set.
+   - Use ``--output-path /path/to/name.json`` to select another output file.
 
-The script writes the generated stats under ``<assets_dir>/<exp_name>/<repo_id>/norm_stats.json``.
-The OpenPI loader later reads the normalization stats from ``<model_path>/<repo_id>`` at runtime.
+OpenPI normally auto-loads a file named ``norm_stats.json``. After validating the
+fast result, either point the training config's ``norm_stats_path`` at the new
+file or explicitly promote it to ``norm_stats.json``. The fast script never
+replaces the official file automatically. If a custom data transform derives
+``state`` or ``actions`` from real image pixels, use the reference
+``toolkits/lerobot/calculate_norm_stats.py`` instead.
 
 A practical tip for stable training is to manually check the normalization statistics for very small standard deviations or narrow q99–q01 ranges. Increasing the standard deviation or widening the q99–q01 gap can help stabilize training, especially in two-stage pipelines that transition from SFT to online training.
 

--- a/docs/source-en/rst_source/guides/performance/index.rst
+++ b/docs/source-en/rst_source/guides/performance/index.rst
@@ -22,6 +22,8 @@ training efficiency becomes the bottleneck.
      - Dynamically schedule resources during training.
    * - :doc:`Profiling <../profile>`
      - System-level profiling of Ray worker processes.
+   * - :doc:`Policy Server Comparison <../policy_server_compare>`
+     - Diagnose OpenPI and RLinf policy server outputs, randomness, latency, and action jitter on identical observations.
    * - :doc:`5D Parallelism <../5D>`
      - Configure 5D parallelism for large models.
 
@@ -34,4 +36,5 @@ training efficiency becomes the bottleneck.
    Auto Placement <../auto_placement>
    Dynamic Scheduling <../dynamic_scheduling>
    Profiling <../profile>
+   Policy Server Comparison <../policy_server_compare>
    5D Parallelism <../5D>

--- a/docs/source-en/rst_source/guides/policy_server_compare.rst
+++ b/docs/source-en/rst_source/guides/policy_server_compare.rst
@@ -1,0 +1,117 @@
+Compare OpenPI Policy Servers
+=============================
+
+Measure the deployed behavior of an OpenPI server and an RLinf policy server
+on the same real ALOHA observations, without restarting or modifying either
+server.
+
+Prepare the Diagnostic Environment
+----------------------------------
+
+Start both OpenPI-compatible WebSocket servers before you run the diagnostic.
+The default endpoints are ``127.0.0.1:8000`` for OpenPI and
+``127.0.0.1:8001`` for RLinf. The defaults also match the currently
+deployed wire layouts: ``--openpi-image-layout chw`` and
+``--rlinf-image-layout hwc``. Both servers receive the same decoded pixels;
+only the axis order differs. Install the optional analysis dependencies in
+the environment that runs the client:
+
+.. code-block:: bash
+
+   python -m pip install pyarrow Pillow matplotlib openpi-client websockets
+
+The packages are imported only by this toolkit. They do not become RLinf core
+runtime dependencies.
+
+Run the Comparison
+------------------
+
+Run the default comparison from the repository root:
+
+.. code-block:: bash
+
+   python toolkits/lerobot/compare_policy_servers.py \
+       --dataset-root data/lerobot-data_mixed_8_v30
+
+What this does: it selects one episode for each of the 11 dataset prompts,
+sends three evenly spaced observations three times, and evaluates three
+consecutive replanning chunks. It keeps one persistent connection to each
+server and writes a timestamped run under
+``results/policy_server_compare/``.
+
+Narrow the run before a full diagnostic:
+
+.. code-block:: bash
+
+   python toolkits/lerobot/compare_policy_servers.py \
+       --dataset-root data/lerobot-data_mixed_8_v30 \
+       --prompt-regex "Place the bread" \
+       --paired-frames 1 \
+       --repeats 1 \
+       --replay-chunks 1 \
+       --request-timeout 120
+
+Use ``--episode-ids 12 24`` to select explicit episodes. Use
+``--episodes-per-prompt``, ``--seed``, ``--openpi-host``, ``--openpi-port``,
+``--rlinf-host``, ``--rlinf-port``, and ``--output-dir`` to control sampling,
+connections, and output placement.
+
+Interpret the Metrics
+---------------------
+
+Use the three metric groups to separate deployment differences from sampling
+noise and temporal behavior.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Group
+     - Interpretation
+   * - Common-prefix difference
+     - MAE, RMSE, P95, maximum error, joint-standard-deviation-normalized MAE,
+       and per-joint/per-step errors over the shared horizon and first 14
+       action dimensions.
+   * - Randomness
+     - Output standard deviation and repeat-to-repeat MAE for repeated calls on
+       an identical observation.
+   * - Jitter proxies
+     - First-action state jump, first and second chunk differences, dataset
+       action error, and the boundary jump between full-horizon replans.
+
+Inspect the Artifacts
+---------------------
+
+Each timestamped directory contains the complete inputs needed to trace an
+aggregate result back to an episode and frame.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Artifact
+     - Contents
+   * - ``run_metadata.json``
+     - CLI arguments, selected episodes, endpoints, handshake metadata, and
+       observed response contracts.
+   * - ``raw_outputs.npz``
+     - Raw paired and replay action chunks with a serialized index.
+   * - ``summary.json`` and ``report.md``
+     - Aggregate metrics, worst prompt, joint, and horizon step, plus the
+       contract warning.
+   * - ``sample_metrics.csv``
+     - Per-request difference, client RTT, and server inference timing.
+   * - ``per_joint_metrics.csv`` and ``per_horizon_metrics.csv``
+     - Detailed common-prefix errors.
+   * - ``jitter_metrics.csv``
+     - Per-chunk jitter proxies and replanning boundary jumps.
+   * - PNG plots
+     - Difference heatmap, worst-sample action trace, and jitter comparison.
+
+.. warning::
+
+   Treat this result as a diagnostic of the currently deployed services. If
+   action horizons, checkpoints, denoising settings, metadata, or other model
+   contracts differ, the common-prefix metrics are not strict numerical
+   parity evidence. Align both server contracts before drawing implementation
+   parity conclusions.

--- a/docs/source-zh/rst_source/examples/embodied/sft_openpi.rst
+++ b/docs/source-zh/rst_source/examples/embodied/sft_openpi.rst
@@ -118,18 +118,19 @@ RLinf 支持 LeRobot 格式的数据集，通过 ``config_name`` 字段指定。
 当你在新采集的 LeRobot 数据集上训练 OpenPI 时，需要在启动 SFT 之前先计算
 归一化统计。这对真实机器人采集的数据集尤其重要。
 
-RLinf 提供了 ``toolkits/lerobot/calculate_norm_stats.py``，用于为
-``state`` 和 ``actions`` 计算 ``norm_stats``。使用方式如下：
+RLinf 提供了 ``toolkits/lerobot/calculate_norm_stats_fast.py``，无需读取或解码
+图像和视频列，即可为 ``state`` 和 ``actions`` 计算全量归一化统计；最后一个不足
+完整 batch 的尾批也会纳入统计。使用方式如下：
 
 .. code:: bash
 
    # 本地数据集目录（包含 meta/info.json）：
-   python toolkits/lerobot/calculate_norm_stats.py \
+   python toolkits/lerobot/calculate_norm_stats_fast.py \
        --config-name pi0_realworld \
        --repo-id /path/to/realworld_franka_bin_relocation
 
    # 或使用默认缓存在 ~/.cache/huggingface/lerobot 下的 Hugging Face repo id：
-   python toolkits/lerobot/calculate_norm_stats.py \
+   python toolkits/lerobot/calculate_norm_stats_fast.py \
        --config-name pi0_realworld \
        --repo-id realworld_franka_bin_relocation
 
@@ -138,9 +139,15 @@ RLinf 提供了 ``toolkits/lerobot/calculate_norm_stats.py``，用于为
    - ``--repo-id`` 可以是本地数据集路径，也可以是 LeRobot 的 Hugging Face repo id。
    - 可选：通过 ``HF_LEROBOT_HOME`` 修改 repo id 的缓存父目录（默认：``~/.cache/huggingface/lerobot``）。
    - ``config_name`` 必须与训练时使用的自定义 OpenPI dataconfig 一致。
+   - 默认输出为 ``<resolved_dataset_root>/norm_stats_fast.json``。除非显式设置
+     ``--overwrite``，否则脚本不会覆盖已有文件。
+   - 使用 ``--output-path /path/to/name.json`` 可以指定其他输出文件。
 
-该脚本会将生成的统计信息写入 ``<assets_dir>/<exp_name>/<repo_id>/norm_stats.json``。
-OpenPI 加载器会在运行时从 ``<model_path>/<repo_id>`` 读取归一化统计信息。
+OpenPI 默认自动加载名为 ``norm_stats.json`` 的文件。验证快速计算结果后，可在训练
+配置中将 ``norm_stats_path`` 指向新文件，或显式将其提升为 ``norm_stats.json``。
+快速脚本不会自动替换正式文件。如果自定义 data transform 通过真实图像像素计算
+``state`` 或 ``actions``，请改用参考实现
+``toolkits/lerobot/calculate_norm_stats.py``。
 
 另一个有助于稳定训练的实用建议是，手动检查归一化统计中是否存在非常小的标准差，
 或过窄的 q99-q01 区间。适当增大标准差，或拉宽 q99-q01 的范围，通常有助于提升

--- a/docs/source-zh/rst_source/guides/performance/index.rst
+++ b/docs/source-zh/rst_source/guides/performance/index.rst
@@ -21,6 +21,8 @@
      - 训练过程中动态调度资源。
    * - :doc:`Profiling <../profile>`
      - 对 Ray worker 进程进行系统级 profiling。
+   * - :doc:`Policy Server 对比 <../policy_server_compare>`
+     - 使用相同 observation 诊断 OpenPI 与 RLinf policy server 的输出、随机性、延迟和 action 抖动。
    * - :doc:`5D 并行 <../5D>`
      - 为大模型配置 5D 并行。
 
@@ -33,4 +35,5 @@
    自动 Placement <../auto_placement>
    动态调度 <../dynamic_scheduling>
    Profiling <../profile>
+   Policy Server 对比 <../policy_server_compare>
    5D 并行 <../5D>

--- a/docs/source-zh/rst_source/guides/policy_server_compare.rst
+++ b/docs/source-zh/rst_source/guides/policy_server_compare.rst
@@ -1,0 +1,104 @@
+对比 OpenPI Policy Server
+=========================
+
+在不修改或重启服务的情况下，使用相同的真实 ALOHA observation 测量
+OpenPI server 与 RLinf policy server 的当前部署行为。
+
+准备诊断环境
+------------
+
+运行诊断前，先启动两个兼容 OpenPI 协议的 WebSocket server。默认端点为
+OpenPI 的 ``127.0.0.1:8000`` 和 RLinf 的 ``127.0.0.1:8001``。默认值也匹配当前部署的 wire layout：
+``--openpi-image-layout chw`` 和 ``--rlinf-image-layout hwc``。两个 server
+接收相同的解码像素，仅 axis 顺序不同。在运行客户端
+的环境中安装可选分析依赖：
+
+.. code-block:: bash
+
+   python -m pip install pyarrow Pillow matplotlib openpi-client websockets
+
+这些包仅由该 toolkit 延迟导入，不会成为 RLinf 核心运行时依赖。
+
+运行对比
+--------
+
+在仓库根目录运行默认对比：
+
+.. code-block:: bash
+
+   python toolkits/lerobot/compare_policy_servers.py \
+       --dataset-root data/lerobot-data_mixed_8_v30
+
+该命令会为数据集的 11 个 prompt 各选择一个 episode，对三个均匀分布的
+observation 分别重复请求三次，并评估三个连续重规划 action chunk。脚本会为
+两个 server 各保留一个持久连接，并将带时间戳的结果写入
+``results/policy_server_compare/``\ 。
+
+在完整诊断前先缩小运行范围：
+
+.. code-block:: bash
+
+   python toolkits/lerobot/compare_policy_servers.py \
+       --dataset-root data/lerobot-data_mixed_8_v30 \
+       --prompt-regex "Place the bread" \
+       --paired-frames 1 \
+       --repeats 1 \
+       --replay-chunks 1 \
+       --request-timeout 120
+
+使用 ``--episode-ids 12 24`` 选择指定 episode。使用
+``--episodes-per-prompt``\ 、``--seed``\ 、``--openpi-host``\ 、
+``--openpi-port``\ 、``--rlinf-host``\ 、``--rlinf-port`` 和
+``--output-dir`` 控制采样、连接与输出位置。
+
+理解指标
+--------
+
+通过三组指标区分部署差异、采样随机性与时间连续性。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - 指标组
+     - 含义
+   * - 共同前缀差异
+     - 在共同 horizon 和前 14 个 action 维度上计算 MAE、RMSE、P95、最大
+       误差、按 joint 标准差归一化的 MAE，以及逐 joint、逐 step 误差。
+   * - 随机性
+     - 对相同 observation 重复请求，计算输出标准差和 repeat-to-repeat MAE。
+   * - 抖动代理
+     - 计算首 action 相对 state 的跳变、chunk 内一阶和二阶差分、相对数据集
+       action 的误差，以及完整 horizon 重规划时的边界跳变。
+
+检查产物
+--------
+
+每个带时间戳的目录都保留从汇总结果追溯到 episode 和 frame 所需的信息。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - 产物
+     - 内容
+   * - ``run_metadata.json``
+     - CLI 参数、选中的 episode、端点、握手 metadata 和实际响应合同。
+   * - ``raw_outputs.npz``
+     - 原始配对与 replay action chunk，以及序列化索引。
+   * - ``summary.json`` 和 ``report.md``
+     - 汇总指标、最差 prompt、joint、horizon step，以及合同限制提示。
+   * - ``sample_metrics.csv``
+     - 逐请求差异、客户端 RTT 和 server inference time。
+   * - ``per_joint_metrics.csv`` 和 ``per_horizon_metrics.csv``
+     - 共同前缀的详细误差。
+   * - ``jitter_metrics.csv``
+     - 逐 chunk 抖动代理和重规划边界跳变。
+   * - PNG 图表
+     - 差异热图、最差样本 action trace 和抖动对比图。
+
+.. warning::
+
+   请将结果视为当前部署服务的行为诊断。如果 action horizon、checkpoint、
+   denoising 设置、metadata 或其他模型合同不一致，共同前缀指标不能作为严格
+   数值 parity 的证据。在判断实现 parity 前，请先对齐两个 server 的合同。

--- a/examples/sft/config/aloha_sft_openpi_pi05_full_fsdp2h100.yaml
+++ b/examples/sft/config/aloha_sft_openpi_pi05_full_fsdp2h100.yaml
@@ -1,0 +1,99 @@
+# Canonical mixed ALOHA Pi0.5 full-parameter SFT configuration using the
+# JAX-aligned openpi_rlinf model. Hardware: one node, two H100 80GB GPUs.
+# This entry point starts from the fp32 Pi0.5 base checkpoint, not a LoRA or
+# legacy OpenPI SFT checkpoint.
+
+defaults:
+  - model/pi0_5_rlinf@actor.model
+  - hybrid_engines/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+  - _self_
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    actor,env,rollout: 0-1
+
+runner:
+  task_type: sft
+  resume_dir: null
+  logger:
+    log_path: ../results
+    project_name: rlinf
+    experiment_name: aloha_sft_openpi_pi05_full_fsdp2h100
+    logger_backends: [tensorboard]
+  max_epochs: -1
+  # The Pi0.5 ALOHA reference recipe trains for 20k steps while its cosine
+  # schedule is parameterized over 30k steps.
+  max_steps: 20000
+  val_check_interval: -1
+  # Every checkpoint is resumable and also exports full_weights.pt.
+  save_interval: 5000
+
+data:
+  # Pass the concrete LeRobot v3.0 dataset root to the official OpenPI loader.
+  train_data_paths: ${oc.env:ALOHA_DATASET_ROOT}
+  num_workers: 4
+
+actor:
+  group_name: ActorGroup
+  training_backend: fsdp
+  # Start from the maintained two-GPU openpi_rlinf batch size. Increase only
+  # after measuring H100 memory with the 50-step action horizon.
+  micro_batch_size: 16
+  global_batch_size: 32
+  seed: 0
+
+  model:
+    # Keep fp32 optimizer master weights; FSDP casts parameters to bf16 only
+    # for forward/backward computation.
+    precision: fp32
+    model_path: ${oc.env:PI05_MODEL_PATH}
+    # pi05_aloha_robotwin uses a 50-step action horizon and pads 14-D ALOHA
+    # actions to the model's 32-D action space.
+    num_action_chunks: 20
+    action_dim: 14
+    is_lora: false
+    add_value_head: false
+    openpi:
+      config_name: pi05_aloha_robotwin
+      num_images_in_input: 3
+      action_chunk: ${actor.model.num_action_chunks}
+      action_env_dim: ${actor.model.action_dim}
+    openpi_data:
+      # These statistics were computed from lerobot-data_mixed_8_v30. Do not
+      # reuse the old sandwich_merged statistics for the mixed dataset.
+      norm_stats_path: ${oc.env:ALOHA_NORM_STATS_PATH}
+
+  optim:
+    lr: 2.5e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 1.0e-10
+    clip_grad: 1.0
+    lr_warmup_steps: 1000
+    total_training_steps: 30000
+    lr_scheduler: openpi_cosine
+    num_cycles: 0.5
+    min_lr: 2.5e-6
+
+  fsdp_config:
+    strategy: fsdp
+    sharding_strategy: full_shard
+    use_orig_params: true
+    enable_gradient_accumulation: false
+    gradient_checkpointing: true
+    gradient_checkpointing_use_reentrant: false
+    save_full_model_weights: true
+    mixed_precision:
+      param_dtype: bf16
+      reduce_dtype: fp32
+      buffer_dtype: fp32

--- a/examples/sft/config/aloha_sft_openpi_pi05_full_fsdp2h100.yaml
+++ b/examples/sft/config/aloha_sft_openpi_pi05_full_fsdp2h100.yaml
@@ -46,7 +46,7 @@ actor:
   group_name: ActorGroup
   training_backend: fsdp
   # Start from the maintained two-GPU openpi_rlinf batch size. Increase only
-  # after measuring H100 memory with the 50-step action horizon.
+  # after measuring H100 memory with the 20-step action horizon.
   micro_batch_size: 16
   global_batch_size: 32
   seed: 0
@@ -56,8 +56,9 @@ actor:
     # for forward/backward computation.
     precision: fp32
     model_path: ${oc.env:PI05_MODEL_PATH}
-    # pi05_aloha_robotwin uses a 50-step action horizon and pads 14-D ALOHA
-    # actions to the model's 32-D action space.
+    # Override pi05_aloha_robotwin's default 50-step horizon with 20 steps. The
+    # official data loader uses this value too and pads 14-D ALOHA actions to
+    # the model's 32-D action space.
     num_action_chunks: 20
     action_dim: 14
     is_lora: false

--- a/examples/sft/config/aloha_sft_openpi_pi05_full_fsdp4090_debug.yaml
+++ b/examples/sft/config/aloha_sft_openpi_pi05_full_fsdp4090_debug.yaml
@@ -1,0 +1,81 @@
+# One-step structural debug for the JAX-aligned openpi_rlinf path only; do not
+# use this configuration for the formal 2xH100 run.
+defaults:
+  - model/pi0_5_rlinf@actor.model
+  - hybrid_engines/fsdp@actor.fsdp_config
+  - override hydra/job_logging: stdout
+  - _self_
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    "actor,env,rollout": 0-0
+
+runner:
+  task_type: sft
+  resume_dir: null
+  logger:
+    log_path: ../results
+    project_name: rlinf
+    experiment_name: aloha_sft_openpi_pi05_full_fsdp4090_debug
+    logger_backends: [tensorboard]
+  max_epochs: -1
+  max_steps: 1
+  val_check_interval: -1
+  save_interval: -1
+
+data:
+  train_data_paths: sandwich_merged
+  num_workers: 0
+
+actor:
+  group_name: ActorGroup
+  training_backend: fsdp
+  # Smoke-test precision only: one 48 GiB 4090 cannot hold fp32 parameters,
+  # gradients, and both Adam moments, while CPU offload exceeds this node's
+  # 100 GiB host-memory limit. The formal 2xH100 config keeps fp32 masters.
+  micro_batch_size: 1
+  global_batch_size: 1
+  seed: 0
+  model:
+    precision: bf16
+    model_path: /inspire/hdd/global_user/czxs253130583/fangchuan/data/model/lerobot/pi05_base
+    num_action_chunks: 20
+    action_dim: 14
+    is_lora: false
+    add_value_head: false
+    openpi:
+      config_name: pi05_aloha_robotwin
+      num_images_in_input: 3
+      action_chunk: ${actor.model.num_action_chunks}
+      action_env_dim: ${actor.model.action_dim}
+    openpi_data:
+      norm_stats_path: /inspire/hdd/global_user/czxs253130583/fangchuan/data/model/lerobot/pi05_base/aloha_sandwich_merged/norm_stats.json
+  optim:
+    lr: 2.5e-5
+    adam_beta1: 0.9
+    adam_beta2: 0.95
+    adam_eps: 1.0e-8
+    weight_decay: 1.0e-10
+    clip_grad: 1.0
+    lr_warmup_steps: 1000
+    total_training_steps: 30000
+    lr_scheduler: openpi_cosine
+    num_cycles: 0.5
+    min_lr: 2.5e-6
+  fsdp_config:
+    strategy: fsdp
+    sharding_strategy: full_shard
+    use_orig_params: true
+    enable_gradient_accumulation: false
+    gradient_checkpointing: true
+    gradient_checkpointing_use_reentrant: false
+    save_full_model_weights: true
+    mixed_precision: {param_dtype: bf16, reduce_dtype: fp32, buffer_dtype: fp32}

--- a/examples/sft/run_aloha_sft_openpi_pi05_full_fsdp2h100.sh
+++ b/examples/sft/run_aloha_sft_openpi_pi05_full_fsdp2h100.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Canonical launcher for Pi0.5 full-parameter ALOHA SFT on 2x H100 80GB.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+VENV="${VENV:-${REPO}/.venv}"
+
+# All paths can be overridden from the environment without editing this file.
+export ALOHA_DATASET_ROOT="${ALOHA_DATASET_ROOT:-${REPO}/data/lerobot-data_mixed_8_v30}"
+export ALOHA_NORM_STATS_PATH="${ALOHA_NORM_STATS_PATH:-${ALOHA_DATASET_ROOT}/norm_stats.json}"
+export PI05_MODEL_PATH="${PI05_MODEL_PATH:-/inspire/hdd/global_user/czxs253130583/fangchuan/data/model/lerobot/pi05_base}"
+export HF_LEROBOT_HOME="${HF_LEROBOT_HOME:-$(dirname -- "${ALOHA_DATASET_ROOT}")}"
+export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export OMP_NUM_THREADS="${OMP_NUM_THREADS:-16}"
+export PYTHONPATH="${REPO}:${PYTHONPATH:-}"
+export EMBODIED_PATH="${REPO}/examples/sft"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"
+
+if [ ! -f "${VENV}/bin/activate" ]; then
+    echo "[launcher] ERROR: Python environment not found: ${VENV}" >&2
+    exit 1
+fi
+# The repository venv contains RLinf/OpenPI dependencies. Activating an outer
+# Conda environment is neither required nor sufficient for this launcher.
+# shellcheck disable=SC1091
+source "${VENV}/bin/activate"
+cd "${REPO}"
+
+for required_path in \
+    "${ALOHA_DATASET_ROOT}/meta/info.json" \
+    "${ALOHA_NORM_STATS_PATH}" \
+    "${PI05_MODEL_PATH}/model.safetensors"; do
+    if [ ! -f "${required_path}" ]; then
+        echo "[launcher] ERROR: required file not found: ${required_path}" >&2
+        exit 1
+    fi
+done
+
+if [ "${SKIP_GPU_CHECK:-0}" != "1" ]; then
+    GPU_COUNT=$(python -c 'import torch; print(torch.cuda.device_count())')
+    if [ "${GPU_COUNT}" -lt 2 ]; then
+        echo "[launcher] ERROR: this FSDP config requires 2 visible GPUs; found ${GPU_COUNT}." >&2
+        echo "[launcher] CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}" >&2
+        echo "[launcher] Run this launcher on the intended 2-GPU node." >&2
+        exit 1
+    fi
+fi
+
+OUTPUT_ROOT="${OUTPUT_ROOT:-/inspire/hdd/global_user/czxs253130583/fangchuan/work/RL/output/model/sft/pi05_rlinf}"
+EXPERIMENT_NAME=aloha_sft_openpi_pi05_full_fsdp2h100
+
+# ---------------------------------------------------------------------------
+# 断点续训: 默认自动寻找 OUTPUT_ROOT 下最新保存的 global_step_* checkpoint
+# 并恢复 model + optimizer + lr_scheduler 完整训练状态。
+# 覆盖方式:
+#   RESUME_DIR=/path/to/checkpoints/global_step_XXXX  -> 显式指定恢复点
+#   RESUME=0                                          -> 从头训练 (不恢复)
+# ---------------------------------------------------------------------------
+RESUME_DIR="${RESUME_DIR:-}"
+if [ "${RESUME:-1}" = "0" ]; then
+    RESUME_DIR=""
+else
+    if [ -n "${RESUME_DIR}" ] && [ ! -d "${RESUME_DIR}/actor" ]; then
+        echo "[launcher] ERROR: RESUME_DIR=${RESUME_DIR} 下不存在 actor 子目录" >&2
+        exit 1
+    fi
+    if [ -z "${RESUME_DIR}" ]; then
+        RESUME_DIR=$(find "${OUTPUT_ROOT}" -maxdepth 4 -type d -name 'global_step_*' \
+            -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2- || true)
+    fi
+fi
+if [ -n "${RESUME_DIR}" ]; then
+    # 沿用该 checkpoint 所属 run 的目录, 使 tensorboard / checkpoint 连续续写
+    RUN_ID="${RUN_ID:-$(basename "$(dirname "$(dirname "$(dirname "${RESUME_DIR}")")")")}"
+    echo "[launcher] 断点续训: resume_dir=${RESUME_DIR}"
+else
+    echo "[launcher] 未找到可恢复的 checkpoint, 从头开始训练"
+fi
+RUN_ID="${RUN_ID:-$(date +'%Y%m%d-%H%M%S')-aloha-openpi-rlinf-full-fsdp2h100}"
+LOG_DIR="${OUTPUT_ROOT}/${RUN_ID}"
+mkdir -p "${LOG_DIR}"
+
+echo "Launching full-parameter Pi0.5 SFT on CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-all}"
+echo "Dataset: ${ALOHA_DATASET_ROOT}"
+echo "Norm stats: ${ALOHA_NORM_STATS_PATH}"
+echo "Base model: ${PI05_MODEL_PATH}"
+echo "Output: ${LOG_DIR}"
+TRAIN_CMD=(
+    python examples/sft/train_vla_sft.py
+    --config-path "${EMBODIED_PATH}/config/"
+    --config-name "${EXPERIMENT_NAME}"
+    "runner.logger.log_path=${LOG_DIR}"
+)
+if [ -n "${RESUME_DIR}" ]; then
+    TRAIN_CMD+=("runner.resume_dir=${RESUME_DIR}")
+fi
+TRAIN_CMD+=("$@")
+exec "${TRAIN_CMD[@]}"

--- a/rlinf/data/datasets/openpi_rlinf/official_sft_data_loader.py
+++ b/rlinf/data/datasets/openpi_rlinf/official_sft_data_loader.py
@@ -61,6 +61,9 @@ def build_official_openpi_sft_dataloader(
     if model_type == SupportedModel.OPENPI_RLINF:
         config = dataclasses.replace(
             config,
+            model=dataclasses.replace(
+                config.model, action_horizon=int(model_cfg.num_action_chunks)
+            ),
             num_workers=int(
                 OmegaConf.select(cfg, "data.num_workers", default=config.num_workers)
             ),

--- a/scripts/calculate_openpi_norm_stats.sh
+++ b/scripts/calculate_openpi_norm_stats.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Calculate OpenPI normalization statistics for a local LeRobot dataset.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+
+DEFAULT_DATASET="${REPO}/data/lerobot-data_mixed_8_v30"
+DATASET_PATH="${1:-${OPENPI_DATASET_PATH:-${DEFAULT_DATASET}}}"
+CONFIG_NAME="${2:-${OPENPI_CONFIG_NAME:-pi05_aloha_robotwin}}"
+VENV_PATH="${OPENPI_VENV_PATH:-${REPO}/.venv}"
+PROGRESS_INTERVAL_SECONDS="${PROGRESS_INTERVAL_SECONDS:-30}"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [DATASET_PATH] [CONFIG_NAME]
+
+Calculate OpenPI normalization statistics for a local LeRobot v3 dataset.
+
+Arguments:
+  DATASET_PATH  Dataset root containing meta/info.json.
+                Default: ${DEFAULT_DATASET}
+  CONFIG_NAME   OpenPI data configuration name.
+                Default: pi05_aloha_robotwin
+
+Environment overrides:
+  OPENPI_DATASET_PATH          Alternative to positional DATASET_PATH.
+  OPENPI_CONFIG_NAME           Alternative to positional CONFIG_NAME.
+  OPENPI_VENV_PATH             Python virtualenv. Default: ${REPO}/.venv
+  PROGRESS_INTERVAL_SECONDS    Hidden index-stage status interval. Default: 30
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") /path/to/lerobot-v3 pi05_aloha_robotwin
+  OPENPI_DATASET_PATH=/path/to/lerobot-v3 $(basename "$0")
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ ! "${PROGRESS_INTERVAL_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[norm-stats] ERROR: PROGRESS_INTERVAL_SECONDS must be a positive integer." >&2
+    exit 2
+fi
+
+if [[ "${DATASET_PATH}" != /* ]]; then
+    DATASET_PATH="${REPO}/${DATASET_PATH}"
+fi
+if [[ ! -f "${DATASET_PATH}/meta/info.json" ]]; then
+    echo "[norm-stats] ERROR: Missing ${DATASET_PATH}/meta/info.json" >&2
+    exit 1
+fi
+if [[ ! -x "${VENV_PATH}/bin/python" ]]; then
+    echo "[norm-stats] ERROR: Python not found at ${VENV_PATH}/bin/python" >&2
+    exit 1
+fi
+
+cd "${REPO}"
+source "${VENV_PATH}/bin/activate"
+export PYTHONPATH="${REPO}:${PYTHONPATH:-}"
+
+TOTAL_FILES=$(find "${DATASET_PATH}/data" -type f -name 'file-*.parquet' | wc -l)
+if [[ "${TOTAL_FILES}" -eq 0 ]]; then
+    echo "[norm-stats] ERROR: No v3 Parquet files found under ${DATASET_PATH}/data" >&2
+    exit 1
+fi
+
+# Prevent duplicate runs launched through this reusable script.
+exec 9>"${DATASET_PATH}/.calculate_norm_stats.lock"
+if command -v flock >/dev/null 2>&1 && ! flock -n 9; then
+    echo "[norm-stats] ERROR: Another norm-stats run holds the dataset lock." >&2
+    exit 1
+fi
+
+echo "[norm-stats] Repository : ${REPO}"
+echo "[norm-stats] Dataset    : ${DATASET_PATH}"
+echo "[norm-stats] Config     : ${CONFIG_NAME}"
+echo "[norm-stats] Files      : ${TOTAL_FILES}"
+echo "[norm-stats] Output     : ${DATASET_PATH}/norm_stats.json"
+
+"${VENV_PATH}/bin/python" toolkits/lerobot/calculate_norm_stats.py \
+    --config-name "${CONFIG_NAME}" \
+    --repo-id "${DATASET_PATH}" &
+WORKER_PID=$!
+
+monitor_index_progress() {
+    local current_path chunk_name file_name chunk_index file_index completed
+    while kill -0 "${WORKER_PID}" 2>/dev/null; do
+        current_path=$(
+            readlink /proc/"${WORKER_PID}"/fd/* 2>/dev/null |
+                grep "${DATASET_PATH}/data/chunk-[0-9]*/file-[0-9]*\.parquet" |
+                tail -1 || true
+        )
+        if [[ -n "${current_path}" ]]; then
+            chunk_name=$(basename "$(dirname "${current_path}")")
+            file_name=$(basename "${current_path}" .parquet)
+            chunk_index=${chunk_name#chunk-}
+            file_index=${file_name#file-}
+            completed=$((10#${chunk_index} * 1000 + 10#${file_index} + 1))
+            if ((completed > TOTAL_FILES)); then
+                completed=${TOTAL_FILES}
+            fi
+            awk -v done="${completed}" -v total="${TOTAL_FILES}" \
+                'BEGIN {printf "[norm-stats] Building dataset index: %d/%d (%.1f%%)\n", done, total, done*100/total}'
+        else
+            echo "[norm-stats] Waiting for index I/O or computing statistics; see the Python tqdm output."
+        fi
+        sleep "${PROGRESS_INTERVAL_SECONDS}"
+    done
+}
+
+monitor_index_progress &
+MONITOR_PID=$!
+
+cleanup_monitor() {
+    kill "${MONITOR_PID}" 2>/dev/null || true
+    wait "${MONITOR_PID}" 2>/dev/null || true
+}
+trap cleanup_monitor EXIT
+
+set +e
+wait "${WORKER_PID}"
+STATUS=$?
+set -e
+
+cleanup_monitor
+trap - EXIT
+
+if [[ "${STATUS}" -ne 0 ]]; then
+    echo "[norm-stats] ERROR: Calculation failed with exit code ${STATUS}." >&2
+    exit "${STATUS}"
+fi
+
+echo "[norm-stats] Complete: ${DATASET_PATH}/norm_stats.json"

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,220 @@
+# LeRobot Norm Stats 快速计算规格
+
+## 1. 背景
+
+当前 `toolkits/lerobot/calculate_norm_stats.py` 通过 OpenPI 通用
+`LeRobotDataset` 和 PyTorch DataLoader 遍历数据。在图像直接存储在
+Parquet 中的数据集上，这条路径会读取并解码每帧图像，但最终归一化
+统计只使用变换后的 `state` 和 `actions`。
+
+当前目标数据集 `data/lerobot-data_mixed_8_v30` 约为 273 GB，包含
+423,922 帧和三路图像。只投影读取 `observation.state`、`action`
+和 `episode_index` 的全量实测约读取 56 MB，用时约 26 秒。
+
+## 2. 目标
+
+新增 `toolkits/lerobot/calculate_norm_stats_fast.py`，为 RLinf 中的 OpenPI
+LeRobot 数据配置提供通用的快速 norm stats 计算路径。
+
+必须满足：
+
+- 不读取或解码真实图像、视频数据。
+- 保留 OpenPI dataconfig 定义的 repack 和 data transform 语义。
+- 支持单个或多个 `action_sequence_keys`。
+- 保留 LeRobot 的 action horizon 和 episode 边界 padding 语义。
+- 统计全部帧，包括不足一个 batch 的最后一批。
+- 默认写入独立的 `norm_stats_fast.json`，不与旧脚本正在生成的
+  `norm_stats.json` 冲突。
+- 输出 JSON 结构与现有 OpenPI norm stats 格式兼容。
+- 兼容 LeRobot v2/v3 本地数据集及已缓存的 Hugging Face repo id。
+
+## 3. 非目标
+
+- 不替换或删除现有 `calculate_norm_stats.py`。
+- 不支持 RLDS 数据集。
+- 不保证支持通过真实像素内容计算 `state` 或 `actions` 的自定义
+  transform。
+- 不引入抽样或近似统计；默认始终扫描全量数据。
+- 本规格阶段不修改任何代码、脚本或文档。
+
+## 4. 命令行接口
+
+快速脚本保持与现有脚本一致的必需参数：
+
+```bash
+python toolkits/lerobot/calculate_norm_stats_fast.py \
+    --config-name pi05_aloha_robotwin \
+    --repo-id /path/to/lerobot_dataset
+```
+
+- `--config-name`：传给 `get_openpi_config()` 的 OpenPI 配置名。
+- `--repo-id`：本地 LeRobot 数据集目录，或位于 `HF_LEROBOT_HOME`
+  下的 repo id。
+- `--output-path`：可选的输出文件路径。默认为解析后数据集根目录下的
+  `norm_stats_fast.json`。
+- `--overwrite`：可选开关，默认为 `False`。仅显式指定时才允许覆盖
+  `--output-path` 指向的已有文件。
+- worker 数量默认沿用训练配置中的 `num_workers`，不新增必需参数。
+- 使用 `normalize.serialize_json()` 产生与 `normalize.save()` 相同的 JSON
+  结构，但允许写入自定义文件名。
+- 输出先写入同目录临时文件，完整序列化成功后再原子更名，避免中断后
+  留下不完整 JSON。
+
+快速脚本默认不会覆盖旧脚本的结果。OpenPI 默认仍只会自动加载正式名称
+`norm_stats.json`。快速结果完成数值对照后，应由用户显式更新训练配置的
+`norm_stats_path`，或手动将通过验证的文件提升为 `norm_stats.json`。快速脚本
+不自动进行该替换。
+
+## 5. 设计
+
+### 5.1 配置和数据集解析
+
+1. 通过 `resolve_lerobot_dataset_root()` 解析本地路径或 repo id。
+2. 检查 `meta/info.json` 和 `data/` 存在，否则返回包含实际解析路径的
+   `FileNotFoundError`。
+3. 通过 `get_openpi_config(config_name, repo_id=repo_id)` 构建真实
+   `DataConfig`，获取 action horizon、batch size、worker 数、
+   `action_sequence_keys`、repack transforms 和 data transforms。
+4. 如果配置指向 RLDS，立即返回明确的不支持错误。
+
+### 5.2 Parquet 列投影
+
+1. 通过 `meta/info.json` 特征定义识别 image/video 特征。
+2. 扫描 `data/**/*.parquet`，只投影：
+   - 全部非视觉特征；
+   - `index`、`episode_index`、`task_index` 等定位和 prompt 构造所需特征；
+   - `action_sequence_keys` 引用的所有动作列。
+3. 根据全局 `index` 恢复确定性顺序，不依赖文件系统 glob 顺序。
+4. 检查全局 index 唯一且连续，episode 内帧连续，同一 episode
+   不能分裂成多个不相邻区间。
+
+投影阶段不得将 image/video 列传给 PyArrow 读取器。
+
+### 5.3 Action horizon 与 episode padding
+
+对每个 anchor frame 和每个 action key：
+
+1. 构造 `[0, 1, ..., action_horizon - 1]` 偏移。
+2. 将偏移后的索引限制在当前 episode 内。
+3. 超过 episode 末尾的位置重复最后一帧动作，不允许跨 episode
+   取数。
+4. 多个 action key 分别构造 horizon，然后交给现有 transform 合并或重排。
+
+实现应使用 NumPy 索引批量构造 chunk，不应对 horizon 内每个
+step 进行 Python 循环。
+
+### 5.4 复用现有 transforms
+
+1. 从投影后的非视觉列构造与 LeRobot sample 键名一致的输入。
+2. prompt 优先使用数据集原始字段；若 `prompt_from_task=True`，则使用
+   `task_index` 和数据集 task metadata 还原。
+3. 为 repack transform 要求的视觉键提供形状兼容的共享占位数组，
+   不读取原始像素。占位数组仅用于让现有 transform 完成键名和
+   形状处理，不进入统计。
+4. 按旧脚本相同顺序应用：
+   - `data_config.repack_transforms.inputs`；
+   - `data_config.data_transforms.inputs`；
+   - 删除字符串输出。
+5. 只提取变换后的 `state` 和 `actions`。
+
+若 transform 缺少非视觉输入、产生不稳定维度，或数值输出依赖真实
+像素，快速脚本应终止并给出可操作错误，提示用户改用
+`calculate_norm_stats.py`。不得静默计算可能错误的 stats。
+
+### 5.5 统计聚合
+
+1. 使用 `openpi.shared.normalize.RunningStats`。
+2. 按配置 batch size 将变换后的 sample 聚合为 batch，保持确定性顺序。
+3. `state` 每个 anchor frame 计数一次。
+4. `actions` 保留 `[batch, horizon, action_dim]` 形状交给
+   `RunningStats.update()`，由其按旧语义展平 horizon。
+5. 最后一个不完整 batch 也必须更新 stats。这与旧脚本的
+   `drop_last=True` 不同，是有意修正。
+6. 调用 `get_statistics()` 生成 `mean`、`std`、`q01`和 `q99`。
+
+## 6. 性能要求
+
+- 性能收益必须主要来自减少 I/O 和图像解码，不得以抽样换取速度。
+- 对目标数据集，Parquet 读取量应保持在非视觉列的量级，不应随
+  273 GB 图像数据规模线性增长。
+- 数据扫描和变换应有独立的进度信息，至少显示已处理帧数、总帧数
+  和阶段名称。
+- 避免构造整个 `[num_frames, horizon, action_dim]` 数组；动作
+  chunk 应分批或按 episode 构造，限制峰值内存。
+
+## 7. 错误处理
+
+以下情况必须在写出前失败：
+
+- 数据集路径或 `meta/info.json` 不存在。
+- 未发现 Parquet 数据文件。
+- dataconfig 没有 repo id 或指向 RLDS。
+- 缺少 action key、state 所需原始特征、episode/index 字段。
+- 存在重复/缺失全局 index，或 episode 帧不连续。
+- transform 后缺少 `state` 或 `actions`，或各 sample 维度不一致。
+- 数据集少于两个可统计向量。
+- 输出文件已存在且未显式传入 `--overwrite`。
+
+错误应包含 config 名、repo id/解析路径、缺失键或失败 transform 的类名。
+
+## 8. 代码接入
+
+实现完成后：
+
+- 保留 `toolkits/lerobot/calculate_norm_stats.py` 不变，用于兼容特殊 transform
+  和作为数值参考。
+- 将 `tmp/merge_data.sh` 的调用切换为
+  `toolkits/lerobot/calculate_norm_stats_fast.py`，其余参数不变。
+- 在英文和中文 `sft_openpi.rst` 归一化统计章节中同步推荐快速脚本，
+  说明它的全量统计、列投影、默认输出名和兼容边界。
+
+## 9. 测试与验收
+
+### 9.1 单元测试
+
+- 单 episode 的 horizon 构造和末尾重复 padding。
+- 多 episode 时不跨边界取动作。
+- 多 `action_sequence_keys` 维持各自维度和顺序。
+- 多 Parquet 文件顺序打乱后按 `index` 恢复正确帧序。
+- 最后一个不完整 batch 被统计。
+- 图像特征不出现在 PyArrow 投影列表中。
+- 默认生成 `norm_stats_fast.json`，不改动已有 `norm_stats.json`。
+- 已有输出在没有 `--overwrite` 时被拒绝，显式覆盖时使用原子写入。
+- 缺列、不连续 index、不支持 transform 产生明确错误。
+
+### 9.2 数值对照
+
+- 构造小型合成 LeRobot 数据集，对照快速路径与旧 DataLoader 路径
+  变换后的 `state` 和 `actions`。
+- 对于帧数可被 batch size 整除的数据，比较 mean/std/q01/q99，
+  差异必须仅限于 NumPy 浮点聚合误差。
+- 对于不可整除的数据，单独验证快速路径的结果包含尾批，不要求与
+  旧脚本相等。
+
+### 9.3 性能验收
+
+- 在 `data/lerobot-data_mixed_8_v30` 上记录扫描用时、总用时、处理帧数和
+  峰值内存。
+- 确认无图像解码调用，且投影读取规模与非视觉列大小一致。
+- 快速脚本应显著快于旧脚本；如果变换或 histogram 成为新瓶颈，
+  应在不改变统计语义的前提下分批或并行化。
+
+### 9.4 质量门禁
+
+- 运行 Ruff lint/format 检查和相关 pytest。
+- 若更新 EN/ZH 文档，运行两种语言的 Sphinx build，并运行
+  `.codex/skills/docs-check/check_rst_markup.py`。
+- 文档中的脚本路径、CLI 参数和 config 名必须与实际代码一致。
+
+## 10. 完成标准
+
+以下条件全部满足时视为实现完成：
+
+1. 快速脚本可在目标 ALOHA 数据集上生成 OpenPI 可加载的
+   `norm_stats_fast.json`，且不修改已有 `norm_stats.json`。
+2. 标准 RLinf OpenPI LeRobot dataconfig 可复用各自的非像素依赖
+   transforms，无需在快速脚本中写死 ALOHA 变换公式。
+3. action horizon、episode padding、多 action key 和尾批行为通过测试。
+4. Parquet 扫描不读取图像/视频列。
+5. 性能相比旧路径有明显改善，且无抽样导致的统计偏差。
+6. `tmp/merge_data.sh` 和 EN/ZH 文档已同步，所有相关检查通过。

--- a/tests/unit_tests/test_calculate_norm_stats_fast.py
+++ b/tests/unit_tests/test_calculate_norm_stats_fast.py
@@ -1,0 +1,385 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import openpi.shared.normalize as normalize
+import openpi.transforms as transforms
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from openpi.training.config import DataConfig
+
+from rlinf.models.embodiment.openpi.dataconfig import get_openpi_config
+from toolkits.lerobot.calculate_norm_stats_fast import (
+    ProjectedData,
+    ProjectedLeRobotSamples,
+    _load_task_mapping,
+    _sort_and_validate_columns,
+    action_query_indices,
+    compute_norm_stats,
+    episode_end_indices,
+    load_projected_data,
+    projection_columns,
+    write_norm_stats_atomic,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class CombineActions:
+    pixel_dependent: bool = False
+
+    def __call__(self, data: dict) -> dict:
+        state = np.asarray(data["state"])
+        if self.pixel_dependent:
+            state = state + np.asarray(data["image"]).mean()
+        return {
+            "state": state,
+            "actions": np.concatenate(
+                [np.asarray(data["left"]), np.asarray(data["right"])], axis=-1
+            ),
+        }
+
+
+def _projected_data() -> ProjectedData:
+    return ProjectedData(
+        columns={
+            "index": np.arange(5),
+            "episode_index": np.asarray([0, 0, 0, 1, 1]),
+            "frame_index": np.asarray([0, 1, 2, 0, 1]),
+            "state_raw": np.arange(10, dtype=np.float32).reshape(5, 2),
+            "action_left": np.arange(5, dtype=np.float32)[:, None],
+            "action_right": (10 + np.arange(5, dtype=np.float32))[:, None],
+        },
+        visual_features={
+            "camera": {
+                "dtype": "image",
+                "shape": [3, 480, 640],
+                "names": ["channels", "height", "width"],
+            }
+        },
+        info={"total_frames": 5},
+    )
+
+
+def _data_config(*, pixel_dependent: bool = False) -> DataConfig:
+    return DataConfig(
+        repo_id="test/repo",
+        action_sequence_keys=("action_left", "action_right"),
+        repack_transforms=transforms.Group(
+            inputs=[
+                transforms.RepackTransform(
+                    {
+                        "state": "state_raw",
+                        "left": "action_left",
+                        "right": "action_right",
+                        "image": "camera",
+                    }
+                )
+            ]
+        ),
+        data_transforms=transforms.Group(
+            inputs=[CombineActions(pixel_dependent=pixel_dependent)]
+        ),
+    )
+
+
+def _samples(*, pixel_dependent: bool = False) -> ProjectedLeRobotSamples:
+    return ProjectedLeRobotSamples(
+        _projected_data(),
+        _data_config(pixel_dependent=pixel_dependent),
+        action_horizon=3,
+        task_mapping=None,
+        context="test-context",
+    )
+
+
+def test_action_query_indices_repeat_episode_tail() -> None:
+    episode_ids = np.asarray([0, 0, 0, 1, 1])
+    ends = episode_end_indices(episode_ids)
+
+    queries = action_query_indices(np.asarray([1, 2, 3, 4]), ends, 3)
+
+    np.testing.assert_array_equal(
+        queries,
+        np.asarray(
+            [
+                [1, 2, 2],
+                [2, 2, 2],
+                [3, 4, 4],
+                [4, 4, 4],
+            ]
+        ),
+    )
+
+
+def test_projected_samples_support_multiple_action_keys() -> None:
+    sample = _samples().transform(1)
+
+    np.testing.assert_array_equal(sample["state"], np.asarray([2.0, 3.0]))
+    np.testing.assert_array_equal(
+        sample["actions"],
+        np.asarray([[1.0, 11.0], [2.0, 12.0], [2.0, 12.0]]),
+    )
+
+
+def test_compute_norm_stats_includes_partial_batch() -> None:
+    stats = compute_norm_stats(_samples(), batch_size=4, num_workers=0)
+
+    expected_states = np.arange(10, dtype=np.float32).reshape(5, 2)
+    np.testing.assert_allclose(stats["state"].mean, expected_states.mean(axis=0))
+    expected_left = np.asarray(
+        [
+            [0, 1, 2],
+            [1, 2, 2],
+            [2, 2, 2],
+            [3, 4, 4],
+            [4, 4, 4],
+        ],
+        dtype=np.float32,
+    )
+    np.testing.assert_allclose(stats["actions"].mean[0], expected_left.mean())
+
+
+def test_compute_norm_stats_matches_reference_float32_dtype() -> None:
+    samples = _samples()
+    for key in ("state_raw", "action_left", "action_right"):
+        samples._columns[key] = samples._columns[key].astype(np.float64)
+
+    stats = compute_norm_stats(samples, batch_size=4, num_workers=0)
+
+    assert stats["state"].mean.dtype == np.dtype(np.float32)
+    assert stats["actions"].mean.dtype == np.dtype(np.float32)
+
+
+def test_pixel_dependent_transform_is_rejected() -> None:
+    with pytest.raises(ValueError, match="depends on visual pixel values"):
+        _samples(pixel_dependent=True).validate_pixel_independence()
+
+
+def test_projection_columns_exclude_embedded_images() -> None:
+    image_type = pa.struct([("bytes", pa.binary()), ("path", pa.string())])
+    schema = pa.schema(
+        [
+            ("state", pa.list_(pa.float32())),
+            ("actions", pa.list_(pa.float32())),
+            ("camera", image_type),
+            ("index", pa.int64()),
+            ("episode_index", pa.int64()),
+        ]
+    )
+    info = {
+        "features": {
+            "state": {"dtype": "float32", "shape": [2]},
+            "actions": {"dtype": "float32", "shape": [1]},
+            "camera": {"dtype": "image", "shape": [3, 8, 8]},
+        }
+    }
+
+    projected, visual = projection_columns(
+        info, schema, ("actions",), context="test-context"
+    )
+
+    assert "camera" not in projected
+    assert visual == {"camera": info["features"]["camera"]}
+
+
+def test_projection_columns_report_missing_action_key() -> None:
+    schema = pa.schema(
+        [
+            ("state", pa.list_(pa.float32())),
+            ("index", pa.int64()),
+            ("episode_index", pa.int64()),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="missing_action.*test-context"):
+        projection_columns(
+            {"features": {}},
+            schema,
+            ("missing_action",),
+            context="test-context",
+        )
+
+
+def test_load_v2_jsonl_task_mapping(tmp_path) -> None:
+    meta_dir = tmp_path / "meta"
+    meta_dir.mkdir()
+    (meta_dir / "tasks.jsonl").write_text(
+        "\n".join(
+            [
+                '{"task_index": 0, "task": "pick"}',
+                '{"task_index": 1, "task": "place"}',
+            ]
+        )
+        + "\n"
+    )
+
+    assert _load_task_mapping(tmp_path, context="test-context") == {
+        0: "pick",
+        1: "place",
+    }
+
+
+def test_load_projected_data_sorts_files_and_skips_images(tmp_path) -> None:
+    data_dir = tmp_path / "data" / "chunk-000"
+    data_dir.mkdir(parents=True)
+    image_type = pa.struct([("bytes", pa.binary()), ("path", pa.string())])
+
+    def write_file(path, indices, episode_index) -> None:
+        count = len(indices)
+        table = pa.table(
+            {
+                "state": pa.array(
+                    [[float(index), float(index + 1)] for index in indices],
+                    type=pa.list_(pa.float32()),
+                ),
+                "actions": pa.array(
+                    [[float(index)] for index in indices],
+                    type=pa.list_(pa.float32()),
+                ),
+                "camera": pa.array(
+                    [{"bytes": b"not-an-image", "path": ""}] * count,
+                    type=image_type,
+                ),
+                "index": pa.array(indices, type=pa.int64()),
+                "episode_index": pa.array([episode_index] * count, type=pa.int64()),
+                "frame_index": pa.array(range(count), type=pa.int64()),
+            }
+        )
+        pq.write_table(table, path)
+
+    write_file(data_dir / "file-000.parquet", [2, 3], 1)
+    write_file(data_dir / "file-001.parquet", [0, 1], 0)
+    info = {
+        "total_frames": 4,
+        "features": {
+            "state": {"dtype": "float32", "shape": [2]},
+            "actions": {"dtype": "float32", "shape": [1]},
+            "camera": {"dtype": "image", "shape": [3, 8, 8]},
+        },
+    }
+
+    projected = load_projected_data(
+        tmp_path, info, ("actions",), context="test-context"
+    )
+
+    np.testing.assert_array_equal(projected.columns["index"], np.arange(4))
+    assert "camera" not in projected.columns
+    assert "camera" in projected.visual_features
+
+
+def test_noncontiguous_global_index_is_rejected() -> None:
+    columns = {
+        "index": np.asarray([0, 2]),
+        "episode_index": np.asarray([0, 0]),
+        "actions": np.asarray([[0.0], [1.0]]),
+    }
+
+    with pytest.raises(ValueError, match="unique and contiguous"):
+        _sort_and_validate_columns(columns, context="test-context")
+
+
+def test_aloha_fast_sample_matches_reference_transform_pipeline() -> None:
+    config = get_openpi_config("pi05_aloha_robotwin", repo_id="test/repo")
+    data_config = config.data.create(config.assets_dirs, config.model)
+    num_frames = 4
+    states = np.linspace(-0.5, 0.5, num_frames * 14, dtype=np.float32).reshape(
+        num_frames, 14
+    )
+    actions = states + 0.25
+    visual_features = {
+        name: {
+            "dtype": "image",
+            "shape": [3, 2, 2],
+            "names": ["channels", "height", "width"],
+        }
+        for name in (
+            "observation.images.cam_high",
+            "observation.images.cam_left_wrist",
+            "observation.images.cam_right_wrist",
+        )
+    }
+    projected = ProjectedData(
+        columns={
+            "index": np.arange(num_frames),
+            "episode_index": np.zeros(num_frames, dtype=np.int64),
+            "frame_index": np.arange(num_frames),
+            "task_index": np.zeros(num_frames, dtype=np.int64),
+            "observation.state": states,
+            "action": actions,
+        },
+        visual_features=visual_features,
+        info={"total_frames": num_frames},
+    )
+    fast_dataset = ProjectedLeRobotSamples(
+        projected,
+        data_config,
+        config.model.action_horizon,
+        {0: "test task"},
+        context="test-context",
+    )
+
+    fast = fast_dataset.transform(1)
+    query = np.minimum(1 + np.arange(config.model.action_horizon), num_frames - 1)
+    reference = {
+        "observation.state": states[1].copy(),
+        "action": actions[query].copy(),
+        "task_index": np.asarray(0),
+        "prompt": "test task",
+        **{name: np.zeros((3, 2, 2), dtype=np.uint8) for name in visual_features},
+    }
+    for transform in (
+        *data_config.repack_transforms.inputs,
+        *data_config.data_transforms.inputs,
+    ):
+        reference = transform(reference)
+
+    np.testing.assert_array_equal(fast["state"], reference["state"])
+    np.testing.assert_array_equal(fast["actions"], reference["actions"])
+
+
+def test_atomic_output_does_not_overwrite_by_default(tmp_path) -> None:
+    official_path = tmp_path / "norm_stats.json"
+    official_path.write_text("official")
+    fast_path = tmp_path / "norm_stats_fast.json"
+    first = {
+        "state": normalize.NormStats(
+            mean=np.asarray([1.0]),
+            std=np.asarray([2.0]),
+            q01=np.asarray([0.0]),
+            q99=np.asarray([3.0]),
+        )
+    }
+    write_norm_stats_atomic(fast_path, first, overwrite=False)
+
+    assert official_path.read_text() == "official"
+    assert normalize.deserialize_json(fast_path.read_text())["state"].mean == [1.0]
+    with pytest.raises(FileExistsError, match="Pass --overwrite"):
+        write_norm_stats_atomic(fast_path, first, overwrite=False)
+
+    second = {
+        "state": normalize.NormStats(
+            mean=np.asarray([5.0]),
+            std=np.asarray([2.0]),
+            q01=np.asarray([0.0]),
+            q99=np.asarray([6.0]),
+        )
+    }
+    write_norm_stats_atomic(fast_path, second, overwrite=True)
+    assert normalize.deserialize_json(fast_path.read_text())["state"].mean == [5.0]
+    assert not list(tmp_path.glob("*.tmp"))

--- a/tests/unit_tests/test_compare_policy_servers.py
+++ b/tests/unit_tests/test_compare_policy_servers.py
@@ -1,0 +1,293 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import io
+import json
+import threading
+import time
+from contextlib import contextmanager
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from openpi_client import msgpack_numpy
+from PIL import Image
+from websockets.sync.server import serve
+
+from toolkits.lerobot.compare_policy_servers import (
+    PolicyServerClient,
+    action_1_to_10_jump_metrics,
+    chunk_jitter_metrics,
+    common_prefix_metrics,
+    format_observation_layout,
+    load_episode_numeric,
+    load_observations,
+    load_task_prompts,
+    padded_action_chunk,
+    randomness_metrics,
+    replanning_boundary_metrics,
+    scan_episodes,
+    select_episodes,
+    uniform_frame_indices,
+)
+
+
+def _image_bytes(value: int) -> bytes:
+    stream = io.BytesIO()
+    Image.fromarray(np.full((4, 5, 3), value, dtype=np.uint8)).save(
+        stream, format="PNG"
+    )
+    return stream.getvalue()
+
+
+def _write_dataset(root, *, episodes: int = 3) -> None:
+    (root / "meta").mkdir(parents=True)
+    data_dir = root / "data" / "chunk-000"
+    data_dir.mkdir(parents=True)
+    info = {
+        "codebase_version": "v3.0",
+        "features": {
+            "observation.state": {"dtype": "float32", "shape": [14]},
+            "action": {"dtype": "float32", "shape": [14]},
+            **{
+                key: {"dtype": "image", "shape": [3, 4, 5]}
+                for key in (
+                    "observation.images.cam_high",
+                    "observation.images.cam_left_wrist",
+                    "observation.images.cam_right_wrist",
+                )
+            },
+        },
+    }
+    (root / "meta" / "info.json").write_text(json.dumps(info))
+    pq.write_table(
+        pa.table(
+            {
+                "task_index": pa.array([0, 1]),
+                "__index_level_0__": pa.array(["pick", "place"]),
+            }
+        ),
+        root / "meta" / "tasks.parquet",
+    )
+    image_type = pa.struct([("bytes", pa.binary()), ("path", pa.string())])
+    for episode in range(episodes):
+        frames = 5
+        images = [
+            {"bytes": _image_bytes(episode * 10 + frame), "path": None}
+            for frame in range(frames)
+        ]
+        table = pa.table(
+            {
+                "observation.state": pa.array(
+                    [np.full(14, frame, dtype=np.float32) for frame in range(frames)]
+                ),
+                "action": pa.array(
+                    [
+                        np.full(14, 100 * episode + frame, dtype=np.float32)
+                        for frame in range(frames)
+                    ]
+                ),
+                "observation.images.cam_high": pa.array(images, type=image_type),
+                "observation.images.cam_left_wrist": pa.array(images, type=image_type),
+                "observation.images.cam_right_wrist": pa.array(images, type=image_type),
+                "episode_index": pa.array([episode] * frames),
+                "frame_index": pa.array(range(frames)),
+                "task_index": pa.array([episode % 2] * frames),
+            }
+        )
+        pq.write_table(
+            table, data_dir / f"file-{episode:03d}.parquet", row_group_size=2
+        )
+
+
+def test_dataset_selection_image_decode_padding_and_seed(tmp_path) -> None:
+    _write_dataset(tmp_path)
+    prompts = load_task_prompts(tmp_path)
+    refs = scan_episodes(tmp_path, prompts)
+
+    first = select_episodes(
+        refs,
+        episodes_per_prompt=1,
+        prompt_regex=None,
+        episode_ids=None,
+        seed=7,
+    )
+    second = select_episodes(
+        refs,
+        episodes_per_prompt=1,
+        prompt_regex=None,
+        episode_ids=None,
+        seed=7,
+    )
+    assert [ref.episode_id for ref in first] == [ref.episode_id for ref in second]
+    assert {ref.prompt for ref in first} == {"pick", "place"}
+
+    episode = load_episode_numeric(refs[0])
+    observations = load_observations(tmp_path, episode, [1, 4])
+    assert observations[1]["prompt"] == "pick"
+    assert observations[1]["state"].shape == (14,)
+    assert observations[1]["images"]["cam_high"].shape == (4, 5, 3)
+    assert int(observations[1]["images"]["cam_high"][0, 0, 0]) == 1
+    assert format_observation_layout(observations[1], "chw")["images"][
+        "cam_high"
+    ].shape == (3, 4, 5)
+    assert format_observation_layout(observations[1], "hwc")["images"][
+        "cam_high"
+    ].shape == (4, 5, 3)
+    np.testing.assert_array_equal(
+        padded_action_chunk(episode.action, 3, 4)[:, 0], [3, 4, 4, 4]
+    )
+    np.testing.assert_array_equal(uniform_frame_indices(5, 3), [0, 2, 4])
+
+
+def test_metric_functions_known_arrays() -> None:
+    left = np.asarray([[0.0, 2.0], [2.0, 4.0], [4.0, 6.0]])
+    right = np.asarray([[1.0, 0.0], [1.0, 2.0]])
+    metrics = common_prefix_metrics(left, right, np.asarray([1.0, 2.0]))
+
+    assert metrics["common_horizon"] == 2
+    assert metrics["mae"] == pytest.approx(1.5)
+    assert metrics["rmse"] == pytest.approx(np.sqrt(2.5))
+    assert metrics["normalized_mae"] == pytest.approx(1.0)
+    np.testing.assert_allclose(metrics["per_joint_mae"], [1.0, 2.0])
+    np.testing.assert_allclose(metrics["per_horizon_mae"], [1.5, 1.5])
+
+    randomness = randomness_metrics([left, left + 2])
+    assert randomness == {"output_std": 1.0, "repeat_to_repeat_mae": 2.0}
+
+    action_steps = np.arange(20, dtype=np.float64)[:, None]
+    endpoint_jump = action_1_to_10_jump_metrics([action_steps, 2 * action_steps])
+    assert endpoint_jump["num_chunks"] == 2
+    assert endpoint_jump["mae"] == pytest.approx(13.5)
+    assert endpoint_jump["rmse"] == pytest.approx(np.sqrt((9**2 + 18**2) / 2))
+    assert endpoint_jump["max_abs"] == 18.0
+    assert endpoint_jump["mean_l2"] == pytest.approx(13.5)
+
+    jitter = chunk_jitter_metrics(
+        np.asarray([[1.0, 1.0], [2.0, 3.0], [4.0, 6.0]]),
+        np.zeros(2),
+        np.asarray([[1.0, 0.0], [2.0, 2.0], [3.0, 4.0]]),
+    )
+    assert jitter["first_action_state_jump"] == 1.0
+    assert jitter["first_difference_mae"] == 2.0
+    assert jitter["second_difference_mae"] == 1.0
+    assert jitter["ground_truth_mae"] == pytest.approx(5 / 6)
+
+    boundaries = replanning_boundary_metrics(
+        [np.asarray([[0.0], [2.0]]), np.asarray([[5.0], [7.0]])]
+    )
+    assert boundaries == {"boundary_jump_mae": 3.0, "boundary_jump_max": 3.0}
+
+
+@contextmanager
+def _fake_server(handler):
+    with serve(handler, "127.0.0.1", 0) as server:
+        port = server.socket.getsockname()[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            yield port
+        finally:
+            server.shutdown()
+            thread.join(timeout=2)
+
+
+def _protocol_handler(
+    websocket,
+    *,
+    horizon: int = 3,
+    response_kind: str = "normal",
+    delay: float = 0.0,
+    seen: list[dict] | None = None,
+) -> None:
+    websocket.send(msgpack_numpy.packb({"model": "fake", "horizon": horizon}))
+    request = msgpack_numpy.unpackb(websocket.recv())
+    if seen is not None:
+        seen.append(request)
+    if delay:
+        time.sleep(delay)
+    if response_kind == "text":
+        websocket.send("fake traceback")
+        return
+    actions = np.ones((horizon, 14), dtype=np.float32)
+    if response_kind == "nonfinite":
+        actions[0, 0] = np.nan
+    websocket.send(
+        msgpack_numpy.packb({"actions": actions, "server_timing": {"infer_ms": 1.25}})
+    )
+
+
+def test_policy_client_handshake_request_and_different_horizon() -> None:
+    seen: list[dict] = []
+
+    def handler(websocket):
+        _protocol_handler(websocket, horizon=5, seen=seen)
+
+    with _fake_server(handler) as port:
+        with PolicyServerClient("127.0.0.1", port, 2.0, "fake") as client:
+            assert client.metadata == {"model": "fake", "horizon": 5}
+            observation = {
+                "images": {
+                    "cam_high": np.zeros((3, 2, 2), dtype=np.uint8),
+                    "cam_left_wrist": np.zeros((3, 2, 2), dtype=np.uint8),
+                    "cam_right_wrist": np.zeros((3, 2, 2), dtype=np.uint8),
+                },
+                "state": np.zeros(14, dtype=np.float32),
+                "prompt": "pick",
+            }
+            result = client.infer(observation)
+
+    assert result.actions.shape == (5, 14)
+    assert result.server_infer_ms == 1.25
+    assert set(seen[0]) == set(observation)
+    assert seen[0]["state"].shape == (14,)
+
+
+@pytest.mark.parametrize(
+    ("response_kind", "match"),
+    [("text", "text error"), ("nonfinite", "non-finite")],
+)
+def test_policy_client_reports_server_errors(response_kind, match) -> None:
+    def handler(websocket):
+        _protocol_handler(websocket, response_kind=response_kind)
+
+    with _fake_server(handler) as port:
+        with PolicyServerClient("127.0.0.1", port, 2.0, "fake") as client:
+            with pytest.raises(RuntimeError, match=match):
+                client.infer({"state": np.zeros(14)})
+
+
+def test_policy_client_timeout() -> None:
+    def handler(websocket):
+        _protocol_handler(websocket, delay=0.2)
+
+    with _fake_server(handler) as port:
+        with PolicyServerClient("127.0.0.1", port, 0.05, "fake") as client:
+            with pytest.raises(TimeoutError, match="Timed out"):
+                client.infer({"state": np.zeros(14)})
+
+
+def test_policy_client_reports_connection_close() -> None:
+    def handler(websocket):
+        websocket.send(msgpack_numpy.packb({"model": "fake"}))
+        websocket.recv()
+        websocket.close()
+
+    with _fake_server(handler) as port:
+        with PolicyServerClient("127.0.0.1", port, 2.0, "fake") as client:
+            with pytest.raises(RuntimeError, match="Connection to fake"):
+                client.infer({"state": np.zeros(14)})

--- a/tests/unit_tests/test_lerobot_v21_to_v30_hardlinks.py
+++ b/tests/unit_tests/test_lerobot_v21_to_v30_hardlinks.py
@@ -1,0 +1,140 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from lerobot.datasets.lerobot_dataset import LeRobotDatasetMetadata
+
+from toolkits.lerobot.convert_v21_to_v30_hardlinks import (
+    convert_v21_to_v30_hardlinks,
+)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as file:
+        for record in records:
+            file.write(json.dumps(record) + "\n")
+
+
+def _make_v21_dataset(root: Path) -> None:
+    features = {
+        "observation.state": {
+            "dtype": "float32",
+            "shape": [1],
+            "names": ["state"],
+        },
+        "action": {"dtype": "float32", "shape": [1], "names": ["action"]},
+        "timestamp": {"dtype": "float32", "shape": [1], "names": None},
+        "frame_index": {"dtype": "int64", "shape": [1], "names": None},
+        "episode_index": {"dtype": "int64", "shape": [1], "names": None},
+        "index": {"dtype": "int64", "shape": [1], "names": None},
+        "task_index": {"dtype": "int64", "shape": [1], "names": None},
+    }
+    info = {
+        "codebase_version": "v2.1",
+        "robot_type": "test",
+        "total_episodes": 2,
+        "total_frames": 4,
+        "total_tasks": 1,
+        "total_videos": 0,
+        "total_chunks": 1,
+        "chunks_size": 1000,
+        "fps": 10,
+        "splits": {"train": "0:2"},
+        "data_path": "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet",
+        "features": features,
+    }
+    (root / "meta").mkdir(parents=True)
+    with open(root / "meta" / "info.json", "w") as file:
+        json.dump(info, file)
+
+    episodes = []
+    episode_stats = []
+    for episode_index in range(2):
+        start = episode_index * 2
+        table = pa.table(
+            {
+                "observation.state": [[float(start)], [float(start + 1)]],
+                "action": [[float(start)], [float(start + 1)]],
+                "timestamp": [0.0, 0.1],
+                "frame_index": [0, 1],
+                "episode_index": [episode_index, episode_index],
+                "index": [start, start + 1],
+                "task_index": [0, 0],
+            }
+        )
+        parquet_path = (
+            root / "data" / "chunk-000" / f"episode_{episode_index:06d}.parquet"
+        )
+        parquet_path.parent.mkdir(parents=True, exist_ok=True)
+        pq.write_table(table, parquet_path)
+        episodes.append(
+            {
+                "episode_index": episode_index,
+                "tasks": ["test task"],
+                "length": 2,
+            }
+        )
+        stats = {
+            key: {
+                "min": [float(start)],
+                "max": [float(start + 1)],
+                "mean": [float(start) + 0.5],
+                "std": [0.5],
+                "count": [2],
+            }
+            for key in ("observation.state", "action")
+        }
+        episode_stats.append({"episode_index": episode_index, "stats": stats})
+
+    _write_jsonl(root / "meta" / "episodes.jsonl", episodes)
+    _write_jsonl(root / "meta" / "episodes_stats.jsonl", episode_stats)
+    _write_jsonl(
+        root / "meta" / "tasks.jsonl", [{"task_index": 0, "task": "test task"}]
+    )
+
+
+def test_conversion_creates_loadable_v30_hardlink_view(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    output = tmp_path / "output"
+    _make_v21_dataset(source)
+
+    convert_v21_to_v30_hardlinks(source, output)
+
+    metadata = LeRobotDatasetMetadata(output.name, root=output)
+    assert metadata.total_episodes == 2
+    assert metadata.total_frames == 4
+    assert metadata.info["codebase_version"] == "v3.0"
+    assert metadata.info["video_path"] is None
+    assert (output / "meta" / "stats.json").is_file()
+    assert (
+        os.stat(source / "data" / "chunk-000" / "episode_000000.parquet").st_ino
+        == os.stat(output / "data" / "chunk-000" / "file-000.parquet").st_ino
+    )
+
+
+def test_conversion_refuses_to_overwrite_output(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    output = tmp_path / "output"
+    _make_v21_dataset(source)
+    output.mkdir()
+
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        convert_v21_to_v30_hardlinks(source, output)

--- a/tests/unit_tests/test_official_openpi_sft_data_loader.py
+++ b/tests/unit_tests/test_official_openpi_sft_data_loader.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the official OpenPI SFT data-loader adapter."""
+
+import dataclasses
+import importlib
+
+from omegaconf import OmegaConf
+
+
+@dataclasses.dataclass(frozen=True)
+class _OpenPiModelConfig:
+    action_horizon: int = 50
+    action_dim: int = 32
+
+
+@dataclasses.dataclass(frozen=True)
+class _OpenPiTrainConfig:
+    model: _OpenPiModelConfig = dataclasses.field(default_factory=_OpenPiModelConfig)
+    num_workers: int = 2
+    seed: int = 0
+
+
+class _DataLoader:
+    def __init__(self, config):
+        self.config = config
+
+    def data_config(self):
+        return "data-config"
+
+
+def test_openpi_rlinf_data_loader_uses_configured_action_horizon(monkeypatch) -> None:
+    """The OpenPI dataset should produce the same chunk length as the model."""
+    adapter = importlib.import_module(
+        "rlinf.data.datasets.openpi_rlinf.official_sft_data_loader"
+    )
+    dataconfig = importlib.import_module("rlinf.models.embodiment.openpi.dataconfig")
+    openpi_data_loader = importlib.import_module("openpi.training.data_loader")
+    official_config = _OpenPiTrainConfig()
+    captured = {}
+
+    monkeypatch.setattr(adapter, "resolve_lerobot_repo_id", lambda _: "test/repo")
+    monkeypatch.setattr(
+        dataconfig,
+        "get_openpi_config",
+        lambda *args, **kwargs: official_config,
+    )
+
+    def _create_data_loader(config, **kwargs):
+        captured["config"] = config
+        return _DataLoader(config)
+
+    monkeypatch.setattr(openpi_data_loader, "create_data_loader", _create_data_loader)
+    cfg = OmegaConf.create(
+        {
+            "data": {"num_workers": 4},
+            "actor": {
+                "micro_batch_size": 8,
+                "seed": 7,
+                "model": {
+                    "model_type": "openpi_rlinf",
+                    "model_path": "/tmp/model",
+                    "num_action_chunks": 20,
+                    "openpi": {
+                        "config_name": "pi05_aloha_robotwin",
+                        "model_action_dim": 32,
+                    },
+                },
+            },
+        }
+    )
+
+    loader, data_config = adapter.build_official_openpi_sft_dataloader(
+        cfg, world_size=2, rank=0, data_paths="/tmp/data"
+    )
+
+    assert loader.config is captured["config"]
+    assert data_config == "data-config"
+    assert captured["config"].model.action_horizon == 20
+    assert captured["config"].num_workers == 4
+    assert captured["config"].seed == 7
+    assert official_config.model.action_horizon == 50

--- a/toolkits/lerobot/calculate_norm_stats_fast.py
+++ b/toolkits/lerobot/calculate_norm_stats_fast.py
@@ -627,7 +627,7 @@ def main(
     target = (
         output_path.expanduser().resolve()
         if output_path is not None
-        else dataset_root / "norm_stats_fast.json"
+        else dataset_root / "norm_stats.json"
     )
     _check_output_available(target, overwrite)
 

--- a/toolkits/lerobot/calculate_norm_stats_fast.py
+++ b/toolkits/lerobot/calculate_norm_stats_fast.py
@@ -1,0 +1,675 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compute OpenPI normalization statistics without decoding visual columns.
+
+The regular OpenPI data loader materializes every feature in a LeRobot sample.
+For datasets with images embedded in Parquet this makes normalization-statistics
+calculation unnecessarily I/O bound. This module projects only non-visual
+columns, reconstructs episode-aware action chunks, and then applies the existing
+OpenPI repack and data transforms.
+
+Example:
+    python toolkits/lerobot/calculate_norm_stats_fast.py \\
+        --config-name pi05_aloha_robotwin \\
+        --repo-id /path/to/lerobot_dataset
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import openpi.shared.normalize as normalize
+import pyarrow as pa
+import pyarrow.dataset as pads
+import pyarrow.parquet as pq
+import tqdm
+import tyro
+from openpi.training.config import DataConfig
+
+from rlinf.data.storage.lerobot import resolve_lerobot_dataset_root
+from rlinf.models.embodiment.openpi.dataconfig import get_openpi_config
+
+_INDEX_KEY = "index"
+_EPISODE_KEY = "episode_index"
+_TASK_INDEX_KEY = "task_index"
+_STATS_KEYS = ("state", "actions")
+_VISUAL_DTYPES = frozenset({"image", "video"})
+
+
+@dataclasses.dataclass(frozen=True)
+class ProjectedData:
+    """Non-visual LeRobot columns and metadata needed by the fast path."""
+
+    columns: dict[str, np.ndarray]
+    visual_features: dict[str, dict[str, Any]]
+    info: dict[str, Any]
+
+    @property
+    def num_frames(self) -> int:
+        return len(self.columns[_INDEX_KEY])
+
+
+def _context(config_name: str, repo_id: str, dataset_root: Path) -> str:
+    return (
+        f"config_name={config_name!r}, repo_id={repo_id!r}, "
+        f"dataset_root={str(dataset_root)!r}"
+    )
+
+
+def _load_info(dataset_root: Path, *, context: str) -> dict[str, Any]:
+    info_path = dataset_root / "meta" / "info.json"
+    if not info_path.is_file():
+        raise FileNotFoundError(
+            f"LeRobot metadata not found at {info_path} ({context}). "
+            "Pass a local dataset path, a Hugging Face repo id cached under "
+            "HF_LEROBOT_HOME, or download the dataset first."
+        )
+    with info_path.open() as file:
+        info = json.load(file)
+    if not isinstance(info.get("features"), dict):
+        raise ValueError(f"LeRobot info.json has no feature mapping ({context})")
+    return info
+
+
+def _is_visual_arrow_field(field: pa.Field) -> bool:
+    """Return whether an Arrow field has LeRobot's embedded-image structure."""
+
+    if not pa.types.is_struct(field.type):
+        return False
+    child_names = {child.name for child in field.type}
+    return {"bytes", "path"}.issubset(child_names)
+
+
+def projection_columns(
+    info: Mapping[str, Any],
+    schema: pa.Schema,
+    action_sequence_keys: Sequence[str],
+    *,
+    context: str,
+) -> tuple[list[str], dict[str, dict[str, Any]]]:
+    """Select every non-visual Parquet column required by the transforms."""
+
+    features = info.get("features", {})
+    visual_features = {
+        name: feature
+        for name, feature in features.items()
+        if str(feature.get("dtype", "")).lower() in _VISUAL_DTYPES
+    }
+    for field in schema:
+        if _is_visual_arrow_field(field):
+            visual_features.setdefault(field.name, features.get(field.name, {}))
+
+    schema_names = set(schema.names)
+    required = {_INDEX_KEY, _EPISODE_KEY, *action_sequence_keys}
+    missing = sorted(required - schema_names)
+    if missing:
+        raise ValueError(
+            f"Missing required Parquet columns {missing} ({context}); "
+            f"action_sequence_keys={tuple(action_sequence_keys)!r}"
+        )
+
+    projected = [name for name in schema.names if name not in visual_features]
+    return projected, visual_features
+
+
+def _arrow_array_to_numpy(column: pa.ChunkedArray) -> np.ndarray:
+    """Convert an Arrow column to NumPy without creating Python float lists."""
+
+    array = column.combine_chunks()
+    if array.null_count:
+        raise ValueError(f"Column {column.type} contains null values")
+
+    if pa.types.is_fixed_size_list(array.type):
+        values = _arrow_array_to_numpy(pa.chunked_array([array.values]))
+        return values.reshape(len(array), array.type.list_size, *values.shape[1:])
+
+    if pa.types.is_list(array.type) or pa.types.is_large_list(array.type):
+        offsets = array.offsets.to_numpy(zero_copy_only=False)
+        lengths = np.diff(offsets)
+        if len(lengths) == 0:
+            return np.empty((0, 0), dtype=np.float32)
+        if not np.all(lengths == lengths[0]):
+            raise ValueError(
+                f"Variable-length list column is unsupported: lengths={np.unique(lengths)}"
+            )
+        values = _arrow_array_to_numpy(pa.chunked_array([array.values]))
+        return values.reshape(len(array), int(lengths[0]), *values.shape[1:])
+
+    if (
+        pa.types.is_string(array.type)
+        or pa.types.is_large_string(array.type)
+        or pa.types.is_binary(array.type)
+        or pa.types.is_large_binary(array.type)
+        or pa.types.is_struct(array.type)
+    ):
+        return np.asarray(array.to_pylist(), dtype=object)
+
+    return np.asarray(array.to_numpy(zero_copy_only=False))
+
+
+def _read_projected_fragments(
+    dataset: pads.Dataset,
+    projected_columns: Sequence[str],
+    *,
+    expected_frames: int | None,
+    context: str,
+) -> dict[str, np.ndarray]:
+    fragments = sorted(dataset.get_fragments(), key=lambda fragment: fragment.path)
+    if not fragments:
+        raise FileNotFoundError(f"No Parquet data files found ({context})")
+
+    pieces: dict[str, list[np.ndarray]] = {name: [] for name in projected_columns}
+    with tqdm.tqdm(
+        total=expected_frames,
+        desc="Scanning Parquet",
+        unit="frames",
+    ) as progress:
+        for fragment in fragments:
+            try:
+                table = fragment.to_table(
+                    columns=list(projected_columns), use_threads=True
+                )
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Failed to project Parquet fragment {fragment.path!r} ({context})"
+                ) from exc
+            for name in projected_columns:
+                try:
+                    pieces[name].append(_arrow_array_to_numpy(table.column(name)))
+                except Exception as exc:
+                    raise ValueError(
+                        f"Failed to convert projected column {name!r} from "
+                        f"{fragment.path!r} ({context})"
+                    ) from exc
+            progress.update(table.num_rows)
+
+    columns: dict[str, np.ndarray] = {}
+    for name, arrays in pieces.items():
+        try:
+            columns[name] = np.concatenate(arrays, axis=0)
+        except ValueError as exc:
+            shapes = [array.shape[1:] for array in arrays]
+            raise ValueError(
+                f"Inconsistent shapes for column {name!r}: {shapes} ({context})"
+            ) from exc
+    return columns
+
+
+def _scalar_column(column: np.ndarray, name: str, *, context: str) -> np.ndarray:
+    if column.ndim == 1:
+        return column
+    if column.ndim == 2 and column.shape[1] == 1:
+        return column[:, 0]
+    raise ValueError(
+        f"Expected scalar column {name!r}, got shape {column.shape} ({context})"
+    )
+
+
+def _sort_and_validate_columns(
+    columns: dict[str, np.ndarray], *, context: str
+) -> dict[str, np.ndarray]:
+    lengths = {name: len(column) for name, column in columns.items()}
+    if len(set(lengths.values())) != 1:
+        raise ValueError(
+            f"Projected columns have different lengths: {lengths} ({context})"
+        )
+    if not lengths or next(iter(lengths.values())) < 2:
+        raise ValueError(f"Dataset must contain at least two frames ({context})")
+
+    indices = _scalar_column(columns[_INDEX_KEY], _INDEX_KEY, context=context).astype(
+        np.int64, copy=False
+    )
+    order = np.argsort(indices, kind="stable")
+    sorted_indices = indices[order]
+    if np.any(np.diff(sorted_indices) != 1):
+        raise ValueError(
+            f"Global {_INDEX_KEY!r} values must be unique and contiguous ({context})"
+        )
+
+    sorted_columns = {name: column[order] for name, column in columns.items()}
+    sorted_columns[_INDEX_KEY] = sorted_indices
+    episodes = _scalar_column(
+        sorted_columns[_EPISODE_KEY], _EPISODE_KEY, context=context
+    ).astype(np.int64, copy=False)
+    sorted_columns[_EPISODE_KEY] = episodes
+
+    boundaries = np.flatnonzero(episodes[1:] != episodes[:-1]) + 1
+    starts = np.concatenate(([0], boundaries))
+    segment_episode_ids = episodes[starts]
+    if len(np.unique(segment_episode_ids)) != len(segment_episode_ids):
+        raise ValueError(f"An episode is split into non-adjacent segments ({context})")
+
+    if "frame_index" in sorted_columns:
+        frame_indices = _scalar_column(
+            sorted_columns["frame_index"], "frame_index", context=context
+        ).astype(np.int64, copy=False)
+        ends = np.concatenate((boundaries, [len(episodes)]))
+        for start, end in zip(starts, ends, strict=True):
+            if np.any(np.diff(frame_indices[start:end]) != 1):
+                episode_id = int(episodes[start])
+                raise ValueError(
+                    f"Non-contiguous frame_index in episode {episode_id} ({context})"
+                )
+        sorted_columns["frame_index"] = frame_indices
+
+    return sorted_columns
+
+
+def load_projected_data(
+    dataset_root: Path,
+    info: dict[str, Any],
+    action_sequence_keys: Sequence[str],
+    *,
+    context: str,
+) -> ProjectedData:
+    """Load and validate all non-visual columns from a LeRobot dataset."""
+
+    data_dir = dataset_root / "data"
+    if not data_dir.is_dir():
+        raise FileNotFoundError(
+            f"LeRobot data directory not found at {data_dir} ({context})"
+        )
+    try:
+        dataset = pads.dataset(data_dir, format="parquet", exclude_invalid_files=True)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to open Parquet dataset at {data_dir} ({context})"
+        ) from exc
+
+    projected_columns, visual_features = projection_columns(
+        info,
+        dataset.schema,
+        action_sequence_keys,
+        context=context,
+    )
+    columns = _read_projected_fragments(
+        dataset,
+        projected_columns,
+        expected_frames=info.get("total_frames"),
+        context=context,
+    )
+    columns = _sort_and_validate_columns(columns, context=context)
+    return ProjectedData(columns=columns, visual_features=visual_features, info=info)
+
+
+def _load_task_mapping(dataset_root: Path, *, context: str) -> dict[int, str]:
+    """Load LeRobot v2 JSONL or v3 Parquet task metadata."""
+
+    parquet_path = dataset_root / "meta" / "tasks.parquet"
+    if parquet_path.is_file():
+        table = pq.read_table(parquet_path)
+        mapping: dict[int, str] = {}
+        for row in table.to_pylist():
+            task = row.get("task") or row.get("__index_level_0__")
+            if task is None:
+                raise ValueError(
+                    f"Could not find task text in {parquet_path} ({context})"
+                )
+            mapping[int(row[_TASK_INDEX_KEY])] = str(task)
+        return mapping
+
+    jsonl_path = dataset_root / "meta" / "tasks.jsonl"
+    if jsonl_path.is_file():
+        mapping = {}
+        with jsonl_path.open() as file:
+            for line in file:
+                if line.strip():
+                    row = json.loads(line)
+                    mapping[int(row[_TASK_INDEX_KEY])] = str(row["task"])
+        return mapping
+
+    raise FileNotFoundError(
+        f"prompt_from_task=True but no tasks.parquet or tasks.jsonl exists ({context})"
+    )
+
+
+def _minimal_visual_shape(feature: Mapping[str, Any]) -> tuple[int, ...]:
+    raw_shape = feature.get("shape")
+    if not isinstance(raw_shape, list) or not raw_shape:
+        return (1, 1, 3)
+    shape = [max(1, int(size)) for size in raw_shape]
+    names = feature.get("names")
+    if (
+        isinstance(names, list)
+        and len(names) == len(shape)
+        and all(isinstance(name, str) for name in names)
+    ):
+        for index, name in enumerate(names):
+            if name.lower() in {"height", "width"}:
+                shape[index] = 1
+        return tuple(shape)
+    if len(shape) >= 3 and shape[0] == 3:
+        shape[1] = shape[2] = 1
+    elif len(shape) >= 3 and shape[-1] == 3:
+        shape[-3] = shape[-2] = 1
+    elif len(shape) >= 2:
+        shape[-2] = shape[-1] = 1
+    return tuple(shape)
+
+
+def make_visual_placeholders(
+    visual_features: Mapping[str, Mapping[str, Any]], *, value: int
+) -> dict[str, np.ndarray]:
+    """Create shared, read-only minimal images for transform compatibility."""
+
+    placeholders = {}
+    for name, feature in visual_features.items():
+        placeholder = np.full(_minimal_visual_shape(feature), value, dtype=np.uint8)
+        placeholder.setflags(write=False)
+        placeholders[name] = placeholder
+    return placeholders
+
+
+def episode_end_indices(episode_ids: np.ndarray) -> np.ndarray:
+    """Return the exclusive episode end for every frame."""
+
+    boundaries = np.flatnonzero(episode_ids[1:] != episode_ids[:-1]) + 1
+    starts = np.concatenate(([0], boundaries))
+    ends = np.concatenate((boundaries, [len(episode_ids)]))
+    return np.repeat(ends, ends - starts)
+
+
+def action_query_indices(
+    frame_indices: np.ndarray,
+    episode_ends: np.ndarray,
+    action_horizon: int,
+) -> np.ndarray:
+    """Build vectorized, episode-clamped action indices for anchor frames."""
+
+    offsets = np.arange(action_horizon, dtype=np.int64)
+    queries = frame_indices[:, None] + offsets[None, :]
+    return np.minimum(queries, episode_ends[frame_indices, None] - 1)
+
+
+class ProjectedLeRobotSamples:
+    """Random-access transformed samples backed only by projected columns."""
+
+    def __init__(
+        self,
+        projected: ProjectedData,
+        data_config: DataConfig,
+        action_horizon: int,
+        task_mapping: Mapping[int, str] | None,
+        *,
+        context: str,
+    ) -> None:
+        self._columns = projected.columns
+        self._data_config = data_config
+        self._action_keys = tuple(data_config.action_sequence_keys)
+        self._action_horizon = action_horizon
+        self._task_mapping = task_mapping
+        self._context = context
+        self._episode_ends = episode_end_indices(self._columns[_EPISODE_KEY])
+        self._placeholders = make_visual_placeholders(
+            projected.visual_features, value=0
+        )
+        self._alternate_placeholders = make_visual_placeholders(
+            projected.visual_features, value=1
+        )
+        self._transforms = (
+            *data_config.repack_transforms.inputs,
+            *data_config.data_transforms.inputs,
+        )
+
+    def __len__(self) -> int:
+        return len(self._columns[_INDEX_KEY])
+
+    def _raw_item(
+        self, index: int, placeholders: Mapping[str, np.ndarray]
+    ) -> dict[str, Any]:
+        item: dict[str, Any] = {}
+        for name, column in self._columns.items():
+            if name in self._action_keys:
+                continue
+            value = column[index]
+            item[name] = value.copy() if isinstance(value, np.ndarray) else value
+
+        query = action_query_indices(
+            np.asarray([index]), self._episode_ends, self._action_horizon
+        )[0]
+        for name in self._action_keys:
+            item[name] = self._columns[name][query].copy()
+        item.update(placeholders)
+
+        if self._data_config.prompt_from_task:
+            if self._task_mapping is None:
+                raise ValueError(f"Task mapping is unavailable ({self._context})")
+            if _TASK_INDEX_KEY not in item:
+                raise ValueError(
+                    f"Missing {_TASK_INDEX_KEY!r} for prompt_from_task ({self._context})"
+                )
+            task_index = int(np.asarray(item[_TASK_INDEX_KEY]).item())
+            try:
+                item["prompt"] = self._task_mapping[task_index]
+            except KeyError as exc:
+                raise ValueError(
+                    f"task_index={task_index} is absent from task metadata "
+                    f"({self._context})"
+                ) from exc
+        return item
+
+    def transform(
+        self,
+        index: int,
+        placeholders: Mapping[str, np.ndarray] | None = None,
+    ) -> dict[str, np.ndarray]:
+        data = self._raw_item(index, placeholders or self._placeholders)
+        for transform in self._transforms:
+            try:
+                data = transform(data)
+            except Exception as exc:
+                name = type(transform).__name__
+                raise RuntimeError(
+                    f"Transform {name} failed at frame {index} ({self._context}). "
+                    "Use calculate_norm_stats.py if this transform requires real pixels."
+                ) from exc
+
+        missing = [key for key in _STATS_KEYS if key not in data]
+        if missing:
+            raise ValueError(
+                f"Transforms did not produce keys {missing} at frame {index} "
+                f"({self._context})"
+            )
+        result = {key: np.asarray(data[key]) for key in _STATS_KEYS}
+        for key, value in result.items():
+            if value.ndim == 0 or not np.issubdtype(value.dtype, np.number):
+                raise ValueError(
+                    f"Transformed {key!r} must be a numeric array, got "
+                    f"shape={value.shape}, dtype={value.dtype} ({self._context})"
+                )
+        return result
+
+    def validate_pixel_independence(self) -> None:
+        """Reject transforms whose numeric outputs change with placeholder pixels."""
+
+        representative = sorted({0, len(self) // 2, len(self) - 1})
+        for index in representative:
+            zeros = self.transform(index, self._placeholders)
+            ones = self.transform(index, self._alternate_placeholders)
+            for key in _STATS_KEYS:
+                if zeros[key].shape != ones[key].shape or not np.array_equal(
+                    zeros[key], ones[key], equal_nan=True
+                ):
+                    raise ValueError(
+                        f"Transformed {key!r} depends on visual pixel values at frame "
+                        f"{index} ({self._context}). Use calculate_norm_stats.py."
+                    )
+
+
+def compute_norm_stats(
+    dataset: ProjectedLeRobotSamples,
+    batch_size: int,
+    num_workers: int,
+) -> dict[str, normalize.NormStats]:
+    """Compute full-dataset stats, including a final partial batch."""
+
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    dataset.validate_pixel_independence()
+    stats = {key: normalize.RunningStats() for key in _STATS_KEYS}
+    expected_shapes: dict[str, tuple[int, ...]] = {}
+    executor = ThreadPoolExecutor(max_workers=num_workers) if num_workers > 1 else None
+    try:
+        ranges = range(0, len(dataset), batch_size)
+        for start in tqdm.tqdm(
+            ranges,
+            total=(len(dataset) + batch_size - 1) // batch_size,
+            desc="Transforming and computing stats",
+            unit="batches",
+        ):
+            indices = range(start, min(start + batch_size, len(dataset)))
+            if executor is None:
+                samples = [dataset.transform(index) for index in indices]
+            else:
+                samples = list(executor.map(dataset.transform, indices))
+
+            for key in _STATS_KEYS:
+                for sample in samples:
+                    shape = sample[key].shape
+                    expected = expected_shapes.setdefault(key, shape)
+                    if shape != expected:
+                        raise ValueError(
+                            f"Inconsistent transformed {key!r} shape: expected "
+                            f"{expected}, got {shape} at batch starting {start}"
+                        )
+                batch = np.stack([sample[key] for sample in samples]).astype(
+                    np.float32, copy=False
+                )
+                stats[key].update(batch)
+    finally:
+        if executor is not None:
+            executor.shutdown(wait=True, cancel_futures=True)
+    return {key: running.get_statistics() for key, running in stats.items()}
+
+
+def _check_output_available(output_path: Path, overwrite: bool) -> None:
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(
+            f"Output already exists at {output_path}. Pass --overwrite to replace it "
+            "or choose a different --output-path."
+        )
+
+
+def write_norm_stats_atomic(
+    output_path: Path,
+    norm_stats: dict[str, normalize.NormStats],
+    *,
+    overwrite: bool,
+) -> None:
+    """Serialize stats atomically, with race-safe no-overwrite behavior."""
+
+    _check_output_available(output_path, overwrite)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = normalize.serialize_json(norm_stats)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output_path.parent,
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as file:
+            temporary_path = Path(file.name)
+            file.write(serialized)
+            file.flush()
+            os.fsync(file.fileno())
+        temporary_path.chmod(0o644)
+        if overwrite:
+            os.replace(temporary_path, output_path)
+        else:
+            try:
+                os.link(temporary_path, output_path)
+            except FileExistsError as exc:
+                raise FileExistsError(
+                    f"Output appeared while computing stats at {output_path}; "
+                    "it was not overwritten."
+                ) from exc
+            temporary_path.unlink()
+            temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def main(
+    config_name: str,
+    repo_id: str,
+    output_path: Path | None = None,
+    overwrite: bool = False,
+) -> None:
+    """Compute and save non-visual OpenPI normalization statistics."""
+
+    dataset_root = resolve_lerobot_dataset_root(repo_id)
+    context = _context(config_name, repo_id, dataset_root)
+    info = _load_info(dataset_root, context=context)
+    target = (
+        output_path.expanduser().resolve()
+        if output_path is not None
+        else dataset_root / "norm_stats_fast.json"
+    )
+    _check_output_available(target, overwrite)
+
+    config = get_openpi_config(config_name, repo_id=repo_id)
+    data_config = config.data.create(config.assets_dirs, config.model)
+    if data_config.repo_id is None:
+        raise ValueError(f"Data config must have a repo_id ({context})")
+    if data_config.rlds_data_dir is not None:
+        raise ValueError(
+            f"RLDS datasets are unsupported by calculate_norm_stats_fast.py ({context})"
+        )
+    action_keys = tuple(data_config.action_sequence_keys)
+    if not action_keys:
+        raise ValueError(f"Data config has no action_sequence_keys ({context})")
+
+    projected = load_projected_data(
+        dataset_root,
+        info,
+        action_keys,
+        context=context,
+    )
+    task_mapping = (
+        _load_task_mapping(dataset_root, context=context)
+        if data_config.prompt_from_task
+        else None
+    )
+    dataset = ProjectedLeRobotSamples(
+        projected,
+        data_config,
+        config.model.action_horizon,
+        task_mapping,
+        context=context,
+    )
+    workers = max(0, int(config.num_workers))
+    print(
+        f"Computing stats for {projected.num_frames} frames with "
+        f"batch_size={config.batch_size}, num_workers={workers}"
+    )
+    norm_stats = compute_norm_stats(dataset, config.batch_size, workers)
+    print(f"Writing stats atomically to: {target}")
+    write_norm_stats_atomic(target, norm_stats, overwrite=overwrite)
+
+
+if __name__ == "__main__":
+    tyro.cli(main)

--- a/toolkits/lerobot/compare_policy_servers.py
+++ b/toolkits/lerobot/compare_policy_servers.py
@@ -1,0 +1,1332 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compare OpenPI-compatible policy servers on real LeRobot observations.
+
+This is a black-box deployment diagnostic. It deliberately compares the common
+action prefix when the servers return different action horizons; it is not a
+deterministic implementation-parity test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import dataclasses
+import datetime as dt
+import importlib
+import io
+import json
+import re
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+
+IMAGE_COLUMNS = (
+    "observation.images.cam_high",
+    "observation.images.cam_left_wrist",
+    "observation.images.cam_right_wrist",
+)
+REQUEST_IMAGE_KEYS = tuple(
+    key.removeprefix("observation.images.") for key in IMAGE_COLUMNS
+)
+STATE_COLUMN = "observation.state"
+ACTION_COLUMN = "action"
+
+
+def _optional_import(module: str, install: str, purpose: str) -> Any:
+    try:
+        return importlib.import_module(module)
+    except ImportError as exc:
+        raise RuntimeError(
+            f"{purpose} requires optional dependency {module!r}. "
+            f"Install it with: {install}"
+        ) from exc
+
+
+def _require_pyarrow() -> tuple[Any, Any]:
+    pa = _optional_import(
+        "pyarrow", "python -m pip install pyarrow", "LeRobot Parquet loading"
+    )
+    pq = _optional_import(
+        "pyarrow.parquet", "python -m pip install pyarrow", "LeRobot Parquet loading"
+    )
+    return pa, pq
+
+
+def _require_pillow() -> Any:
+    return _optional_import(
+        "PIL.Image", "python -m pip install Pillow", "Embedded image decoding"
+    )
+
+
+def _require_plotting() -> Any:
+    return _optional_import(
+        "matplotlib.pyplot",
+        "python -m pip install matplotlib",
+        "Diagnostic plot generation",
+    )
+
+
+def _require_openpi_protocol() -> tuple[Any, Any]:
+    msgpack_numpy = _optional_import(
+        "openpi_client.msgpack_numpy",
+        "python -m pip install openpi-client",
+        "OpenPI WebSocket serialization",
+    )
+    websocket_client = _optional_import(
+        "websockets.sync.client",
+        "python -m pip install websockets openpi-client",
+        "OpenPI WebSocket communication",
+    )
+    return msgpack_numpy, websocket_client
+
+
+@dataclasses.dataclass(frozen=True)
+class EpisodeRef:
+    """Location and prompt metadata for one contiguous LeRobot episode."""
+
+    episode_id: int
+    task_index: int
+    prompt: str
+    path: Path
+    row_start: int
+    row_stop: int
+
+    @property
+    def num_frames(self) -> int:
+        return self.row_stop - self.row_start
+
+
+@dataclasses.dataclass(frozen=True)
+class EpisodeData:
+    """Small non-visual columns for one episode."""
+
+    ref: EpisodeRef
+    state: np.ndarray
+    action: np.ndarray
+
+
+@dataclasses.dataclass(frozen=True)
+class InferenceResult:
+    """Validated server response plus client and server timing."""
+
+    actions: np.ndarray
+    rtt_ms: float
+    server_infer_ms: float | None
+    response: dict[str, Any]
+
+
+@dataclasses.dataclass(frozen=True)
+class PairedResult:
+    """One repeated, same-observation response pair."""
+
+    prompt: str
+    episode_id: int
+    frame_index: int
+    repeat: int
+    state: np.ndarray
+    truth: np.ndarray
+    openpi: InferenceResult
+    rlinf: InferenceResult
+
+
+class PolicyServerClient:
+    """Persistent client for the OpenPI msgpack-over-WebSocket protocol."""
+
+    def __init__(self, host: str, port: int, timeout: float, name: str) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.name = name
+        self.uri = (
+            host
+            if host.startswith("ws://") or host.startswith("wss://")
+            else f"ws://{host}:{port}"
+        )
+        self.metadata: dict[str, Any] = {}
+        self._connection: Any | None = None
+        self._msgpack: Any | None = None
+
+    def __enter__(self) -> PolicyServerClient:
+        msgpack_numpy, websocket_client = _require_openpi_protocol()
+        self._msgpack = msgpack_numpy
+        try:
+            self._connection = websocket_client.connect(
+                self.uri,
+                compression=None,
+                max_size=None,
+                open_timeout=self.timeout,
+                close_timeout=min(self.timeout, 2.0),
+            )
+            payload = self._connection.recv(timeout=self.timeout)
+        except Exception as exc:
+            self.close()
+            raise RuntimeError(
+                f"Could not connect to {self.name} policy server at {self.uri}: {exc}"
+            ) from exc
+        if isinstance(payload, str):
+            self.close()
+            raise RuntimeError(
+                f"{self.name} policy server sent text instead of handshake metadata: "
+                f"{payload}"
+            )
+        metadata = msgpack_numpy.unpackb(payload)
+        if not isinstance(metadata, dict):
+            self.close()
+            raise RuntimeError(
+                f"{self.name} policy server metadata must be a mapping, got "
+                f"{type(metadata).__name__}"
+            )
+        self.metadata = metadata
+        return self
+
+    def infer(self, observation: dict[str, Any]) -> InferenceResult:
+        if self._connection is None or self._msgpack is None:
+            raise RuntimeError(f"{self.name} policy server client is not connected")
+        started = time.perf_counter()
+        try:
+            self._connection.send(self._msgpack.packb(observation))
+            payload = self._connection.recv(timeout=self.timeout)
+        except TimeoutError as exc:
+            raise TimeoutError(
+                f"Timed out after {self.timeout:g}s waiting for {self.name} at {self.uri}"
+            ) from exc
+        except Exception as exc:
+            raise RuntimeError(
+                f"Connection to {self.name} policy server at {self.uri} failed: {exc}"
+            ) from exc
+        rtt_ms = (time.perf_counter() - started) * 1000.0
+        if isinstance(payload, str):
+            raise RuntimeError(
+                f"{self.name} policy server returned a text error:\n{payload}"
+            )
+        response = self._msgpack.unpackb(payload)
+        if not isinstance(response, dict):
+            raise RuntimeError(
+                f"{self.name} response must be a mapping, got {type(response).__name__}"
+            )
+        if "actions" not in response:
+            raise RuntimeError(
+                f"{self.name} response is missing required key 'actions'"
+            )
+        actions = np.asarray(response["actions"])
+        if actions.ndim != 2 or not all(size > 0 for size in actions.shape):
+            raise RuntimeError(
+                f"{self.name} actions must have shape [horizon, action_dim], got "
+                f"{actions.shape}"
+            )
+        if not np.issubdtype(actions.dtype, np.number):
+            raise RuntimeError(
+                f"{self.name} actions must be numeric, got {actions.dtype}"
+            )
+        actions = actions.astype(np.float64, copy=False)
+        if not np.all(np.isfinite(actions)):
+            bad = np.argwhere(~np.isfinite(actions))[0].tolist()
+            raise RuntimeError(
+                f"{self.name} actions contain a non-finite value at index {bad}"
+            )
+        timing = response.get("server_timing", {})
+        server_ms = timing.get("infer_ms") if isinstance(timing, dict) else None
+        if server_ms is not None:
+            server_ms = float(server_ms)
+        return InferenceResult(actions, rtt_ms, server_ms, response)
+
+    def close(self) -> None:
+        if self._connection is not None:
+            with contextlib.suppress(Exception):
+                self._connection.close()
+            self._connection = None
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def load_task_prompts(dataset_root: Path) -> dict[int, str]:
+    """Read LeRobot v3 task prompts, including pandas index-formatted tables."""
+    _, pq = _require_pyarrow()
+    path = dataset_root / "meta" / "tasks.parquet"
+    if not path.is_file():
+        raise FileNotFoundError(f"LeRobot task metadata does not exist: {path}")
+    table = pq.read_table(path)
+    columns = table.column_names
+    if "task_index" not in columns:
+        raise ValueError(f"Task metadata is missing 'task_index': {path}")
+    text_columns = [
+        name for name in ("task", "prompt", "__index_level_0__") if name in columns
+    ]
+    if not text_columns:
+        raise ValueError(
+            f"Task metadata must contain task, prompt, or __index_level_0__: {path}"
+        )
+    indices = table["task_index"].to_pylist()
+    prompts = table[text_columns[0]].to_pylist()
+    mapping = {
+        int(index): str(prompt) for index, prompt in zip(indices, prompts, strict=True)
+    }
+    if len(mapping) != len(indices):
+        raise ValueError(f"Task metadata contains duplicate task_index values: {path}")
+    return mapping
+
+
+def _scalar_array(column: Any) -> np.ndarray:
+    return np.asarray(column.combine_chunks().to_pylist())
+
+
+def scan_episodes(dataset_root: Path, prompts: dict[int, str]) -> list[EpisodeRef]:
+    """Scan only scalar locator columns and return deterministic episode refs."""
+    _, pq = _require_pyarrow()
+    data_paths = sorted((dataset_root / "data").rglob("*.parquet"))
+    if not data_paths:
+        raise FileNotFoundError(
+            f"No Parquet data files found under {dataset_root / 'data'}"
+        )
+    refs: list[EpisodeRef] = []
+    seen: set[int] = set()
+    required = ("episode_index", "frame_index", "task_index")
+    for path in data_paths:
+        parquet = pq.ParquetFile(path)
+        missing = sorted(set(required) - set(parquet.schema_arrow.names))
+        if missing:
+            raise ValueError(f"{path} is missing locator columns: {missing}")
+        table = parquet.read(columns=list(required))
+        episode_ids = _scalar_array(table["episode_index"]).astype(np.int64)
+        frame_ids = _scalar_array(table["frame_index"]).astype(np.int64)
+        task_ids = _scalar_array(table["task_index"]).astype(np.int64)
+        for episode_id in np.unique(episode_ids):
+            rows = np.flatnonzero(episode_ids == episode_id)
+            start, stop = int(rows[0]), int(rows[-1]) + 1
+            if not np.array_equal(rows, np.arange(start, stop)):
+                raise ValueError(f"Episode {episode_id} is not contiguous in {path}")
+            if int(episode_id) in seen:
+                raise ValueError(
+                    f"Episode {episode_id} spans multiple Parquet files; consolidate it "
+                    "before running this diagnostic"
+                )
+            seen.add(int(episode_id))
+            episode_frames = frame_ids[rows]
+            if not np.array_equal(episode_frames, np.arange(len(rows))):
+                raise ValueError(
+                    f"Episode {episode_id} frame_index must be contiguous from zero in {path}"
+                )
+            unique_tasks = np.unique(task_ids[rows])
+            if len(unique_tasks) != 1:
+                raise ValueError(
+                    f"Episode {episode_id} has multiple task_index values in {path}"
+                )
+            task_index = int(unique_tasks[0])
+            if task_index not in prompts:
+                raise ValueError(
+                    f"Episode {episode_id} references unknown task_index {task_index}"
+                )
+            refs.append(
+                EpisodeRef(
+                    episode_id=int(episode_id),
+                    task_index=task_index,
+                    prompt=prompts[task_index],
+                    path=path,
+                    row_start=start,
+                    row_stop=stop,
+                )
+            )
+    return sorted(refs, key=lambda ref: ref.episode_id)
+
+
+def select_episodes(
+    refs: Sequence[EpisodeRef],
+    *,
+    episodes_per_prompt: int,
+    prompt_regex: str | None,
+    episode_ids: set[int] | None,
+    seed: int,
+) -> list[EpisodeRef]:
+    """Select a seeded, stable set of episodes grouped by prompt."""
+    if episodes_per_prompt < 1:
+        raise ValueError("episodes_per_prompt must be at least 1")
+    pattern = re.compile(prompt_regex) if prompt_regex else None
+    grouped: dict[str, list[EpisodeRef]] = defaultdict(list)
+    for ref in refs:
+        if episode_ids is not None and ref.episode_id not in episode_ids:
+            continue
+        if pattern is not None and pattern.search(ref.prompt) is None:
+            continue
+        grouped[ref.prompt].append(ref)
+    if not grouped:
+        raise ValueError("No episodes match the prompt and episode filters")
+    rng = np.random.default_rng(seed)
+    selected: list[EpisodeRef] = []
+    for prompt in sorted(grouped):
+        candidates = sorted(grouped[prompt], key=lambda ref: ref.episode_id)
+        count = min(episodes_per_prompt, len(candidates))
+        positions = np.sort(rng.choice(len(candidates), size=count, replace=False))
+        selected.extend(candidates[int(position)] for position in positions)
+    return selected
+
+
+def uniform_frame_indices(num_frames: int, count: int) -> np.ndarray:
+    """Return unique, evenly spaced frame indices, including both endpoints."""
+    if num_frames < 1 or count < 1:
+        raise ValueError("num_frames and count must be positive")
+    count = min(num_frames, count)
+    return np.unique(np.rint(np.linspace(0, num_frames - 1, count)).astype(np.int64))
+
+
+def replay_frame_indices(
+    num_frames: int, horizon: int, chunks: int, rng: np.random.Generator
+) -> np.ndarray:
+    """Choose consecutive full-horizon replanning anchors within an episode."""
+    if horizon < 1 or chunks < 1:
+        raise ValueError("horizon and chunks must be positive")
+    maximum_start = max(0, num_frames - 1 - horizon * (chunks - 1))
+    start = int(rng.integers(maximum_start + 1))
+    return np.minimum(start + np.arange(chunks) * horizon, num_frames - 1)
+
+
+def _vector_column(table: Any, name: str, dtype: Any = np.float32) -> np.ndarray:
+    return np.asarray(table[name].combine_chunks().to_pylist(), dtype=dtype)
+
+
+def load_episode_numeric(ref: EpisodeRef) -> EpisodeData:
+    """Load state and actions without touching image columns."""
+    _, pq = _require_pyarrow()
+    parquet = pq.ParquetFile(ref.path)
+    missing = sorted({STATE_COLUMN, ACTION_COLUMN} - set(parquet.schema_arrow.names))
+    if missing:
+        raise ValueError(f"{ref.path} is missing required columns: {missing}")
+    table = parquet.read(columns=[STATE_COLUMN, ACTION_COLUMN]).slice(
+        ref.row_start, ref.num_frames
+    )
+    state = _vector_column(table, STATE_COLUMN)
+    action = _vector_column(table, ACTION_COLUMN)
+    if state.ndim != 2 or state.shape[1] != 14:
+        raise ValueError(
+            f"Episode {ref.episode_id} state must have shape [N, 14], got {state.shape}"
+        )
+    if action.ndim != 2 or action.shape[1] != 14:
+        raise ValueError(
+            f"Episode {ref.episode_id} action must have shape [N, 14], got {action.shape}"
+        )
+    if not np.all(np.isfinite(state)) or not np.all(np.isfinite(action)):
+        raise ValueError(
+            f"Episode {ref.episode_id} contains non-finite state or action"
+        )
+    return EpisodeData(ref=ref, state=state, action=action)
+
+
+def _read_selected_cells(
+    path: Path, column: str, row_indices: Sequence[int]
+) -> list[Any]:
+    """Read one column and only row groups containing requested rows."""
+    pa, pq = _require_pyarrow()
+    parquet = pq.ParquetFile(path)
+    requested = np.asarray(row_indices, dtype=np.int64)
+    if len(requested) == 0:
+        return []
+    output: dict[int, Any] = {}
+    offset = 0
+    for row_group in range(parquet.num_row_groups):
+        row_count = parquet.metadata.row_group(row_group).num_rows
+        mask = (requested >= offset) & (requested < offset + row_count)
+        if np.any(mask):
+            locals_ = requested[mask] - offset
+            values = parquet.read_row_group(row_group, columns=[column])[column]
+            selected = values.take(pa.array(locals_)).to_pylist()
+            output.update(zip(requested[mask].tolist(), selected, strict=True))
+        offset += row_count
+    missing = [int(index) for index in requested if int(index) not in output]
+    if missing:
+        raise IndexError(f"Rows {missing} are outside {path}")
+    return [output[int(index)] for index in requested]
+
+
+def _decode_image(value: Any, dataset_root: Path) -> np.ndarray:
+    image_module = _require_pillow()
+    if isinstance(value, dict):
+        image_bytes = value.get("bytes")
+        image_path = value.get("path")
+    elif isinstance(value, (bytes, bytearray, memoryview)):
+        image_bytes, image_path = bytes(value), None
+    else:
+        raise ValueError(f"Unsupported embedded image value: {type(value).__name__}")
+    if image_bytes is not None:
+        source: Any = io.BytesIO(image_bytes)
+    elif image_path:
+        source = dataset_root / image_path
+    else:
+        raise ValueError("Image value contains neither bytes nor path")
+    with image_module.open(source) as image:
+        return np.asarray(image.convert("RGB"), dtype=np.uint8)
+
+
+def load_observations(
+    dataset_root: Path, episode: EpisodeData, frame_indices: Sequence[int]
+) -> dict[int, dict[str, Any]]:
+    """Load selected frames one image column at a time and build server requests."""
+    local_indices = np.unique(np.asarray(frame_indices, dtype=np.int64))
+    if np.any(local_indices < 0) or np.any(local_indices >= episode.ref.num_frames):
+        raise IndexError(f"Frame indices are outside episode {episode.ref.episode_id}")
+    file_indices = episode.ref.row_start + local_indices
+    images_by_key: dict[str, list[np.ndarray]] = {}
+    for column, request_key in zip(IMAGE_COLUMNS, REQUEST_IMAGE_KEYS, strict=True):
+        values = _read_selected_cells(episode.ref.path, column, file_indices)
+        images_by_key[request_key] = [
+            _decode_image(value, dataset_root) for value in values
+        ]
+    observations: dict[int, dict[str, Any]] = {}
+    for position, frame_index in enumerate(local_indices):
+        observations[int(frame_index)] = {
+            "images": {key: images_by_key[key][position] for key in REQUEST_IMAGE_KEYS}
+        }
+        observations[int(frame_index)]["state"] = episode.state[frame_index].copy()
+        observations[int(frame_index)]["prompt"] = episode.ref.prompt
+    return observations
+
+
+def format_observation_layout(
+    observation: dict[str, Any], layout: str
+) -> dict[str, Any]:
+    """Format canonical HWC images for one server without changing content."""
+    if layout not in {"chw", "hwc"}:
+        raise ValueError(f"Unsupported image layout: {layout}")
+    images = observation["images"]
+    return {
+        "images": {
+            key: np.moveaxis(value, -1, 0) if layout == "chw" else value
+            for key, value in images.items()
+        },
+        "state": observation["state"],
+        "prompt": observation["prompt"],
+    }
+
+
+def padded_action_chunk(
+    actions: np.ndarray, frame_index: int, horizon: int
+) -> np.ndarray:
+    """Build an episode-local ground-truth chunk with tail-repeat padding."""
+    if horizon < 1:
+        raise ValueError("horizon must be positive")
+    indices = np.minimum(frame_index + np.arange(horizon), len(actions) - 1)
+    return np.asarray(actions[indices], dtype=np.float64)
+
+
+def common_prefix_metrics(
+    left: np.ndarray, right: np.ndarray, joint_std: np.ndarray
+) -> dict[str, Any]:
+    """Compute errors over the shared action horizon and dimensions."""
+    horizon = min(left.shape[0], right.shape[0])
+    dimensions = min(left.shape[1], right.shape[1], len(joint_std))
+    if horizon == 0 or dimensions == 0:
+        raise ValueError("Action chunks have no common prefix")
+    difference = np.asarray(left[:horizon, :dimensions] - right[:horizon, :dimensions])
+    absolute = np.abs(difference)
+    safe_std = np.maximum(np.asarray(joint_std[:dimensions], dtype=np.float64), 1e-12)
+    return {
+        "common_horizon": horizon,
+        "common_action_dim": dimensions,
+        "mae": float(absolute.mean()),
+        "rmse": float(np.sqrt(np.mean(np.square(difference)))),
+        "p95_abs": float(np.percentile(absolute, 95)),
+        "max_abs": float(absolute.max()),
+        "normalized_mae": float((absolute / safe_std[None, :]).mean()),
+        "per_joint_mae": absolute.mean(axis=0),
+        "per_horizon_mae": absolute.mean(axis=1),
+        "absolute_difference": absolute,
+    }
+
+
+def randomness_metrics(chunks: Sequence[np.ndarray]) -> dict[str, float]:
+    """Summarize repeated stochastic outputs over their common prefix."""
+    if not chunks:
+        raise ValueError("At least one action chunk is required")
+    horizon = min(chunk.shape[0] for chunk in chunks)
+    dimensions = min(chunk.shape[1] for chunk in chunks)
+    stacked = np.stack([chunk[:horizon, :dimensions] for chunk in chunks])
+    output_std = float(stacked.std(axis=0).mean())
+    pairwise = [
+        np.abs(stacked[left] - stacked[right]).mean()
+        for left in range(len(stacked))
+        for right in range(left + 1, len(stacked))
+    ]
+    return {
+        "output_std": output_std,
+        "repeat_to_repeat_mae": float(np.mean(pairwise)) if pairwise else 0.0,
+    }
+
+
+def action_1_to_10_jump_metrics(chunks: Sequence[np.ndarray]) -> dict[str, Any]:
+    """Summarize net action change from one-based steps 1 to 10."""
+    if not chunks:
+        raise ValueError("At least one action chunk is required")
+    if any(chunk.ndim != 2 or chunk.shape[0] < 10 for chunk in chunks):
+        raise ValueError(
+            "Every action chunk must have shape [horizon >= 10, action_dim]"
+        )
+    dimensions = min(chunk.shape[1] for chunk in chunks)
+    deltas = np.stack(
+        [chunk[9, :dimensions] - chunk[0, :dimensions] for chunk in chunks]
+    )
+    absolute = np.abs(deltas)
+    per_joint = absolute.mean(axis=0)
+    return {
+        "num_chunks": len(chunks),
+        "action_dim": dimensions,
+        "mae": float(absolute.mean()),
+        "rmse": float(np.sqrt(np.square(deltas).mean())),
+        "p95_abs": float(np.percentile(absolute, 95)),
+        "max_abs": float(absolute.max()),
+        "mean_l2": float(np.linalg.norm(deltas, axis=1).mean()),
+        "worst_joint": int(np.argmax(per_joint)),
+        "worst_joint_mae": float(per_joint.max()),
+        "per_joint_mae": per_joint,
+    }
+
+
+def chunk_jitter_metrics(
+    chunk: np.ndarray, state: np.ndarray, truth: np.ndarray
+) -> dict[str, float]:
+    """Compute state jump, temporal differences, and data error for one chunk."""
+    dimensions = min(chunk.shape[1], len(state), truth.shape[1])
+    horizon = min(chunk.shape[0], truth.shape[0])
+    first_difference = np.diff(chunk[:, :dimensions], axis=0)
+    second_difference = np.diff(chunk[:, :dimensions], n=2, axis=0)
+    return {
+        "first_action_state_jump": float(
+            np.abs(chunk[0, :dimensions] - state[:dimensions]).mean()
+        ),
+        "first_difference_mae": float(np.abs(first_difference).mean())
+        if len(first_difference)
+        else 0.0,
+        "second_difference_mae": float(np.abs(second_difference).mean())
+        if len(second_difference)
+        else 0.0,
+        "ground_truth_mae": float(
+            np.abs(chunk[:horizon, :dimensions] - truth[:horizon, :dimensions]).mean()
+        ),
+    }
+
+
+def replanning_boundary_metrics(chunks: Sequence[np.ndarray]) -> dict[str, float]:
+    """Measure jumps between the last and first actions of adjacent chunks."""
+    jumps = []
+    for previous, current in zip(chunks, chunks[1:]):
+        dimensions = min(previous.shape[1], current.shape[1])
+        jumps.append(np.abs(previous[-1, :dimensions] - current[0, :dimensions]))
+    if not jumps:
+        return {"boundary_jump_mae": 0.0, "boundary_jump_max": 0.0}
+    absolute = np.concatenate(jumps)
+    return {
+        "boundary_jump_mae": float(absolute.mean()),
+        "boundary_jump_max": float(absolute.max()),
+    }
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, Path):
+        return str(value)
+    if dataclasses.is_dataclass(value):
+        return _jsonable(dataclasses.asdict(value))
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(_jsonable(value), indent=2, sort_keys=True) + "\n")
+
+
+def _write_csv(path: Path, rows: Sequence[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("")
+        return
+    fieldnames = list(rows[0])
+    with path.open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _metric_scalars(metrics: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in metrics.items() if np.isscalar(value)}
+
+
+def _aggregate_pair_metrics(
+    paired: Sequence[PairedResult], joint_std: np.ndarray
+) -> tuple[
+    dict[str, Any], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]
+]:
+    sample_rows: list[dict[str, Any]] = []
+    joint_rows: list[dict[str, Any]] = []
+    horizon_rows: list[dict[str, Any]] = []
+    by_prompt: dict[str, list[float]] = defaultdict(list)
+    absolute_differences: list[np.ndarray] = []
+    for result in paired:
+        metrics = common_prefix_metrics(
+            result.openpi.actions, result.rlinf.actions, joint_std
+        )
+        identity = {
+            "prompt": result.prompt,
+            "episode_id": result.episode_id,
+            "frame_index": result.frame_index,
+            "repeat": result.repeat,
+        }
+        sample_rows.append(
+            {
+                **identity,
+                **_metric_scalars(metrics),
+                "openpi_horizon": result.openpi.actions.shape[0],
+                "rlinf_horizon": result.rlinf.actions.shape[0],
+                "openpi_action_dim": result.openpi.actions.shape[1],
+                "rlinf_action_dim": result.rlinf.actions.shape[1],
+                "openpi_rtt_ms": result.openpi.rtt_ms,
+                "rlinf_rtt_ms": result.rlinf.rtt_ms,
+                "openpi_server_infer_ms": result.openpi.server_infer_ms,
+                "rlinf_server_infer_ms": result.rlinf.server_infer_ms,
+            }
+        )
+        by_prompt[result.prompt].append(metrics["mae"])
+        absolute_differences.append(metrics["absolute_difference"])
+        for joint, mae in enumerate(metrics["per_joint_mae"]):
+            joint_rows.append({**identity, "joint": joint, "mae": float(mae)})
+        for step, mae in enumerate(metrics["per_horizon_mae"]):
+            horizon_rows.append({**identity, "horizon_step": step, "mae": float(mae)})
+    common_horizon = min(array.shape[0] for array in absolute_differences)
+    common_dim = min(array.shape[1] for array in absolute_differences)
+    absolute = np.stack(
+        [array[:common_horizon, :common_dim] for array in absolute_differences]
+    )
+    per_joint = absolute.mean(axis=(0, 1))
+    per_horizon = absolute.mean(axis=(0, 2))
+    prompt_mae = {
+        prompt: float(np.mean(values)) for prompt, values in by_prompt.items()
+    }
+    worst_prompt = max(prompt_mae, key=prompt_mae.get)
+    return (
+        {
+            "num_pairs": len(paired),
+            "common_horizon": common_horizon,
+            "common_action_dim": common_dim,
+            "mae": float(absolute.mean()),
+            "rmse": float(np.sqrt(np.mean(np.square(absolute)))),
+            "p95_abs": float(np.percentile(absolute, 95)),
+            "max_abs": float(absolute.max()),
+            "normalized_mae": float(
+                (
+                    absolute / np.maximum(joint_std[:common_dim], 1e-12)[None, None, :]
+                ).mean()
+            ),
+            "prompt_mae": prompt_mae,
+            "worst_prompt": {"prompt": worst_prompt, "mae": prompt_mae[worst_prompt]},
+            "worst_joint": {
+                "joint": int(np.argmax(per_joint)),
+                "mae": float(per_joint.max()),
+            },
+            "worst_horizon_step": {
+                "horizon_step": int(np.argmax(per_horizon)),
+                "mae": float(per_horizon.max()),
+            },
+            "mean_absolute_difference": absolute.mean(axis=0),
+        },
+        sample_rows,
+        joint_rows,
+        horizon_rows,
+    )
+
+
+def _randomness_summary(paired: Sequence[PairedResult]) -> dict[str, Any]:
+    grouped: dict[tuple[str, int, int], list[PairedResult]] = defaultdict(list)
+    for result in paired:
+        grouped[(result.prompt, result.episode_id, result.frame_index)].append(result)
+    summary: dict[str, Any] = {}
+    for server in ("openpi", "rlinf"):
+        metrics = [
+            randomness_metrics([getattr(item, server).actions for item in items])
+            for items in grouped.values()
+        ]
+        summary[server] = {
+            key: float(np.mean([metric[key] for metric in metrics]))
+            for key in ("output_std", "repeat_to_repeat_mae")
+        }
+    return summary
+
+
+def _action_1_to_10_summary(paired: Sequence[PairedResult]) -> dict[str, Any]:
+    """Compare steps 1 and 10 on identical paired observations."""
+    output = {
+        server: action_1_to_10_jump_metrics(
+            [getattr(item, server).actions for item in paired]
+        )
+        for server in ("openpi", "rlinf")
+    }
+    dimensions = min(item.openpi.actions.shape[1] for item in paired)
+    dimensions = min(dimensions, min(item.rlinf.actions.shape[1] for item in paired))
+    displacement_difference = np.stack(
+        [
+            (item.openpi.actions[9, :dimensions] - item.openpi.actions[0, :dimensions])
+            - (item.rlinf.actions[9, :dimensions] - item.rlinf.actions[0, :dimensions])
+            for item in paired
+        ]
+    )
+    absolute = np.abs(displacement_difference)
+    output["paired_displacement_difference"] = {
+        "num_pairs": len(paired),
+        "mae": float(absolute.mean()),
+        "rmse": float(np.sqrt(np.square(displacement_difference).mean())),
+        "p95_abs": float(np.percentile(absolute, 95)),
+        "max_abs": float(absolute.max()),
+    }
+    output["rlinf_to_openpi_mae_ratio"] = (
+        output["rlinf"]["mae"] / output["openpi"]["mae"]
+    )
+    return output
+
+
+def _latency_summary(paired: Sequence[PairedResult]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for server in ("openpi", "rlinf"):
+        values = [getattr(item, server) for item in paired]
+        rtt = np.asarray([item.rtt_ms for item in values])
+        infer = np.asarray(
+            [
+                item.server_infer_ms
+                for item in values
+                if item.server_infer_ms is not None
+            ]
+        )
+        output[server] = {
+            "rtt_ms_mean": float(rtt.mean()),
+            "rtt_ms_p95": float(np.percentile(rtt, 95)),
+            "server_infer_ms_mean": float(infer.mean()) if len(infer) else None,
+            "server_infer_ms_p95": float(np.percentile(infer, 95))
+            if len(infer)
+            else None,
+        }
+    return output
+
+
+def _plot_outputs(
+    output_dir: Path,
+    pair_summary: dict[str, Any],
+    paired: Sequence[PairedResult],
+    jitter_rows: Sequence[dict[str, Any]],
+) -> None:
+    plt = _require_plotting()
+    heatmap = np.asarray(pair_summary["mean_absolute_difference"])
+    figure, axis = plt.subplots(figsize=(10, 5))
+    image = axis.imshow(heatmap.T, aspect="auto", origin="lower")
+    axis.set(
+        xlabel="Horizon step", ylabel="Joint", title="Mean absolute server difference"
+    )
+    figure.colorbar(image, ax=axis, label="Absolute difference")
+    figure.tight_layout()
+    figure.savefig(output_dir / "difference_heatmap.png", dpi=160)
+    plt.close(figure)
+
+    worst = max(
+        paired,
+        key=lambda item: common_prefix_metrics(
+            item.openpi.actions,
+            item.rlinf.actions,
+            np.ones(min(item.openpi.actions.shape[1], item.rlinf.actions.shape[1])),
+        )["mae"],
+    )
+    dimensions = min(14, worst.openpi.actions.shape[1], worst.rlinf.actions.shape[1])
+    figure, axes = plt.subplots(7, 2, figsize=(12, 18), sharex=True)
+    truth_openpi = padded_action_chunk(worst.truth, 0, worst.openpi.actions.shape[0])
+    truth_rlinf = padded_action_chunk(worst.truth, 0, worst.rlinf.actions.shape[0])
+    for joint, axis in enumerate(axes.flat[:dimensions]):
+        axis.plot(worst.openpi.actions[:, joint], label="OpenPI")
+        axis.plot(worst.rlinf.actions[:, joint], label="RLinf")
+        axis.plot(truth_openpi[:, joint], linestyle="--", label="Dataset/OpenPI H")
+        if len(truth_rlinf) != len(truth_openpi):
+            axis.plot(truth_rlinf[:, joint], linestyle=":", label="Dataset/RLinf H")
+        axis.set_title(f"Joint {joint}")
+    axes.flat[0].legend(fontsize="small")
+    figure.suptitle(
+        f"Worst paired trace: episode {worst.episode_id}, frame {worst.frame_index}"
+    )
+    figure.tight_layout()
+    figure.savefig(output_dir / "action_trace.png", dpi=160)
+    plt.close(figure)
+
+    metric_names = (
+        "first_action_state_jump",
+        "first_difference_mae",
+        "second_difference_mae",
+        "ground_truth_mae",
+    )
+    servers = ("openpi", "rlinf")
+    means = [
+        [
+            np.mean(
+                [float(row[name]) for row in jitter_rows if row["server"] == server]
+            )
+            for name in metric_names
+        ]
+        for server in servers
+    ]
+    x = np.arange(len(metric_names))
+    figure, axis = plt.subplots(figsize=(11, 5))
+    width = 0.36
+    axis.bar(x - width / 2, means[0], width, label="OpenPI")
+    axis.bar(x + width / 2, means[1], width, label="RLinf")
+    axis.set_xticks(x, [name.replace("_", "\n") for name in metric_names])
+    axis.set(ylabel="Mean absolute magnitude", title="Action jitter proxies")
+    axis.legend()
+    figure.tight_layout()
+    figure.savefig(output_dir / "jitter_metrics.png", dpi=160)
+    plt.close(figure)
+
+
+def _write_report(output_dir: Path, summary: dict[str, Any]) -> None:
+    pair = summary["paired_comparison"]
+    endpoint_jump = summary["action_1_to_10_jump"]
+    contract = summary["contract"]
+    randomness = summary["randomness"]
+    latency = summary["latency"]
+    lines = [
+        "# Policy Server Black-Box Diagnostic",
+        "",
+        "> This run describes the currently deployed behavior. The servers returned "
+        f"horizons {contract['openpi_horizons']} and {contract['rlinf_horizons']}; "
+        "when contracts differ, these results are not strict numerical parity evidence.",
+        "",
+        "## Common-Prefix Comparison",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| Samples | {pair['num_pairs']} |",
+        f"| Common horizon | {pair['common_horizon']} |",
+        f"| Common action dimensions | {pair['common_action_dim']} |",
+        f"| MAE | {pair['mae']:.6g} |",
+        f"| RMSE | {pair['rmse']:.6g} |",
+        f"| P95 absolute difference | {pair['p95_abs']:.6g} |",
+        f"| Maximum absolute difference | {pair['max_abs']:.6g} |",
+        f"| Joint-std normalized MAE | {pair['normalized_mae']:.6g} |",
+        "",
+        f"Worst prompt: `{pair['worst_prompt']['prompt']}` "
+        f"(MAE {pair['worst_prompt']['mae']:.6g}).",
+        "",
+        f"Worst joint: {pair['worst_joint']['joint']} "
+        f"(MAE {pair['worst_joint']['mae']:.6g}).",
+        "",
+        f"Worst horizon step: {pair['worst_horizon_step']['horizon_step']} "
+        f"(MAE {pair['worst_horizon_step']['mae']:.6g}).",
+        "",
+        "## Per-Prompt MAE",
+        "",
+        "| Prompt | MAE |",
+        "| --- | ---: |",
+    ]
+    for prompt, mae in sorted(pair["prompt_mae"].items(), key=lambda item: -item[1]):
+        escaped_prompt = prompt.replace("|", "\\|")
+        lines.append(f"| {escaped_prompt} | {mae:.6g} |")
+    lines.extend(
+        [
+            "",
+            "## Action 1 to Action 10 Jump",
+            "",
+            "For each response chunk, this compares one-based action steps 1 and 10 "
+            "(`actions[0]` and `actions[9]`). Both servers provide these steps, so "
+            "the metric is unaffected by their different full horizons.",
+            "",
+            "| Server | Chunks | MAE | RMSE | P95 | Maximum | Mean chunk L2 | Worst joint |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for server in ("openpi", "rlinf"):
+        values = endpoint_jump[server]
+        lines.append(
+            f"| {server} | {values['num_chunks']} | {values['mae']:.6g} | "
+            f"{values['rmse']:.6g} | {values['p95_abs']:.6g} | "
+            f"{values['max_abs']:.6g} | {values['mean_l2']:.6g} | "
+            f"{values['worst_joint']} ({values['worst_joint_mae']:.6g}) |"
+        )
+    displacement = endpoint_jump["paired_displacement_difference"]
+    relative_change = (endpoint_jump["rlinf_to_openpi_mae_ratio"] - 1.0) * 100.0
+    lines.extend(
+        [
+            "",
+            f"RLinf's mean absolute jump is {abs(relative_change):.2f}% "
+            f"{'higher' if relative_change >= 0 else 'lower'} than OpenPI's. "
+            "The paired action-displacement vectors differ by "
+            f"MAE {displacement['mae']:.6g}, RMSE {displacement['rmse']:.6g}, "
+            f"P95 {displacement['p95_abs']:.6g}, and maximum "
+            f"{displacement['max_abs']:.6g}; similar aggregate jump magnitudes do "
+            "not imply matching per-joint directions.",
+        ]
+    )
+    lines.extend(
+        [
+            "",
+            "## Randomness and Latency",
+            "",
+            "| Server | Output std | Repeat MAE | Mean RTT (ms) | Mean inference (ms) |",
+            "| --- | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for server in ("openpi", "rlinf"):
+        inference = latency[server]["server_infer_ms_mean"]
+        inference_text = f"{inference:.3f}" if inference is not None else "n/a"
+        lines.append(
+            f"| {server} | {randomness[server]['output_std']:.6g} | "
+            f"{randomness[server]['repeat_to_repeat_mae']:.6g} | "
+            f"{latency[server]['rtt_ms_mean']:.3f} | {inference_text} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Artifacts",
+            "",
+            "- `summary.json`: machine-readable aggregate metrics.",
+            "- `sample_metrics.csv`: paired sample and timing metrics.",
+            "- `per_joint_metrics.csv` and `per_horizon_metrics.csv`: detailed errors.",
+            "- `jitter_metrics.csv`: chunk smoothness and replay boundary proxies.",
+            "- `raw_outputs.npz`: every raw action chunk and its index.",
+            "- `difference_heatmap.png`, `action_trace.png`, and `jitter_metrics.png`: plots.",
+            "",
+        ]
+    )
+    (output_dir / "report.md").write_text("\n".join(lines))
+
+
+def _load_joint_std(dataset_root: Path) -> np.ndarray:
+    path = dataset_root / "meta" / "stats.json"
+    if not path.is_file():
+        raise FileNotFoundError(f"Dataset statistics do not exist: {path}")
+    stats = json.loads(path.read_text())
+    if ACTION_COLUMN not in stats or "std" not in stats[ACTION_COLUMN]:
+        raise ValueError(f"Dataset statistics are missing action.std: {path}")
+    values = np.asarray(stats[ACTION_COLUMN]["std"], dtype=np.float64)
+    if values.ndim != 1 or len(values) < 1 or not np.all(np.isfinite(values)):
+        raise ValueError(f"Dataset action.std must be a finite vector: {path}")
+    return values
+
+
+def run(args: argparse.Namespace) -> Path:
+    """Run the comparison and return the timestamped artifact directory."""
+    dataset_root = Path(args.dataset_root).resolve()
+    info_path = dataset_root / "meta" / "info.json"
+    if not info_path.is_file():
+        raise FileNotFoundError(f"LeRobot v3 metadata does not exist: {info_path}")
+    info = json.loads(info_path.read_text())
+    if info.get("codebase_version") != "v3.0":
+        raise ValueError(
+            f"Expected LeRobot codebase_version 'v3.0', got {info.get('codebase_version')!r}"
+        )
+    prompts = load_task_prompts(dataset_root)
+    refs = scan_episodes(dataset_root, prompts)
+    selected = select_episodes(
+        refs,
+        episodes_per_prompt=args.episodes_per_prompt,
+        prompt_regex=args.prompt_regex,
+        episode_ids=set(args.episode_ids) if args.episode_ids else None,
+        seed=args.seed,
+    )
+    joint_std = _load_joint_std(dataset_root)
+    timestamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_dir = Path(args.output_dir) / timestamp
+    output_dir.mkdir(parents=True, exist_ok=False)
+
+    paired: list[PairedResult] = []
+    jitter_rows: list[dict[str, Any]] = []
+    replay_summary: dict[str, list[dict[str, float]]] = defaultdict(list)
+    raw: dict[str, np.ndarray] = {}
+    raw_index: list[dict[str, Any]] = []
+    rng = np.random.default_rng(args.seed)
+    server_layouts = {
+        "openpi": args.openpi_image_layout,
+        "rlinf": args.rlinf_image_layout,
+    }
+    with (
+        PolicyServerClient(
+            args.openpi_host, args.openpi_port, args.request_timeout, "OpenPI"
+        ) as openpi,
+        PolicyServerClient(
+            args.rlinf_host, args.rlinf_port, args.request_timeout, "RLinf"
+        ) as rlinf,
+    ):
+        for ref in selected:
+            print(f"Comparing episode {ref.episode_id}: {ref.prompt}", flush=True)
+            episode = load_episode_numeric(ref)
+            paired_frames = uniform_frame_indices(ref.num_frames, args.paired_frames)
+            observations = load_observations(dataset_root, episode, paired_frames)
+            for frame_index in paired_frames:
+                per_server_repeats: dict[str, list[np.ndarray]] = defaultdict(list)
+                for repeat in range(args.repeats):
+                    openpi_result = openpi.infer(
+                        format_observation_layout(
+                            observations[int(frame_index)], server_layouts["openpi"]
+                        )
+                    )
+                    rlinf_result = rlinf.infer(
+                        format_observation_layout(
+                            observations[int(frame_index)], server_layouts["rlinf"]
+                        )
+                    )
+                    truth_horizon = max(
+                        openpi_result.actions.shape[0], rlinf_result.actions.shape[0]
+                    )
+                    truth = padded_action_chunk(
+                        episode.action, int(frame_index), truth_horizon
+                    )
+                    result = PairedResult(
+                        prompt=ref.prompt,
+                        episode_id=ref.episode_id,
+                        frame_index=int(frame_index),
+                        repeat=repeat,
+                        state=episode.state[frame_index],
+                        truth=truth,
+                        openpi=openpi_result,
+                        rlinf=rlinf_result,
+                    )
+                    paired.append(result)
+                    for server, response in (
+                        ("openpi", openpi_result),
+                        ("rlinf", rlinf_result),
+                    ):
+                        per_server_repeats[server].append(response.actions)
+                        key = f"paired_{len(raw_index):06d}_{server}"
+                        raw[key] = response.actions
+                        raw_index.append(
+                            {
+                                "key": key,
+                                "kind": "paired",
+                                "server": server,
+                                "episode_id": ref.episode_id,
+                                "frame_index": int(frame_index),
+                                "repeat": repeat,
+                                "prompt": ref.prompt,
+                            }
+                        )
+                        truth_for_server = padded_action_chunk(
+                            episode.action, int(frame_index), response.actions.shape[0]
+                        )
+                        jitter_rows.append(
+                            {
+                                "kind": "paired",
+                                "server": server,
+                                "prompt": ref.prompt,
+                                "episode_id": ref.episode_id,
+                                "frame_index": int(frame_index),
+                                "chunk_index": repeat,
+                                **chunk_jitter_metrics(
+                                    response.actions,
+                                    episode.state[frame_index],
+                                    truth_for_server,
+                                ),
+                                "boundary_jump_mae": "",
+                                "boundary_jump_max": "",
+                            }
+                        )
+
+            horizons = {
+                "openpi": paired[-1].openpi.actions.shape[0],
+                "rlinf": paired[-1].rlinf.actions.shape[0],
+            }
+            replay_frames = {
+                server: replay_frame_indices(
+                    ref.num_frames, horizon, args.replay_chunks, rng
+                )
+                for server, horizon in horizons.items()
+            }
+            replay_observations = load_observations(
+                dataset_root,
+                episode,
+                np.unique(np.concatenate(list(replay_frames.values()))),
+            )
+            for server, client in (("openpi", openpi), ("rlinf", rlinf)):
+                chunks: list[np.ndarray] = []
+                rows_for_server: list[dict[str, Any]] = []
+                for chunk_index, frame_index in enumerate(replay_frames[server]):
+                    response = client.infer(
+                        format_observation_layout(
+                            replay_observations[int(frame_index)],
+                            server_layouts[server],
+                        )
+                    )
+                    chunks.append(response.actions)
+                    truth = padded_action_chunk(
+                        episode.action, int(frame_index), response.actions.shape[0]
+                    )
+                    row = {
+                        "kind": "replay",
+                        "server": server,
+                        "prompt": ref.prompt,
+                        "episode_id": ref.episode_id,
+                        "frame_index": int(frame_index),
+                        "chunk_index": chunk_index,
+                        **chunk_jitter_metrics(
+                            response.actions, episode.state[frame_index], truth
+                        ),
+                        "boundary_jump_mae": "",
+                        "boundary_jump_max": "",
+                    }
+                    rows_for_server.append(row)
+                    key = f"replay_{len(raw_index):06d}_{server}"
+                    raw[key] = response.actions
+                    raw_index.append(
+                        {
+                            "key": key,
+                            "kind": "replay",
+                            "server": server,
+                            "episode_id": ref.episode_id,
+                            "frame_index": int(frame_index),
+                            "chunk_index": chunk_index,
+                            "prompt": ref.prompt,
+                        }
+                    )
+                boundary = replanning_boundary_metrics(chunks)
+                for row in rows_for_server[1:]:
+                    row.update(boundary)
+                jitter_rows.extend(rows_for_server)
+                replay_summary[server].append(boundary)
+
+        pair_summary, sample_rows, joint_rows, horizon_rows = _aggregate_pair_metrics(
+            paired, joint_std
+        )
+        contract = {
+            "openpi_horizons": sorted(
+                {item.openpi.actions.shape[0] for item in paired}
+            ),
+            "rlinf_horizons": sorted({item.rlinf.actions.shape[0] for item in paired}),
+            "openpi_action_dims": sorted(
+                {item.openpi.actions.shape[1] for item in paired}
+            ),
+            "rlinf_action_dims": sorted(
+                {item.rlinf.actions.shape[1] for item in paired}
+            ),
+            "contracts_match": all(
+                item.openpi.actions.shape == item.rlinf.actions.shape for item in paired
+            ),
+        }
+        summary = {
+            "diagnostic_scope": (
+                "currently deployed behavior; not strict numerical parity when "
+                "server contracts differ"
+            ),
+            "contract": contract,
+            "paired_comparison": pair_summary,
+            "action_1_to_10_jump": _action_1_to_10_summary(paired),
+            "randomness": _randomness_summary(paired),
+            "latency": _latency_summary(paired),
+            "replanning_boundaries": {
+                server: {
+                    key: float(np.mean([item[key] for item in items]))
+                    for key in ("boundary_jump_mae", "boundary_jump_max")
+                }
+                for server, items in replay_summary.items()
+            },
+        }
+        run_metadata = {
+            "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "argv": sys.argv,
+            "arguments": vars(args),
+            "dataset": {
+                "root": dataset_root,
+                "codebase_version": info.get("codebase_version"),
+                "total_tasks": info.get("total_tasks"),
+                "total_episodes": info.get("total_episodes"),
+                "selected_episodes": selected,
+            },
+            "request_contract": {
+                "images": {
+                    "keys": list(REQUEST_IMAGE_KEYS),
+                    "dtype": "uint8",
+                    "openpi_layout": args.openpi_image_layout,
+                    "rlinf_layout": args.rlinf_image_layout,
+                },
+                "state": "float32 [14]",
+                "prompt": "dataset task string",
+                "batched": False,
+            },
+            "servers": {
+                "openpi": {
+                    "uri": openpi.uri,
+                    "metadata": openpi.metadata,
+                },
+                "rlinf": {
+                    "uri": rlinf.uri,
+                    "metadata": rlinf.metadata,
+                },
+            },
+            "contract": contract,
+        }
+
+    raw["index_json"] = np.frombuffer(
+        json.dumps(_jsonable(raw_index)).encode("utf-8"), dtype=np.uint8
+    )
+    np.savez_compressed(output_dir / "raw_outputs.npz", **raw)
+    _write_json(output_dir / "run_metadata.json", run_metadata)
+    _write_json(output_dir / "summary.json", summary)
+    _write_csv(output_dir / "sample_metrics.csv", sample_rows)
+    _write_csv(output_dir / "per_joint_metrics.csv", joint_rows)
+    _write_csv(output_dir / "per_horizon_metrics.csv", horizon_rows)
+    _write_csv(output_dir / "jitter_metrics.csv", jitter_rows)
+    _plot_outputs(output_dir, pair_summary, paired, jitter_rows)
+    _write_report(output_dir, summary)
+    return output_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare two OpenPI-compatible policy servers using real ALOHA "
+            "observations from a LeRobot v3 dataset."
+        )
+    )
+    parser.add_argument(
+        "--dataset-root", default="data/lerobot-data_mixed_8_v30", type=Path
+    )
+    parser.add_argument("--openpi-host", default="127.0.0.1")
+    parser.add_argument("--openpi-port", default=8000, type=int)
+    parser.add_argument("--rlinf-host", default="127.0.0.1")
+    parser.add_argument("--rlinf-port", default=8001, type=int)
+    parser.add_argument("--openpi-image-layout", choices=("chw", "hwc"), default="chw")
+    parser.add_argument("--rlinf-image-layout", choices=("chw", "hwc"), default="hwc")
+    parser.add_argument("--episodes-per-prompt", default=1, type=int)
+    parser.add_argument("--paired-frames", default=3, type=int)
+    parser.add_argument("--repeats", default=3, type=int)
+    parser.add_argument("--replay-chunks", default=3, type=int)
+    parser.add_argument("--prompt-regex")
+    parser.add_argument("--episode-ids", nargs="+", type=int)
+    parser.add_argument("--seed", default=0, type=int)
+    parser.add_argument("--request-timeout", default=120.0, type=float)
+    parser.add_argument(
+        "--output-dir", default=Path("results/policy_server_compare"), type=Path
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if min(args.paired_frames, args.repeats, args.replay_chunks) < 1:
+        raise SystemExit(
+            "--paired-frames, --repeats, and --replay-chunks must be positive"
+        )
+    output_dir = run(args)
+    print(f"Wrote policy server diagnostic to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/toolkits/lerobot/convert_v21_to_v30_hardlinks.py
+++ b/toolkits/lerobot/convert_v21_to_v30_hardlinks.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert a local LeRobot v2.1 dataset to v3.0 with hard-linked data files.
+
+This converter is intended for large, image-in-Parquet datasets where the
+official v2.1-to-v3.0 converter's Pandas rewrite would require too much memory
+and disk space. It creates a separate v3.0 dataset, keeps the source unchanged,
+and hard-links each episode Parquet file into the v3.0 file layout. This is
+valid because the official converter does not change data columns; it only
+groups episode files and rewrites metadata.
+
+The source and output must be on the same filesystem. Video-backed datasets
+are deliberately rejected because their media layout also needs conversion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Iterator
+
+import jsonlines
+import pandas as pd
+import pyarrow.parquet as pq
+from datasets import Dataset
+from lerobot.datasets.compute_stats import aggregate_stats
+from lerobot.datasets.lerobot_dataset import LeRobotDatasetMetadata
+from lerobot.datasets.utils import (
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_DATA_FILE_SIZE_IN_MB,
+    DEFAULT_DATA_PATH,
+    DEFAULT_VIDEO_FILE_SIZE_IN_MB,
+    cast_stats_to_numpy,
+    flatten_dict,
+    update_chunk_file_indices,
+    write_episodes,
+    write_info,
+    write_stats,
+    write_tasks,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    with jsonlines.open(path, "r") as reader:
+        return list(reader)
+
+
+def _source_episode_path(
+    source_dir: Path, info: dict[str, Any], episode_index: int
+) -> Path:
+    data_path = info.get(
+        "data_path",
+        "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet",
+    )
+    chunks_size = int(info.get("chunks_size", DEFAULT_CHUNK_SIZE))
+    relative_path = data_path.format(
+        episode_chunk=episode_index // chunks_size,
+        episode_index=episode_index,
+    )
+    return source_dir / relative_path
+
+
+def _validate_source(source_dir: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    info_path = source_dir / "meta" / "info.json"
+    if not info_path.is_file():
+        raise FileNotFoundError(f"Missing LeRobot metadata: {info_path}")
+
+    with open(info_path) as file:
+        info = json.load(file)
+    if info.get("codebase_version") != "v2.1":
+        raise ValueError(
+            "Hard-link conversion requires a v2.1 source, got "
+            f"{info.get('codebase_version')!r}."
+        )
+
+    video_keys = [
+        key
+        for key, feature in info.get("features", {}).items()
+        if feature.get("dtype") == "video"
+    ]
+    if video_keys:
+        raise NotImplementedError(
+            "Hard-link conversion currently supports embedded images only; "
+            f"video features require media conversion: {video_keys}."
+        )
+
+    required_metadata = [
+        source_dir / "meta" / "episodes.jsonl",
+        source_dir / "meta" / "episodes_stats.jsonl",
+        source_dir / "meta" / "tasks.jsonl",
+    ]
+    missing = [str(path) for path in required_metadata if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(f"Missing required v2.1 metadata: {missing}")
+
+    episodes = sorted(
+        _read_jsonl(source_dir / "meta" / "episodes.jsonl"),
+        key=lambda episode: int(episode["episode_index"]),
+    )
+    expected_indices = list(range(len(episodes)))
+    actual_indices = [int(episode["episode_index"]) for episode in episodes]
+    if actual_indices != expected_indices:
+        raise ValueError(
+            "Episode indices must be contiguous and zero-based: "
+            f"expected 0..{len(episodes) - 1}."
+        )
+    if len(episodes) != int(info["total_episodes"]):
+        raise ValueError(
+            "episodes.jsonl count does not match info.json: "
+            f"{len(episodes)} != {info['total_episodes']}."
+        )
+    return info, episodes
+
+
+def _write_v30_info(info: dict[str, Any], output_dir: Path) -> None:
+    converted = dict(info)
+    converted["codebase_version"] = "v3.0"
+    converted.pop("total_chunks", None)
+    converted.pop("total_videos", None)
+    converted["data_files_size_in_mb"] = DEFAULT_DATA_FILE_SIZE_IN_MB
+    converted["video_files_size_in_mb"] = DEFAULT_VIDEO_FILE_SIZE_IN_MB
+    converted["data_path"] = DEFAULT_DATA_PATH
+    converted["video_path"] = None
+    converted["fps"] = int(converted["fps"])
+    for feature in converted["features"].values():
+        feature["fps"] = converted["fps"]
+    write_info(converted, output_dir)
+
+
+def _write_v30_tasks(source_dir: Path, output_dir: Path) -> None:
+    records = sorted(
+        _read_jsonl(source_dir / "meta" / "tasks.jsonl"),
+        key=lambda task: int(task["task_index"]),
+    )
+    tasks = pd.DataFrame(
+        {"task_index": [int(record["task_index"]) for record in records]},
+        index=[record["task"] for record in records],
+    )
+    write_tasks(tasks, output_dir)
+
+
+def _load_episode_stats(source_dir: Path) -> dict[int, dict[str, Any]]:
+    records = _read_jsonl(source_dir / "meta" / "episodes_stats.jsonl")
+    return {
+        int(record["episode_index"]): cast_stats_to_numpy(record["stats"])
+        for record in records
+    }
+
+
+def _episode_rows(
+    episodes: list[dict[str, Any]],
+    data_locations: list[dict[str, int]],
+    episode_stats: dict[int, dict[str, Any]],
+) -> Iterator[dict[str, Any]]:
+    for episode, location in zip(episodes, data_locations, strict=True):
+        episode_index = int(episode["episode_index"])
+        if episode_index not in episode_stats:
+            raise ValueError(f"Missing statistics for episode {episode_index}.")
+        row = {
+            **location,
+            **episode,
+            **flatten_dict({"stats": episode_stats[episode_index]}),
+            "meta/episodes/chunk_index": 0,
+            "meta/episodes/file_index": 0,
+        }
+        yield row
+
+
+def _link_data_files(
+    source_dir: Path,
+    output_dir: Path,
+    info: dict[str, Any],
+    episodes: list[dict[str, Any]],
+) -> list[dict[str, int]]:
+    chunk_index = 0
+    file_index = 0
+    global_frame_index = 0
+    locations: list[dict[str, int]] = []
+
+    for position, episode in enumerate(episodes):
+        episode_index = int(episode["episode_index"])
+        source_path = _source_episode_path(source_dir, info, episode_index)
+        if not source_path.is_file():
+            raise FileNotFoundError(f"Missing episode Parquet: {source_path}")
+
+        num_frames = pq.read_metadata(source_path).num_rows
+        expected_frames = int(episode["length"])
+        if num_frames != expected_frames:
+            raise ValueError(
+                f"Episode {episode_index} frame count mismatch: "
+                f"Parquet={num_frames}, metadata={expected_frames}."
+            )
+
+        relative_output = DEFAULT_DATA_PATH.format(
+            chunk_index=chunk_index,
+            file_index=file_index,
+        )
+        output_path = output_dir / relative_output
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        os.link(source_path, output_path)
+
+        locations.append(
+            {
+                "episode_index": episode_index,
+                "data/chunk_index": chunk_index,
+                "data/file_index": file_index,
+                "dataset_from_index": global_frame_index,
+                "dataset_to_index": global_frame_index + num_frames,
+            }
+        )
+        global_frame_index += num_frames
+        chunk_index, file_index = update_chunk_file_indices(
+            chunk_index, file_index, DEFAULT_CHUNK_SIZE
+        )
+        if (position + 1) % 50 == 0 or position + 1 == len(episodes):
+            logger.info("Linked %d/%d episodes", position + 1, len(episodes))
+
+    if global_frame_index != int(info["total_frames"]):
+        raise ValueError(
+            "Linked frame count does not match info.json: "
+            f"{global_frame_index} != {info['total_frames']}."
+        )
+    return locations
+
+
+def _validate_output(
+    source_dir: Path,
+    output_dir: Path,
+    episodes: list[dict[str, Any]],
+) -> None:
+    metadata = LeRobotDatasetMetadata(output_dir.name, root=output_dir)
+    if metadata.total_episodes != len(episodes):
+        raise ValueError(
+            f"Converted metadata has {metadata.total_episodes} episodes; "
+            f"expected {len(episodes)}."
+        )
+
+    sample_indices = sorted({0, len(episodes) // 2, len(episodes) - 1})
+    for episode_index in sample_indices:
+        source_info, _ = _validate_source(source_dir)
+        source_path = _source_episode_path(source_dir, source_info, episode_index)
+        output_path = output_dir / metadata.get_data_file_path(episode_index)
+        if source_path.stat().st_ino != output_path.stat().st_ino:
+            raise ValueError(
+                f"Episode {episode_index} is not hard-linked to its source file."
+            )
+
+
+def convert_v21_to_v30_hardlinks(source_dir: Path, output_dir: Path) -> None:
+    """Create a separate LeRobot v3.0 dataset backed by v2.1 hard links.
+
+    Args:
+        source_dir: Existing local LeRobot v2.1 dataset.
+        output_dir: New path for the LeRobot v3.0 view. It must not exist.
+    """
+    source_dir = source_dir.expanduser().resolve()
+    output_dir = output_dir.expanduser().resolve()
+    if output_dir.exists():
+        raise FileExistsError(f"Refusing to overwrite existing output: {output_dir}")
+    if output_dir == source_dir or source_dir in output_dir.parents:
+        raise ValueError("Output must be separate from and outside the source dataset.")
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    if source_dir.stat().st_dev != output_dir.parent.stat().st_dev:
+        raise OSError(
+            "Source and output must be on the same filesystem for hard links."
+        )
+
+    info, episodes = _validate_source(source_dir)
+    temporary_dir = output_dir.parent / f".{output_dir.name}.tmp-{os.getpid()}"
+    if temporary_dir.exists():
+        raise FileExistsError(f"Temporary output already exists: {temporary_dir}")
+
+    logger.info("Converting %s", source_dir)
+    logger.info("Writing v3.0 hard-link view to %s", output_dir)
+    temporary_dir.mkdir()
+    try:
+        _write_v30_info(info, temporary_dir)
+        _write_v30_tasks(source_dir, temporary_dir)
+        data_locations = _link_data_files(source_dir, temporary_dir, info, episodes)
+        episode_stats = _load_episode_stats(source_dir)
+        episode_dataset = Dataset.from_generator(
+            lambda: _episode_rows(episodes, data_locations, episode_stats)
+        )
+        write_episodes(episode_dataset, temporary_dir)
+        write_stats(aggregate_stats(list(episode_stats.values())), temporary_dir)
+        temporary_dir.rename(output_dir)
+        _validate_output(source_dir, output_dir, episodes)
+    except Exception:
+        if temporary_dir.exists():
+            shutil.rmtree(temporary_dir)
+        raise
+
+    logger.info("Conversion complete: %s", output_dir)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = _build_parser().parse_args()
+    convert_v21_to_v30_hardlinks(args.source_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description

Add OpenPI policy-server validation and LeRobot data-preparation tooling for ALOHA SFT workflows.

- Compare two OpenPI-compatible policy servers on sampled LeRobot episodes and emit JSON, CSV, plots, and a Markdown report.
- Calculate normalization statistics through a projected, image-free data path and convert LeRobot v2.1 datasets into v3.0 hard-link views.
- Propagate the configured action-chunk horizon into the official OpenPI SFT data loader.
- Add full-parameter Pi0.5 ALOHA SFT configurations and a two-H100 launcher with checkpoint resume support.
- Document the policy-server comparison and SFT workflows in English and Chinese.

### Motivation and Context

OpenPI development needs reproducible tools for preparing local LeRobot datasets, checking normalization statistics, and comparing policy-server behavior before expensive ALOHA SFT runs. These additions make those workflows available in the repository and align the official loader with the configured training horizon.

### How has this been tested?

- `PYTHONPATH=<repo> HF_HOME=/tmp/rlinf-pr-hf-cache python -m pytest -q tests/unit_tests/test_calculate_norm_stats_fast.py tests/unit_tests/test_compare_policy_servers.py tests/unit_tests/test_lerobot_v21_to_v30_hardlinks.py tests/unit_tests/test_official_openpi_sft_data_loader.py` (22 passed, 16 deprecation warnings)
- `python -m ruff check <8 changed Python files>` (passed)
- `python -m ruff format --check <8 changed Python files>` (passed)
- `git diff --check upstream/main...HEAD` (passed)

### Additional information (optional, e.g., figures and logs):

The full two-H100 SFT training recipe was not run as part of this validation.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
