### PR TITLE
fix(libero): pin mujoco to the era-faithful 3.3.0 for embodied LIBERO

### DIFF
--- a/requirements/install.sh
+++ b/requirements/install.sh
@@ -2373,6 +2373,9 @@ retry_cmd() {
 
 install_libero_env() {
     uv pip install rlinf-libero
+    # rlinf-libero caps mujoco only from above (<3.9.0); >=3.4.0 desyncs
+    # LIBERO's saved init states, so pin the era-faithful version explicitly.
+    uv pip install --no-deps mujoco==3.3.0
     materialize_package_files rlinf-libero
     retry_cmd libero-download-assets --skip-existing
     reset_libero_config
@@ -2450,6 +2453,7 @@ install_d4rl_env() {
 
 install_liberopro_env() {
     uv pip install rlinf-libero rlinf-liberopro
+    uv pip install --no-deps mujoco==3.3.0
     materialize_package_files rlinf-libero
     materialize_package_files rlinf-liberopro
     retry_cmd libero-download-assets --skip-existing
@@ -2459,6 +2463,7 @@ install_liberopro_env() {
 
 install_liberoplus_env() {
     uv pip install rlinf-libero "rlinf-liberoplus>=0.1.3"
+    uv pip install --no-deps mujoco==3.3.0
     materialize_package_files rlinf-libero
     materialize_package_files rlinf-liberoplus
     retry_cmd libero-download-assets --skip-existing


### PR DESCRIPTION
### Description

Pin `mujoco==3.3.0` (`--no-deps`, mirroring `install_robocasa365_env`/`install_roboverse_env`) right after each `rlinf-libero` install in `install_libero_env`, `install_liberopro_env`, and `install_liberoplus_env`. `install_maniskill_libero_env` calls `install_libero_env` and inherits the fix.

### Motivation and Context

`rlinf-libero`'s package metadata caps mujoco only from above (`mujoco<3.9.0,>=3.0.0`), so a fresh `uv pip install rlinf-libero` resolves to 3.8.1 today. mujoco 3.4.0 changed box-box collision handling, which desyncs `libero_spatial` task 5's saved init state: the bowl no longer settles onto the ramekin during `reset()`, and task-5 success collapses from 98% at the 3.3.x models were trained under to 12% at 3.8.1 (see #1460's evidence table). This makes the published GRPO LIBERO-spatial numbers unreproducible on a fresh install, through no fault of the checkpoint.

A prior v0.x install path had this exact pin (`mujoco<=3.9.0`, added in #1302), until #1410 dropped it while migrating `install_libero_env` off the git-clone-based LIBERO install onto the `rlinf-libero` PyPI package, with no replacement.

Fixes #1460

### How has this been tested?

- Confirmed on current HEAD, via `uv pip install rlinf-libero` in a clean container, that mujoco resolves to 3.8.1 unpinned; with `uv pip install --no-deps mujoco==3.3.0` added, it resolves to 3.3.0 as intended.
- Read #1410's diff directly to confirm the prior pin was dropped as refactor fallout, not a deliberate revert.
- Ran `.cursor/skills/install-check/check.sh`: same 33 pre-existing candidates before and after, no new hits from this change.
- Not independently re-run: the physics regression itself (no LIBERO/mujoco simulation available in this environment). That part relies on #1460's own settle-probe evidence (raw JSON output at two mujoco versions, same 50 init states) and the maintainer's related advice in #1375 to downgrade to mujoco 3.3.2 for a separate visual regression.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
