### PR TITLE
docs(readme): acknowledge vLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ If you use FUSCO for MoE communication in RLinf, you can cite our paper:
 
 **Acknowledgements**
 RLinf has been inspired by, and benefits from, the ideas and tooling of the broader open-source community.
-In particular, we would like to thank the teams and contributors behind VeRL, AReaL, Megatron-LM, SGLang, and PyTorch Fully Sharded Data Parallel (FSDP), and if we have inadvertently missed your project or contribution, please open an issue or a pull request so we can properly credit you.
+In particular, we would like to thank the teams and contributors behind veRL, vLLM, AReaL, Megatron-LM, SGLang, and PyTorch Fully Sharded Data Parallel (FSDP), and if we have inadvertently missed your project or contribution, please open an issue or a pull request so we can properly credit you.
 
 **Contact:**
 We welcome applications from Postdocs, PhD/Master's students, and interns. Join us in shaping the future of RL infrastructure and embodied AI!

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -501,7 +501,7 @@ RLinf 具有全面的 CI 测试，涵盖核心组件（通过单元测试）和�
 
 **致谢**
 RLinf 的灵感来源并受益于更广泛开源社区的思想与工具。
-我们特别感谢 VeRL、AReaL、Megatron-LM、SGLang 和 PyTorch Fully Sharded Data Parallel (FSDP) 的团队与贡献者。
+我们特别感谢 veRL、vLLM、AReaL、Megatron-LM、SGLang 和 PyTorch Fully Sharded Data Parallel (FSDP) 的团队与贡献者。
 如果我们不慎遗漏了您的项目或贡献，请提交 issue 或 pull request，以便我们能够给予您应有的致谢。
 
 **联系方式：**


### PR DESCRIPTION
### Description

Adds vLLM to the list of projects credited in the Acknowledgements section of both READMEs.

- `README.md`: Acknowledgements now thanks the teams behind veRL, vLLM, AReaL, Megatron-LM, SGLang, and PyTorch FSDP.
- `README.zh-CN.md`: the same addition in the 致谢 section, keeping EN/ZH parity.

### Motivation and Context

RLinf supports vLLM as a rollout backend alongside SGLang (both READMEs already list "FSDP + HuggingFace/SGLang/vLLM" and "Megatron + SGLang/vLLM" as supported combinations), but the Acknowledgements only credited SGLang. This gives vLLM the same credit.

### How has this been tested?

Documentation-only change; no code paths touched. Verified the rendered wording and EN/ZH parity by diffing both files.

### Additional information (optional, e.g., figures and logs):

### Types of changes

- [x] Documentation update (Document-only update)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
