### PR TITLE
chore(envs): drop unused render locals in Wan world-model env

### DIFF
--- a/rlinf/envs/world_model/world_model_wan_env.py
+++ b/rlinf/envs/world_model/world_model_wan_env.py
@@ -725,16 +725,6 @@ class WanEnv(BaseWorldEnv):
         chunk_truncations = torch.zeros_like(raw_chunk_truncations)
         chunk_truncations[:, -1] = past_truncations
 
-        # Get actions and rewards for rendering
-        chunk_actions_for_render = policy_output_action
-        if isinstance(chunk_actions_for_render, torch.Tensor):
-            chunk_actions_for_render = chunk_actions_for_render.detach().cpu().numpy()
-        chunk_rewards_for_render = chunk_rewards_tensors.detach().cpu().numpy()
-
-        # Reshape for rendering: [num_envs, chunk, action_dim] -> [chunk, num_envs, action_dim]
-        chunk_actions_for_render = chunk_actions_for_render.transpose(1, 0, 2)
-        chunk_rewards_for_render = chunk_rewards_for_render.T  # [chunk, num_envs]
-
         return (
             [extracted_obs],
             chunk_rewards_tensors,


### PR DESCRIPTION
### Description

`WanEnv.chunk_step` builds `chunk_actions_for_render` and `chunk_rewards_for_render`, then never uses them — they are absent from the return tuple and `git grep for_render` finds nothing else in the tree. Delete the block. It reads as if the return contract carried per-chunk render data, which it does not.

### How has this been tested?

Not run; the change deletes ten lines of unreferenced locals whose only operations (`detach`, `cpu`, `numpy`, `transpose`) are pure. Return tuple untouched, `policy_output_action` and `chunk_rewards_tensors` are still read earlier in the same function.

### Types of changes

- [x] Code cleanup / refactor (no functional change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
