### PR TITLE
refactor(envs): keep the Wan condition window in the backend

### DIFF
--- a/rlinf/envs/world_model/backend.py
+++ b/rlinf/envs/world_model/backend.py
@@ -1,0 +1,70 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The interface between a world-model environment and the thing that generates frames.
+
+The env owns episode semantics — session lifetime, rewards, auto reset, metrics — and a backend only
+advances frames. It is session-shaped so a backend that pools per-trajectory state knows when a
+trajectory begins and ends. Implementations live next to this module, one file each.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, Sequence, runtime_checkable
+
+import torch
+
+__all__ = ["WorldModelBackend", "FrameQueue"]
+
+FrameQueue = Sequence[Sequence[torch.Tensor]]
+
+
+@runtime_checkable
+class WorldModelBackend(Protocol):
+    """Advances frames for a world-model environment."""
+
+    def open_session(
+        self,
+        env_ids: Sequence[int],
+        init_frames: FrameQueue,
+        task_ids: Sequence[Any],
+        seeds: Sequence[int],
+    ) -> None:
+        """Start a trajectory per env slot."""
+
+    def generate(
+        self,
+        env_ids: Sequence[int],
+        actions: torch.Tensor,
+        condition: FrameQueue,
+    ) -> torch.Tensor:
+        """Advance one action chunk.
+
+        Args:
+            env_ids: Env slots the batch rows belong to, in row order.
+            actions: ``[B, T, action_dim]``.
+            condition: Per env slot, the condition frames as ``[C, 1, H, W]`` tensors.
+
+        Returns:
+            Generated frames as ``[B, C, T, H, W]`` in ``[-1, 1]``.
+        """
+
+    def close_session(self, env_ids: Sequence[int]) -> None:
+        """End the trajectories of these env slots; slots without a session are ignored."""
+
+    def offload(self) -> None:
+        """Move weights off the execution device."""
+
+    def onload(self) -> None:
+        """Move weights back to the execution device."""

--- a/rlinf/envs/world_model/backend.py
+++ b/rlinf/envs/world_model/backend.py
@@ -16,7 +16,9 @@
 
 The env owns episode semantics — session lifetime, rewards, auto reset, metrics — and a backend only
 advances frames. It is session-shaped so a backend that pools per-trajectory state knows when a
-trajectory begins and ends. Implementations live next to this module, one file each.
+trajectory begins and ends: the condition window lives behind the session, so the env hands it over once
+at ``open_session`` and afterwards sends nothing but the new action chunk. Implementations live next to
+this module, one file each.
 """
 
 from __future__ import annotations
@@ -38,26 +40,35 @@ class WorldModelBackend(Protocol):
         self,
         env_ids: Sequence[int],
         init_frames: FrameQueue,
+        init_actions: torch.Tensor,
         task_ids: Sequence[Any],
         seeds: Sequence[int],
     ) -> None:
-        """Start a trajectory per env slot."""
+        """Start a trajectory per env slot from its initial condition window.
+
+        Args:
+            env_ids: Env slots to open.
+            init_frames: Per env slot, the initial condition frames as ``[C, 1, H, W]`` tensors in
+                ``[-1, 1]``. The first frame is the reference frame the backend must keep for the
+                whole trajectory.
+            init_actions: ``[B, window, action_dim]``, the actions that led to ``init_frames``.
+            task_ids: Per env slot, the task the trajectory runs.
+            seeds: Per env slot, the seed its noise is drawn from.
+        """
 
     def generate(
         self,
         env_ids: Sequence[int],
         actions: torch.Tensor,
-        condition: FrameQueue,
     ) -> torch.Tensor:
-        """Advance one action chunk.
+        """Advance one action chunk from the session's own condition window.
 
         Args:
             env_ids: Env slots the batch rows belong to, in row order.
-            actions: ``[B, T, action_dim]``.
-            condition: Per env slot, the condition frames as ``[C, 1, H, W]`` tensors.
+            actions: ``[B, chunk, action_dim]``.
 
         Returns:
-            Generated frames as ``[B, C, T, H, W]`` in ``[-1, 1]``.
+            Generated frames as ``[B, C, T, H, W]`` in ``[-1, 1]``, the whole window plus the chunk.
         """
 
     def close_session(self, env_ids: Sequence[int]) -> None:

--- a/rlinf/envs/world_model/wan_backend.py
+++ b/rlinf/envs/world_model/wan_backend.py
@@ -1,0 +1,154 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+import torch
+from diffsynth.pipelines.wan_video_new import ModelConfig, WanVideoPipeline
+from PIL import Image
+
+from rlinf.envs.world_model.backend import FrameQueue
+
+__all__ = ["WanBackend"]
+
+
+class WanBackend:
+    """In-process backend holding diffsynth's action-conditioned ``WanVideoPipeline``."""
+
+    def __init__(self, cfg, device: torch.device, device_str: str):
+        self.cfg = cfg
+        self.device = device
+        self.num_inference_steps = cfg.num_inference_steps
+        self.num_frames = cfg.num_frames
+        self._sessions: dict[int, dict[str, Any]] = {}
+        self._pipe = self._build_pipeline(device_str)
+
+    def _build_pipeline(self, device_str: str) -> WanVideoPipeline:
+        pipe = WanVideoPipeline.from_pretrained(
+            torch_dtype=torch.bfloat16,
+            device=device_str,
+            model_configs=[
+                ModelConfig(path=self.cfg.model_path, offload_device="cpu"),
+                ModelConfig(path=self.cfg.VAE_path, offload_device="cpu"),
+            ],
+        )
+        pipe.dit.to(self.device)
+        pipe.vae.to(self.device)
+        return pipe
+
+    def open_session(
+        self,
+        env_ids: Sequence[int],
+        init_frames: FrameQueue,
+        task_ids: Sequence[Any],
+        seeds: Sequence[int],
+    ) -> None:
+        # init_frames are not retained: the pipeline re-conditions from the window the env sends with
+        # every generate. A pooled backend would encode them here.
+        for env_id, task_id, seed in zip(env_ids, task_ids, seeds):
+            self._sessions[int(env_id)] = {"task_id": task_id, "seed": int(seed)}
+
+    def close_session(self, env_ids: Sequence[int]) -> None:
+        for env_id in env_ids:
+            self._sessions.pop(int(env_id), None)
+
+    def _batch_seed(self, env_ids: Sequence[int]) -> int:
+        missing = [int(i) for i in env_ids if int(i) not in self._sessions]
+        if missing:
+            raise RuntimeError(
+                f"generate called for env slots without a session: {missing}"
+            )
+        seeds = {self._sessions[int(i)]["seed"] for i in env_ids}
+        if len(seeds) > 1:
+            raise NotImplementedError(
+                f"WanVideoPipeline draws one noise tensor per batch, so the batch needs a single "
+                f"seed; got {sorted(seeds)}"
+            )
+        return seeds.pop()
+
+    def _pipe_kwargs(
+        self,
+        env_ids: Sequence[int],
+        actions: torch.Tensor,
+        condition: FrameQueue,
+    ) -> dict[str, Any]:
+        batch_input_image = []
+        batch_input_image4 = []
+        for frames in condition:
+            imgs = []
+            for frame in frames:
+                frame = frame[:, 0].cpu().numpy()  # [3, H, W]
+                img = np.transpose(frame, (1, 2, 0))
+                if img.max() <= 1.2:
+                    img = ((img + 1.0) / 2.0 * 255.0).clip(0, 255)
+                imgs.append(Image.fromarray(img.astype(np.uint8)))
+            batch_input_image.append(imgs[0])
+            batch_input_image4.append(imgs[-4:])
+
+        return {
+            "seed": self._batch_seed(env_ids),
+            "tiled": False,
+            "input_image": batch_input_image,
+            "input_image4": batch_input_image4,
+            "action": actions,
+            "height": 256,
+            "width": 256,
+            "num_frames": self.num_frames,
+            "num_inference_steps": self.num_inference_steps,
+            "cfg_scale": 1.0,
+            "progress_bar_cmd": lambda x: x,
+            "batch_size": len(batch_input_image),
+        }
+
+    def generate(
+        self,
+        env_ids: Sequence[int],
+        actions: torch.Tensor,
+        condition: FrameQueue,
+    ) -> torch.Tensor:
+        batch_size = len(env_ids)
+        if len(condition) != batch_size or actions.shape[0] != batch_size:
+            raise ValueError(
+                f"env_ids, condition and actions must describe the same batch rows; got "
+                f"{batch_size}, {len(condition)}, {actions.shape[0]}"
+            )
+        output = self._pipe(**self._pipe_kwargs(env_ids, actions, condition))
+
+        videos = []
+        for env_idx in range(batch_size):
+            frames = []
+            for img in output[env_idx]:
+                # Keep frame tensors in fp32 to avoid silent fp64 promotion
+                # that can significantly increase GPU memory usage.
+                arr = np.asarray(img, dtype=np.float32) / 255.0
+                arr = arr * 2.0 - 1.0
+                frames.append(arr)
+
+            video = np.stack(frames, axis=0)  # [T, H, W, 3]
+            video = video.transpose(0, 3, 1, 2)  # [T, 3, H, W]
+            video = torch.from_numpy(video)
+            videos.append(video.transpose(0, 1))  # [3, T, H, W]
+
+        return torch.stack(videos, dim=0)
+
+    def offload(self) -> None:
+        self._pipe.vae = self._pipe.vae.to("cpu")
+        self._pipe.dit = self._pipe.dit.to("cpu")
+
+    def onload(self) -> None:
+        self._pipe.dit = self._pipe.dit.to(self.device)
+        self._pipe.vae = self._pipe.vae.to(self.device)

--- a/rlinf/envs/world_model/wan_backend.py
+++ b/rlinf/envs/world_model/wan_backend.py
@@ -27,13 +27,19 @@ __all__ = ["WanBackend"]
 
 
 class WanBackend:
-    """In-process backend holding diffsynth's action-conditioned ``WanVideoPipeline``."""
+    """In-process backend holding diffsynth's action-conditioned ``WanVideoPipeline``.
+
+    Each session owns its condition window: the reference frame the trajectory started from, the last
+    generated frames, and the actions that produced them. The env only sends new action chunks.
+    """
 
     def __init__(self, cfg, device: torch.device, device_str: str):
         self.cfg = cfg
         self.device = device
         self.num_inference_steps = cfg.num_inference_steps
         self.num_frames = cfg.num_frames
+        self.condition_frame_length = cfg.condition_frame_length
+        self.retain_action = cfg.get("retain_action", True)
         self._sessions: dict[int, dict[str, Any]] = {}
         self._pipe = self._build_pipeline(device_str)
 
@@ -50,17 +56,29 @@ class WanBackend:
         pipe.vae.to(self.device)
         return pipe
 
+    @staticmethod
+    def _to_pil(frame: torch.Tensor) -> Image.Image:
+        """``[C, 1, H, W]`` in ``[-1, 1]`` (or ``[0, 1]``) to the uint8 image the pipeline takes."""
+        img = np.transpose(frame[:, 0].cpu().numpy(), (1, 2, 0))
+        if img.max() <= 1.2:
+            img = ((img + 1.0) / 2.0 * 255.0).clip(0, 255)
+        return Image.fromarray(img.astype(np.uint8))
+
     def open_session(
         self,
         env_ids: Sequence[int],
         init_frames: FrameQueue,
+        init_actions: torch.Tensor,
         task_ids: Sequence[Any],
         seeds: Sequence[int],
     ) -> None:
-        # init_frames are not retained: the pipeline re-conditions from the window the env sends with
-        # every generate. A pooled backend would encode them here.
-        for env_id, task_id, seed in zip(env_ids, task_ids, seeds):
-            self._sessions[int(env_id)] = {"task_id": task_id, "seed": int(seed)}
+        for row, (env_id, task_id, seed) in enumerate(zip(env_ids, task_ids, seeds)):
+            self._sessions[int(env_id)] = {
+                "task_id": task_id,
+                "seed": int(seed),
+                "frames": [self._to_pil(f) for f in init_frames[row]],
+                "actions": init_actions[row].clone(),
+            }
 
     def close_session(self, env_ids: Sequence[int]) -> None:
         for env_id in env_ids:
@@ -80,56 +98,65 @@ class WanBackend:
             )
         return seeds.pop()
 
+    def _window_actions(
+        self, env_ids: Sequence[int], actions: torch.Tensor
+    ) -> torch.Tensor:
+        """Prepend each session's action history to its chunk, then roll the history forward."""
+        history = torch.stack(
+            [self._sessions[int(i)]["actions"] for i in env_ids], dim=0
+        ).to(device=actions.device, dtype=actions.dtype)
+
+        if self.retain_action:
+            actions = torch.cat([history, actions], dim=1)
+
+        tail = actions[:, -(self.condition_frame_length - 1) :, :]
+        for row, env_id in enumerate(env_ids):
+            session_actions = self._sessions[int(env_id)]["actions"]
+            session_actions[1 : self.condition_frame_length] = tail[row].to(
+                device=session_actions.device, dtype=session_actions.dtype
+            )
+        return actions
+
     def _pipe_kwargs(
-        self,
-        env_ids: Sequence[int],
-        actions: torch.Tensor,
-        condition: FrameQueue,
+        self, env_ids: Sequence[int], actions: torch.Tensor
     ) -> dict[str, Any]:
-        batch_input_image = []
-        batch_input_image4 = []
-        for frames in condition:
-            imgs = []
-            for frame in frames:
-                frame = frame[:, 0].cpu().numpy()  # [3, H, W]
-                img = np.transpose(frame, (1, 2, 0))
-                if img.max() <= 1.2:
-                    img = ((img + 1.0) / 2.0 * 255.0).clip(0, 255)
-                imgs.append(Image.fromarray(img.astype(np.uint8)))
-            batch_input_image.append(imgs[0])
-            batch_input_image4.append(imgs[-4:])
+        windows = [self._sessions[int(i)]["frames"] for i in env_ids]
 
         return {
             "seed": self._batch_seed(env_ids),
             "tiled": False,
-            "input_image": batch_input_image,
-            "input_image4": batch_input_image4,
-            "action": actions,
+            "input_image": [frames[0] for frames in windows],
+            "input_image4": [frames[-4:] for frames in windows],
+            "action": self._window_actions(env_ids, actions),
             "height": 256,
             "width": 256,
             "num_frames": self.num_frames,
             "num_inference_steps": self.num_inference_steps,
             "cfg_scale": 1.0,
             "progress_bar_cmd": lambda x: x,
-            "batch_size": len(batch_input_image),
+            "batch_size": len(windows),
         }
 
     def generate(
         self,
         env_ids: Sequence[int],
         actions: torch.Tensor,
-        condition: FrameQueue,
     ) -> torch.Tensor:
         batch_size = len(env_ids)
-        if len(condition) != batch_size or actions.shape[0] != batch_size:
+        if actions.shape[0] != batch_size:
             raise ValueError(
-                f"env_ids, condition and actions must describe the same batch rows; got "
-                f"{batch_size}, {len(condition)}, {actions.shape[0]}"
+                f"env_ids and actions must describe the same batch rows; got "
+                f"{batch_size}, {actions.shape[0]}"
             )
-        output = self._pipe(**self._pipe_kwargs(env_ids, actions, condition))
+        output = self._pipe(**self._pipe_kwargs(env_ids, actions))
 
         videos = []
-        for env_idx in range(batch_size):
+        for env_idx, env_id in enumerate(env_ids):
+            # The pipeline's own frames are what the next chunk conditions on, so they go into the
+            # window as they are: converting them to [-1, 1] and back would cost a gray level.
+            window = self._sessions[int(env_id)]["frames"]
+            window[1:] = output[env_idx][-(self.condition_frame_length - 1) :]
+
             frames = []
             for img in output[env_idx]:
                 # Keep frame tensors in fp32 to avoid silent fp64 promotion

--- a/rlinf/envs/world_model/world_model_wan_env.py
+++ b/rlinf/envs/world_model/world_model_wan_env.py
@@ -23,12 +23,12 @@ import torch
 import torch.nn.functional as F
 import torchvision.transforms as transforms
 from diffsynth.models.reward_model import ResnetRewModel, TaskEmbedResnetRewModel
-from diffsynth.pipelines.wan_video_new import ModelConfig, WanVideoPipeline
-from PIL import Image
 
 from rlinf.data.datasets.world_model import NpyTrajectoryDatasetWrapper
 from rlinf.envs.utils import recursive_to_device
+from rlinf.envs.world_model.backend import WorldModelBackend
 from rlinf.envs.world_model.base_world_env import BaseWorldEnv
+from rlinf.envs.world_model.wan_backend import WanBackend
 
 __all__ = ["WanEnv"]
 
@@ -73,8 +73,10 @@ class WanEnv(BaseWorldEnv):
         self.retain_action = cfg.get("retain_action", True)  # Default True
         self.enable_kir = cfg.get("enable_kir", True)
 
-        # load pipeline
-        self.pipe = self._build_pipeline()
+        # Inference backend; the env keeps episode semantics and the condition window.
+        self.backend: WorldModelBackend = WanBackend(
+            cfg, self.device, self._get_runtime_device_str()
+        )
 
         # Load reward model if specified
         self.reward_model = self._load_reward_model().eval().to(self.device)
@@ -120,21 +122,6 @@ class WanEnv(BaseWorldEnv):
         return NpyTrajectoryDatasetWrapper(
             cfg.initial_image_path, enable_kir=self.enable_kir
         )
-
-    def _build_pipeline(self):
-        pipe = WanVideoPipeline.from_pretrained(
-            torch_dtype=torch.bfloat16,
-            device=self._get_runtime_device_str(),
-            model_configs=[
-                # Paths are loaded from yaml
-                ModelConfig(path=self.cfg.model_path, offload_device="cpu"),
-                ModelConfig(path=self.cfg.VAE_path, offload_device="cpu"),
-            ],
-        )
-        # pipe.enable_vram_management()
-        pipe.dit.to(self.device)
-        pipe.vae.to(self.device)
-        return pipe
 
     def _load_reward_model(self):
         if self.cfg.reward_model.type == "ResnetRewModel":
@@ -400,6 +387,16 @@ class WanEnv(BaseWorldEnv):
             ]
             self.image_queue[env_idx] = frames
 
+        # Every reset restarts all env slots, so all sessions are replaced. Noise is drawn from a
+        # single seed shared by the batch; per-trajectory seeds are future work.
+        self.backend.close_session(range(num_envs))
+        self.backend.open_session(
+            env_ids=range(num_envs),
+            init_frames=self.image_queue,
+            task_ids=list(episode_indices),
+            seeds=[0] * num_envs,
+        )
+
         self._reset_metrics()
 
         # Initialize action buffer (if needed)
@@ -515,66 +512,21 @@ class WanEnv(BaseWorldEnv):
         self.condition_action[:, 1 : self.condition_frame_length, :] = actions_tensor[
             :, -(self.condition_frame_length - 1) :, :
         ]
-        # print(f'actions_tensor:{actions_tensor.shape}')
-        # Process each environment separately
-        all_samples = []
-
-        B = num_envs
-
-        batch_input_image = []
-        batch_input_image4 = []
+        # videos: [num_envs, C, T, H, W] in [-1, 1]
+        videos = self.backend.generate(
+            env_ids=range(num_envs),
+            actions=actions_tensor,
+            condition=self.image_queue,
+        )
 
         for env_idx in range(num_envs):
-            # image_queue: [8, 3, 1, H, W]
-            imgs = []
-            for frame in self.image_queue[env_idx]:
-                frame = frame[:, 0].cpu().numpy()  # [3, H, W]
-                img = np.transpose(frame, (1, 2, 0))
-                if img.max() <= 1.2:
-                    img = ((img + 1.0) / 2.0 * 255.0).clip(0, 255)
-                imgs.append(Image.fromarray(img.astype(np.uint8)))
-
-            batch_input_image.append(imgs[0])  # First frame
-            batch_input_image4.append(imgs[-4:])  # Last 4 frames
-
-        kwargs = {
-            "seed": 0,
-            "tiled": False,
-            "input_image": batch_input_image,  # List[PIL], len = B
-            "input_image4": batch_input_image4,  # List[List[PIL]], B×4
-            "action": actions_tensor,  # [B, T, A], T=13 or 8
-            "height": 256,
-            "width": 256,
-            "num_frames": self.num_frames,
-            "num_inference_steps": self.num_inference_steps,
-            "cfg_scale": 1.0,
-            "progress_bar_cmd": lambda x: x,
-            "batch_size": B,
-        }
-
-        output = self.pipe(**kwargs)
-        for env_idx in range(num_envs):
-            frames = []
-            for img in output[env_idx]:
-                # Keep frame tensors in fp32 to avoid silent fp64 promotion
-                # that can significantly increase GPU memory usage.
-                arr = np.asarray(img, dtype=np.float32) / 255.0
-                arr = arr * 2.0 - 1.0
-                frames.append(arr)
-
-            video = np.stack(frames, axis=0)  # [T, H, W, 3]
-            video = video.transpose(0, 3, 1, 2)  # [T, 3, H, W]
-            video = torch.from_numpy(video)
-            video = video.transpose(0, 1)  # [3, T, H, W]
-
+            video = videos[env_idx]
             # Update image_queue
             for t in range(video.shape[1] - 4, video.shape[1]):
                 self.image_queue[env_idx][t - 8] = video[:, t : t + 1]
 
-            all_samples.append(video[:, 5:])
-
         # Stack all environments: [num_envs, C, T, H, W]
-        x_samples = torch.stack(all_samples, dim=0).to(
+        x_samples = videos[:, :, self.condition_frame_length :].to(
             self.device, dtype=self.current_obs.dtype
         )
 
@@ -747,8 +699,7 @@ class WanEnv(BaseWorldEnv):
         """Move heavy models and runtime tensors to CPU."""
         if self._is_offloaded:
             return
-        self.pipe.vae = self.pipe.vae.to("cpu")
-        self.pipe.dit = self.pipe.dit.to("cpu")
+        self.backend.offload()
         self.reward_model = self.reward_model.to("cpu")
         self.current_obs = recursive_to_device(self.current_obs, "cpu")
         self.prev_step_reward = self.prev_step_reward.cpu()
@@ -763,8 +714,7 @@ class WanEnv(BaseWorldEnv):
         """Move models and runtime tensors back to execution device."""
         if not self._is_offloaded:
             return
-        self.pipe.dit = self.pipe.dit.to(self.device)
-        self.pipe.vae = self.pipe.vae.to(self.device)
+        self.backend.onload()
         self.reward_model = self.reward_model.to(self.device)
         self.current_obs = recursive_to_device(self.current_obs, self.device)
         self.prev_step_reward = self.prev_step_reward.to(self.device)

--- a/rlinf/envs/world_model/world_model_wan_env.py
+++ b/rlinf/envs/world_model/world_model_wan_env.py
@@ -69,11 +69,9 @@ class WanEnv(BaseWorldEnv):
 
         self.image_size = tuple(cfg.image_size)
 
-        #
-        self.retain_action = cfg.get("retain_action", True)  # Default True
         self.enable_kir = cfg.get("enable_kir", True)
 
-        # Inference backend; the env keeps episode semantics and the condition window.
+        # Inference backend; it owns the condition window, the env owns episode semantics.
         self.backend: WorldModelBackend = WanBackend(
             cfg, self.device, self._get_runtime_device_str()
         )
@@ -87,26 +85,8 @@ class WanEnv(BaseWorldEnv):
         self.task_descriptions = [""] * self.num_envs
         self.init_ee_poses = [None] * self.num_envs
 
-        # Image queue for condition frames to generate video,
-        # keep length of condition_frame_length
-        self.image_queue = [
-            [None] * self.condition_frame_length for _ in range(self.num_envs)
-        ]
-
-        # Condition action to generate video,
-        # keep length of condition_frame_length
-        self.condition_action = torch.zeros(
-            self.num_envs,
-            self.condition_frame_length,
-            7,
-        )
-
         self.reset_gripper_open = cfg.get("reset_gripper_open", True)
         self.is_libero_env = cfg.get("wm_env_type", "libero") == "libero"
-
-        # If reset_gripper_open is True and the environment is Libero, set the gripper open action to -1
-        if self.reset_gripper_open and self.is_libero_env:
-            self.condition_action[:, :, -1] = -1
 
         self.trans_norm = transforms.Compose(
             [
@@ -372,27 +352,28 @@ class WanEnv(BaseWorldEnv):
         # Reshape to [num_envs, 3, 1, condition_frame_length, H, W] for compatibility
         # [8, 3, 1, 5, 256, 256]
         self.current_obs = stacked_imgs.unsqueeze(2).to(self.device)
-        self.condition_action = torch.stack(condition_actions, dim=0).to(self.device)
 
         num_envs, c, v, t, h, w = self.current_obs.shape
         assert t == self.condition_frame_length, (
             f"Unexpected current_obs shape: {self.current_obs.shape}, expected {num_envs, c, v, self.condition_frame_length, h, w}"
         )
 
-        # Fill image queues for each environment with per-frame tensors [C, 1, H, W]
-        for env_idx in range(num_envs):
-            frames = [
+        # The condition window, per env slot as [C, 1, H, W] frames; the backend keeps it from here on.
+        init_frames = [
+            [
                 self.current_obs[env_idx, :, 0, t_idx : t_idx + 1, :, :]
                 for t_idx in range(self.condition_frame_length)
             ]
-            self.image_queue[env_idx] = frames
+            for env_idx in range(num_envs)
+        ]
 
         # Every reset restarts all env slots, so all sessions are replaced. Noise is drawn from a
         # single seed shared by the batch; per-trajectory seeds are future work.
         self.backend.close_session(range(num_envs))
         self.backend.open_session(
             env_ids=range(num_envs),
-            init_frames=self.image_queue,
+            init_frames=init_frames,
+            init_actions=torch.stack(condition_actions, dim=0).to(self.device),
             task_ids=list(episode_indices),
             seeds=[0] * num_envs,
         )
@@ -502,28 +483,11 @@ class WanEnv(BaseWorldEnv):
             if isinstance(actions, np.ndarray)
             else actions.to(self.device)
         )
-        self.condition_action = self.condition_action.to(
-            device=actions_tensor.device, dtype=actions_tensor.dtype
-        )
-
-        if self.retain_action:
-            actions_tensor = torch.cat([self.condition_action, actions_tensor], dim=1)
-
-        self.condition_action[:, 1 : self.condition_frame_length, :] = actions_tensor[
-            :, -(self.condition_frame_length - 1) :, :
-        ]
         # videos: [num_envs, C, T, H, W] in [-1, 1]
         videos = self.backend.generate(
             env_ids=range(num_envs),
             actions=actions_tensor,
-            condition=self.image_queue,
         )
-
-        for env_idx in range(num_envs):
-            video = videos[env_idx]
-            # Update image_queue
-            for t in range(video.shape[1] - 4, video.shape[1]):
-                self.image_queue[env_idx][t - 8] = video[:, t : t + 1]
 
         # Stack all environments: [num_envs, C, T, H, W]
         x_samples = videos[:, :, self.condition_frame_length :].to(

--- a/tests/unit_tests/test_world_model_backend.py
+++ b/tests/unit_tests/test_world_model_backend.py
@@ -1,0 +1,113 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_backend_module(monkeypatch):
+    """Load the Wan backend with diffsynth stubbed out, so it runs without the Wan deps."""
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "rlinf" / "envs" / "world_model" / "wan_backend.py"
+
+    fake_wan_video = types.ModuleType("diffsynth.pipelines.wan_video_new")
+    fake_wan_video.ModelConfig = object
+    fake_wan_video.WanVideoPipeline = object
+    fake_pipelines = types.ModuleType("diffsynth.pipelines")
+    fake_pipelines.wan_video_new = fake_wan_video
+    fake_diffsynth = types.ModuleType("diffsynth")
+    fake_diffsynth.pipelines = fake_pipelines
+
+    monkeypatch.setitem(sys.modules, "diffsynth", fake_diffsynth)
+    monkeypatch.setitem(sys.modules, "diffsynth.pipelines", fake_pipelines)
+    monkeypatch.setitem(
+        sys.modules, "diffsynth.pipelines.wan_video_new", fake_wan_video
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "rlinf.envs.world_model.wan_backend", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_backend(module, num_frames=9, num_inference_steps=5):
+    backend = object.__new__(module.WanBackend)
+    backend.device = torch.device("cpu")
+    backend.num_frames = num_frames
+    backend.num_inference_steps = num_inference_steps
+    backend._sessions = {}
+    return backend
+
+
+def test_batch_seed_requires_an_open_session(monkeypatch):
+    module = _load_backend_module(monkeypatch)
+    backend = _make_backend(module)
+
+    backend.open_session(
+        env_ids=[0, 1], init_frames=[[], []], task_ids=[7, 7], seeds=[0, 0]
+    )
+    assert backend._batch_seed([0, 1]) == 0
+
+    backend.close_session([1])
+    with pytest.raises(RuntimeError):
+        backend._batch_seed([0, 1])
+
+
+def test_batch_seed_rejects_mixed_seeds(monkeypatch):
+    module = _load_backend_module(monkeypatch)
+    backend = _make_backend(module)
+
+    backend.open_session(
+        env_ids=[0, 1], init_frames=[[], []], task_ids=[7, 8], seeds=[0, 1]
+    )
+    with pytest.raises(NotImplementedError):
+        backend._batch_seed([0, 1])
+
+
+def test_generate_rejects_a_batch_that_does_not_line_up(monkeypatch):
+    module = _load_backend_module(monkeypatch)
+    backend = _make_backend(module)
+    backend.open_session(
+        env_ids=[0, 1], init_frames=[[], []], task_ids=[7, 7], seeds=[0, 0]
+    )
+
+    condition = [[torch.zeros(3, 1, 256, 256)]]
+    with pytest.raises(ValueError):
+        backend.generate(
+            env_ids=[0, 1], actions=torch.zeros(2, 4, 7), condition=condition
+        )
+
+
+def test_pipe_kwargs_takes_the_last_four_condition_frames(monkeypatch):
+    module = _load_backend_module(monkeypatch)
+    backend = _make_backend(module)
+    backend.open_session(env_ids=[0], init_frames=[[]], task_ids=[7], seeds=[3])
+
+    condition = [[torch.zeros(3, 1, 256, 256) for _ in range(5)]]
+    kwargs = backend._pipe_kwargs(
+        env_ids=[0], actions=torch.zeros(1, 4, 7), condition=condition
+    )
+
+    assert kwargs["seed"] == 3
+    assert kwargs["batch_size"] == 1
+    assert len(kwargs["input_image4"][0]) == 4
+    assert kwargs["input_image"][0].size == (256, 256)

--- a/tests/unit_tests/test_world_model_backend.py
+++ b/tests/unit_tests/test_world_model_backend.py
@@ -17,8 +17,13 @@ import sys
 import types
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
+from PIL import Image
+
+WINDOW = 5
+CHUNK = 8
 
 
 def _load_backend_module(monkeypatch):
@@ -49,22 +54,39 @@ def _load_backend_module(monkeypatch):
     return module
 
 
-def _make_backend(module, num_frames=9, num_inference_steps=5):
+def _make_backend(module, retain_action=True):
     backend = object.__new__(module.WanBackend)
     backend.device = torch.device("cpu")
-    backend.num_frames = num_frames
-    backend.num_inference_steps = num_inference_steps
+    backend.num_frames = WINDOW + CHUNK
+    backend.num_inference_steps = 5
+    backend.condition_frame_length = WINDOW
+    backend.retain_action = retain_action
     backend._sessions = {}
     return backend
+
+
+def _open(backend, env_ids, seeds, size=8):
+    frames = [[torch.zeros(3, 1, size, size) for _ in range(WINDOW)] for _ in env_ids]
+    backend.open_session(
+        env_ids=env_ids,
+        init_frames=frames,
+        init_actions=torch.zeros(len(env_ids), WINDOW, 7),
+        task_ids=[7] * len(env_ids),
+        seeds=seeds,
+    )
+
+
+def _gray_frames(values, size=8):
+    return [
+        Image.fromarray(np.full((size, size, 3), v, dtype=np.uint8)) for v in values
+    ]
 
 
 def test_batch_seed_requires_an_open_session(monkeypatch):
     module = _load_backend_module(monkeypatch)
     backend = _make_backend(module)
+    _open(backend, [0, 1], seeds=[0, 0])
 
-    backend.open_session(
-        env_ids=[0, 1], init_frames=[[], []], task_ids=[7, 7], seeds=[0, 0]
-    )
     assert backend._batch_seed([0, 1]) == 0
 
     backend.close_session([1])
@@ -75,10 +97,8 @@ def test_batch_seed_requires_an_open_session(monkeypatch):
 def test_batch_seed_rejects_mixed_seeds(monkeypatch):
     module = _load_backend_module(monkeypatch)
     backend = _make_backend(module)
+    _open(backend, [0, 1], seeds=[0, 1])
 
-    backend.open_session(
-        env_ids=[0, 1], init_frames=[[], []], task_ids=[7, 8], seeds=[0, 1]
-    )
     with pytest.raises(NotImplementedError):
         backend._batch_seed([0, 1])
 
@@ -86,28 +106,47 @@ def test_batch_seed_rejects_mixed_seeds(monkeypatch):
 def test_generate_rejects_a_batch_that_does_not_line_up(monkeypatch):
     module = _load_backend_module(monkeypatch)
     backend = _make_backend(module)
-    backend.open_session(
-        env_ids=[0, 1], init_frames=[[], []], task_ids=[7, 7], seeds=[0, 0]
-    )
+    _open(backend, [0, 1], seeds=[0, 0])
 
-    condition = [[torch.zeros(3, 1, 256, 256)]]
     with pytest.raises(ValueError):
-        backend.generate(
-            env_ids=[0, 1], actions=torch.zeros(2, 4, 7), condition=condition
-        )
+        backend.generate(env_ids=[0, 1], actions=torch.zeros(1, CHUNK, 7))
 
 
-def test_pipe_kwargs_takes_the_last_four_condition_frames(monkeypatch):
+def test_pipe_kwargs_conditions_on_the_session_window(monkeypatch):
     module = _load_backend_module(monkeypatch)
     backend = _make_backend(module)
-    backend.open_session(env_ids=[0], init_frames=[[]], task_ids=[7], seeds=[3])
+    _open(backend, [0], seeds=[3])
+    backend._sessions[0]["frames"] = _gray_frames([10, 20, 30, 40, 50])
 
-    condition = [[torch.zeros(3, 1, 256, 256) for _ in range(5)]]
-    kwargs = backend._pipe_kwargs(
-        env_ids=[0], actions=torch.zeros(1, 4, 7), condition=condition
-    )
+    actions = torch.arange(CHUNK * 7, dtype=torch.float32).reshape(1, CHUNK, 7)
+    kwargs = backend._pipe_kwargs(env_ids=[0], actions=actions)
 
     assert kwargs["seed"] == 3
     assert kwargs["batch_size"] == 1
-    assert len(kwargs["input_image4"][0]) == 4
-    assert kwargs["input_image"][0].size == (256, 256)
+    assert np.asarray(kwargs["input_image"][0]).max() == 10
+    assert [np.asarray(f).max() for f in kwargs["input_image4"][0]] == [20, 30, 40, 50]
+    # retain_action prepends the window's actions, and the window then keeps the last ones sent
+    assert kwargs["action"].shape == (1, WINDOW + CHUNK, 7)
+    assert torch.equal(
+        backend._sessions[0]["actions"][1:], kwargs["action"][0, -(WINDOW - 1) :]
+    )
+    assert torch.all(backend._sessions[0]["actions"][0] == 0)
+
+
+def test_generate_keeps_the_reference_frame_and_rolls_the_window(monkeypatch):
+    module = _load_backend_module(monkeypatch)
+    backend = _make_backend(module)
+    _open(backend, [0], seeds=[0])
+    backend._sessions[0]["frames"] = _gray_frames([10, 20, 30, 40, 50])
+
+    generated = _gray_frames(range(100, 100 + WINDOW + CHUNK))
+    backend._pipe = lambda **kwargs: [generated]
+
+    videos = backend.generate(env_ids=[0], actions=torch.zeros(1, CHUNK, 7))
+
+    assert videos.shape == (1, 3, WINDOW + CHUNK, 8, 8)
+    window = backend._sessions[0]["frames"]
+    assert np.asarray(window[0]).max() == 10
+    # the pipeline's own frames go into the window untouched, not through a [-1, 1] round trip
+    assert [np.asarray(f).max() for f in window[1:]] == [109, 110, 111, 112]
+    assert all(a is b for a, b in zip(window[1:], generated[-(WINDOW - 1) :]))


### PR DESCRIPTION
﻿### Description

**Depends on #1518** â€” stacked on that branch, review it first. PR 2 of the plan in #1511.

The condition window moves from `WanEnv` into `WanBackend`:

- `open_session` takes `init_actions` alongside `init_frames`, so a session starts from a complete window: the reference frame the trajectory conditions on, the last generated frames, and the actions that produced them.
- `generate(env_ids, actions)` no longer takes `condition`. The env sends only the new action chunk; the backend prepends its own action history, conditions on its own frames, and rolls both forward.
- `WanEnv` loses `image_queue` and `condition_action` entirely.

Window semantics are unchanged: slot 0 stays the reset-time reference frame (KIR), slots 1â€“4 are the last four generated frames, and `retain_action` still prepends the action history to the chunk.

### Motivation and Context

A remote backend cannot cache anything per trajectory while the env re-sends the whole window on every call â€” five 256Ã—256 frames per env per chunk over the wire, with no way for the server to reuse the previous encode. With the window behind the session, that becomes the backend's choice.

It also removes the only conversion on this path that existed purely to cross the interface: the pipeline emits PIL frames, the env stored them as `[-1, 1]` float tensors, and the backend converted them back to uint8 on the next call. That round trip is not lossless â€” `x/255*2-1` restored through `((v+1)/2*255).astype(np.uint8)` truncates, so 63 of 256 gray levels come back one lower (~1/4 of pixels on a random image). The frames the pipeline conditioned on were systematically a gray level dark; keeping its own output fixes that.

#1511 tracks the rest: `WorldModelEnv` dedup + `OpenSoraBackend` (PR 3), the `world_model.backend` config key (PR 4), `RemoteBackend` (PR 5).

### How has this been tested?

Env: 2Ã—MI300X (ROCm 6.4), `wan_libero_spatial_grpo_openvlaoft`, 16 envs Ã— 16 steps, `RLinf-Wan-LIBERO-Spatial`.

1. **End to end.** `env_interact_step = 209.5 s` against 206.5 / 208.3 / 209.5 s on the previous trees; exit 0, Global Step 1/1. A byte-identical gate is not available here by construction: dropping the round trip changes the condition frames handed to the pipeline, which is the point of the change.
2. **Unit.** `tests/unit_tests/test_world_model_backend.py` â€” the window keeps its reference frame, rolls in the pipeline's own frames without a round trip, and prepends the action history (5 passed).

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.