### PR TITLE
Claude/rlinf issue 1422 dot0do

### DIFF
--- a/docs/source-en/rst_source/extending/custom_env_reward.rst
+++ b/docs/source-en/rst_source/extending/custom_env_reward.rst
@@ -1,0 +1,116 @@
+Custom Environment Rewards
+==========================
+
+This page shows how to customize the per-step reward an embodied
+environment feeds into RL training (GRPO, PPO, ...): dense rewards,
+hierarchical (staged) reward structures, and fully custom reward
+functions — all selected from YAML, without modifying environment code.
+
+How step rewards flow into training
+-----------------------------------
+
+Each embodied environment converts the simulator's raw reward and the
+per-step ``info`` dict into the training reward inside
+``_calc_step_reward`` (e.g. ``rlinf/envs/maniskill/maniskill_env.py``).
+That reward feeds trajectory returns, which the advantage function
+selected by ``algorithm.adv_type`` (e.g. ``grpo``, ``gae``) consumes.
+
+The reward function is chosen by ``env.<split>.reward_mode``. For the
+ManiSkill environment:
+
+- ``default`` — the built-in hardcoded hierarchy
+  (grasp ``0.1`` + consecutive grasp ``0.1`` + gated success ``1.0``);
+- ``raw`` — pass through the simulator's raw (typically dense) reward;
+- ``only_success`` — sparse ``1.0`` on task success;
+- any other name — looked up in the step-reward registry
+  (``rlinf/envs/rewards``), described next.
+
+Weighted hierarchical dense rewards from YAML
+---------------------------------------------
+
+The built-in ``weighted_components`` reward composes a dense, layered
+reward purely from config. Each component references a tensor in the
+env's step ``info`` dict (the special name ``raw`` references the
+simulator's raw reward):
+
+.. code-block:: yaml
+
+   env:
+     train:
+       reward_mode: weighted_components
+       reward_components:
+         # Stage 1: contact / grasp detection
+         is_src_obj_grasped: 0.3
+         # Stage 2: dense pose-alignment shaping from a distance signal
+         gripper_carrot_dist:
+           weight: 0.5
+           transform: one_minus_tanh
+           scale: 5.0
+         # Stage 3: task completion, gated on the grasp stage
+         success:
+           weight: 1.0
+           requires: [is_src_obj_grasped]
+
+Each entry is either ``name: weight`` or a dict with:
+
+- ``weight`` (required) — the component's coefficient;
+- ``transform`` — reshapes the signal before weighting:
+  ``none`` (default), ``neg`` (``-scale * v``, for penalties),
+  ``neg_exp`` (``exp(-scale * v)``) and ``one_minus_tanh``
+  (``1 - tanh(scale * v)``) — the latter two turn distances into dense
+  rewards that peak at zero;
+- ``scale`` — transform sharpness (default ``1.0``);
+- ``requires`` — a list of boolean ``info`` keys that must all hold for
+  the component to count, which is how hierarchical / staged structures
+  are expressed.
+
+The available component names are whatever the task's ``evaluate()``
+puts into ``info``: for the ManiSkill put-on tasks these include
+``is_src_obj_grasped``, ``consecutive_grasp``, ``success``,
+``gripper_carrot_dist``, ``carrot_plate_dist``, and more. A component
+name missing from ``info`` raises an error listing the available keys.
+
+Registering a fully custom reward function
+------------------------------------------
+
+When weighted components are not expressive enough, register your own
+function. It receives the raw reward, the step ``info`` dict, and the
+env config node, and returns a ``[num_envs]`` float tensor:
+
+.. code-block:: python
+
+   # my_pkg/my_rewards.py
+   import torch
+   from rlinf.envs.rewards import register_env_reward
+
+   @register_env_reward("staged_pick_place")
+   def staged_pick_place(*, raw_reward, info, cfg=None):
+       reward = 0.3 * info["is_src_obj_grasped"].float()
+       reward += 0.5 * (1.0 - torch.tanh(5.0 * info["carrot_plate_dist"]))
+       reward += 1.0 * (info["success"] & info["is_src_obj_grasped"]).float()
+       return reward
+
+Then select it from YAML. If the module lives outside the RLinf tree,
+point ``reward_fn_module`` at it so the decorator runs before lookup:
+
+.. code-block:: yaml
+
+   env:
+     train:
+       reward_mode: staged_pick_place
+       reward_fn_module: my_pkg.my_rewards
+
+Notes
+-----
+
+- ``env.<split>.use_rel_reward: True`` applies to every reward mode: the
+  env emits the per-step *difference* of your reward, so a monotone
+  staged reward becomes a one-time bonus per achieved stage.
+- Group-based advantages (``algorithm.adv_type: grpo``) normalize
+  trajectory returns within each group, so only relative reward scale
+  across trajectories matters; with ``gae``, per-step dense shaping
+  directly affects the value target.
+- For environments other than ManiSkill, route their
+  ``_calc_step_reward`` through
+  ``rlinf.envs.rewards.get_env_reward_fn`` the same way to adopt the
+  registry.

--- a/docs/source-en/rst_source/extending/index.rst
+++ b/docs/source-en/rst_source/extending/index.rst
@@ -19,6 +19,12 @@ to RLinf.
 
       Add a new RL environment and wire it into the env registry.
 
+   .. grid-item-card:: Custom Environment Rewards
+      :link: custom_env_reward
+      :link-type: doc
+
+      Configure dense, hierarchical, or fully custom step rewards.
+
    .. grid-item-card:: New Model with FSDP
       :link: new_model_fsdp
       :link-type: doc
@@ -54,6 +60,7 @@ to RLinf.
 
    Extending Overview <overview>
    New Environment <new_env>
+   Custom Environment Rewards <custom_env_reward>
    New Model with FSDP <new_model_fsdp>
    New Model with Megatron <new_model_megatron>
    New SFT Model <new_model_sft>

--- a/docs/source-zh/rst_source/extending/custom_env_reward.rst
+++ b/docs/source-zh/rst_source/extending/custom_env_reward.rst
@@ -1,0 +1,109 @@
+自定义环境奖励
+==============
+
+本页介绍如何自定义具身环境每步送入 RL 训练（GRPO、PPO 等）的奖励：
+稠密奖励、分层（阶段化）奖励结构，以及完全自定义的奖励函数——
+全部通过 YAML 选择，无需修改环境代码。
+
+步进奖励如何进入训练
+--------------------
+
+每个具身环境在 ``_calc_step_reward`` 中（例如
+``rlinf/envs/maniskill/maniskill_env.py``）把仿真器的原始奖励和每步
+``info`` 字典转换为训练奖励。该奖励构成轨迹回报，随后由
+``algorithm.adv_type`` 选择的优势函数（如 ``grpo``、``gae``）消费。
+
+奖励函数由 ``env.<split>.reward_mode`` 选择。对 ManiSkill 环境：
+
+- ``default`` —— 内置的硬编码分层奖励
+  （抓取 ``0.1`` + 持续抓取 ``0.1`` + 门控成功 ``1.0``）；
+- ``raw`` —— 透传仿真器的原始（通常为稠密）奖励；
+- ``only_success`` —— 稀疏奖励，任务成功时为 ``1.0``；
+- 其他任意名称 —— 在步进奖励注册表（``rlinf/envs/rewards``）中查找，
+  见下文。
+
+用 YAML 配置加权分层稠密奖励
+----------------------------
+
+内置的 ``weighted_components`` 奖励完全通过配置组合出稠密、分层的
+奖励。每个分量引用环境步进 ``info`` 字典中的一个张量（特殊名称
+``raw`` 引用仿真器的原始奖励）：
+
+.. code-block:: yaml
+
+   env:
+     train:
+       reward_mode: weighted_components
+       reward_components:
+         # 第一层：接触 / 抓取检测
+         is_src_obj_grasped: 0.3
+         # 第二层：基于距离信号的稠密位姿对齐塑形
+         gripper_carrot_dist:
+           weight: 0.5
+           transform: one_minus_tanh
+           scale: 5.0
+         # 第三层：任务完成，以抓取阶段为门控
+         success:
+           weight: 1.0
+           requires: [is_src_obj_grasped]
+
+每个条目要么是 ``name: weight``，要么是包含以下键的字典：
+
+- ``weight`` （必填）—— 分量系数；
+- ``transform`` —— 加权前对信号做变换：
+  ``none`` （默认）、``neg`` （``-scale * v``，用于惩罚项）、
+  ``neg_exp`` （``exp(-scale * v)``）和 ``one_minus_tanh``
+  （``1 - tanh(scale * v)``）——后两者把距离转换为在零处取峰值的
+  稠密奖励；
+- ``scale`` —— 变换陡峭程度（默认 ``1.0``）；
+- ``requires`` —— 一组必须全部为真的布尔 ``info`` 键，分量才计入
+  奖励；分层 / 阶段化结构由此表达。
+
+可用的分量名称取决于任务 ``evaluate()`` 写入 ``info`` 的内容：
+ManiSkill 的 put-on 任务包括 ``is_src_obj_grasped``、
+``consecutive_grasp``、``success``、``gripper_carrot_dist``、
+``carrot_plate_dist`` 等。若分量名称不在 ``info`` 中，会报错并列出
+可用键。
+
+注册完全自定义的奖励函数
+------------------------
+
+当加权分量表达能力不足时，可注册自己的函数。函数接收原始奖励、
+步进 ``info`` 字典和环境配置节点，返回形状为 ``[num_envs]`` 的
+浮点张量：
+
+.. code-block:: python
+
+   # my_pkg/my_rewards.py
+   import torch
+   from rlinf.envs.rewards import register_env_reward
+
+   @register_env_reward("staged_pick_place")
+   def staged_pick_place(*, raw_reward, info, cfg=None):
+       reward = 0.3 * info["is_src_obj_grasped"].float()
+       reward += 0.5 * (1.0 - torch.tanh(5.0 * info["carrot_plate_dist"]))
+       reward += 1.0 * (info["success"] & info["is_src_obj_grasped"]).float()
+       return reward
+
+然后在 YAML 中选择它。若模块位于 RLinf 源码树之外，用
+``reward_fn_module`` 指向该模块，使装饰器在查找前先执行：
+
+.. code-block:: yaml
+
+   env:
+     train:
+       reward_mode: staged_pick_place
+       reward_fn_module: my_pkg.my_rewards
+
+注意事项
+--------
+
+- ``env.<split>.use_rel_reward: True`` 对所有奖励模式生效：环境输出
+  的是奖励的每步 *差分* ，因此单调的阶段化奖励会变成每达成一个阶段
+  发放一次的奖励。
+- 基于组的优势（``algorithm.adv_type: grpo``）在组内对轨迹回报做
+  归一化，因此只有轨迹间的相对奖励尺度有意义；使用 ``gae`` 时，
+  每步稠密塑形会直接影响价值目标。
+- 对于 ManiSkill 之外的环境，可用相同方式让其
+  ``_calc_step_reward`` 经过 ``rlinf.envs.rewards.get_env_reward_fn``
+  以接入注册表。

--- a/docs/source-zh/rst_source/extending/index.rst
+++ b/docs/source-zh/rst_source/extending/index.rst
@@ -18,6 +18,12 @@
 
       添加一个新的 RL 环境并接入环境注册表。
 
+   .. grid-item-card:: 自定义环境奖励
+      :link: custom_env_reward
+      :link-type: doc
+
+      配置稠密、分层或完全自定义的步进奖励。
+
    .. grid-item-card:: FSDP 新模型
       :link: new_model_fsdp
       :link-type: doc
@@ -53,6 +59,7 @@
 
    扩展概览 <overview>
    新环境 <new_env>
+   自定义环境奖励 <custom_env_reward>
    FSDP 新模型 <new_model_fsdp>
    Megatron 新模型 <new_model_megatron>
    新 SFT 模型 <new_model_sft>

--- a/rlinf/envs/maniskill/maniskill_env.py
+++ b/rlinf/envs/maniskill/maniskill_env.py
@@ -26,6 +26,7 @@ from omegaconf import open_dict
 from omegaconf.omegaconf import OmegaConf
 
 from rlinf.envs.maniskill.utils import allow_pci_render_backend
+from rlinf.envs.rewards import get_env_reward_fn
 
 __all__ = ["ManiskillEnv"]
 
@@ -209,17 +210,19 @@ class ManiskillEnv(gym.Env):
         return state_obs
 
     def _calc_step_reward(self, reward, info):
-        if getattr(self.cfg, "reward_mode", "default") == "raw":
-            pass
-        elif getattr(self.cfg, "reward_mode", "default") == "only_success":
-            reward = info["success"] * 1.0
-        else:
+        reward_mode = getattr(self.cfg, "reward_mode", "default")
+        if reward_mode == "default":
             reward = torch.zeros(self.num_envs, dtype=torch.float32).to(
                 self.env.unwrapped.device
             )  # [B, ]
             reward += info["is_src_obj_grasped"] * 0.1
             reward += info["consecutive_grasp"] * 0.1
             reward += (info["success"] & info["is_src_obj_grasped"]) * 1.0
+        else:
+            reward_fn = get_env_reward_fn(
+                reward_mode, module=getattr(self.cfg, "reward_fn_module", None)
+            )
+            reward = reward_fn(raw_reward=reward, info=info, cfg=self.cfg)
         # diff
         reward_diff = reward - self.prev_step_reward
         self.prev_step_reward = reward

--- a/rlinf/envs/rewards/__init__.py
+++ b/rlinf/envs/rewards/__init__.py
@@ -1,0 +1,35 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Customizable step-reward functions for embodied environments.
+
+See :mod:`rlinf.envs.rewards.registry` for the function contract and
+:mod:`rlinf.envs.rewards.builtin` for the built-in dense/hierarchical
+``weighted_components`` reward.
+"""
+
+from rlinf.envs.rewards import builtin  # noqa: F401  (registers built-ins)
+from rlinf.envs.rewards.registry import (
+    ENV_REWARD_REGISTRY,
+    get_env_reward_fn,
+    list_env_rewards,
+    register_env_reward,
+)
+
+__all__ = [
+    "ENV_REWARD_REGISTRY",
+    "get_env_reward_fn",
+    "list_env_rewards",
+    "register_env_reward",
+]

--- a/rlinf/envs/rewards/builtin.py
+++ b/rlinf/envs/rewards/builtin.py
@@ -1,0 +1,141 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Built-in step-reward functions for embodied environments.
+
+Besides the trivial ``raw`` and ``only_success`` modes, this module provides
+``weighted_components``: a config-driven dense/hierarchical reward that sums
+weighted signals from the environment's ``info`` dict, e.g.::
+
+    env:
+      train:
+        reward_mode: weighted_components
+        reward_components:
+          is_src_obj_grasped: 0.3          # contact / grasp detection
+          gripper_carrot_dist:             # dense pose-alignment shaping
+            weight: 0.5
+            transform: one_minus_tanh
+            scale: 5.0
+          success:                         # task completion, gated on grasp
+            weight: 1.0
+            requires: [is_src_obj_grasped]
+
+Each component is either ``name: weight`` or ``name: {weight, transform,
+scale, requires}``. ``name`` is looked up in ``info`` (the special name
+``raw`` refers to the simulator's raw reward). ``transform`` reshapes the
+signal before weighting — useful for turning distances into dense rewards —
+and ``requires`` gates the component on boolean stage signals, enabling
+hierarchical (staged) reward structures.
+"""
+
+from typing import Any
+
+import torch
+
+from rlinf.envs.rewards.registry import register_env_reward
+
+_TRANSFORMS = {
+    # Use the signal as-is (booleans become 0/1).
+    "none": lambda v, scale: v,
+    # Negated signal: reward decreasing quantities such as distances.
+    "neg": lambda v, scale: -scale * v,
+    # exp(-scale * v): dense shaping in (0, 1] that peaks at v == 0.
+    "neg_exp": lambda v, scale: torch.exp(-scale * v),
+    # 1 - tanh(scale * v): dense shaping in (0, 1] that peaks at v == 0.
+    "one_minus_tanh": lambda v, scale: 1.0 - torch.tanh(scale * v),
+}
+
+
+def _cfg_get(cfg: Any, key: str, default: Any = None) -> Any:
+    if cfg is None:
+        return default
+    if isinstance(cfg, dict):
+        return cfg.get(key, default)
+    getter = getattr(cfg, "get", None)
+    if callable(getter):
+        return getter(key, default)
+    return getattr(cfg, key, default)
+
+
+def _component_value(name: str, raw_reward: torch.Tensor, info: dict) -> torch.Tensor:
+    if name == "raw":
+        value = raw_reward
+    elif name in info:
+        value = info[name]
+    else:
+        tensor_keys = sorted(k for k, v in info.items() if isinstance(v, torch.Tensor))
+        raise KeyError(
+            f"Reward component '{name}' not found in env info. "
+            f"Available info tensors: {tensor_keys} (plus the special "
+            "component 'raw' for the simulator's raw reward)."
+        )
+    return torch.as_tensor(value, device=raw_reward.device).to(torch.float32)
+
+
+@register_env_reward("raw")
+def raw_reward_fn(
+    *, raw_reward: torch.Tensor, info: dict, cfg: Any = None
+) -> torch.Tensor:
+    """Pass through the simulator's raw (typically dense) reward."""
+    return torch.as_tensor(raw_reward).to(torch.float32)
+
+
+@register_env_reward("only_success")
+def only_success_reward_fn(
+    *, raw_reward: torch.Tensor, info: dict, cfg: Any = None
+) -> torch.Tensor:
+    """Sparse reward: 1.0 on task success, 0.0 otherwise."""
+    return _component_value("success", raw_reward, info)
+
+
+@register_env_reward("weighted_components")
+def weighted_components_reward_fn(
+    *, raw_reward: torch.Tensor, info: dict, cfg: Any = None
+) -> torch.Tensor:
+    """Config-driven weighted sum of ``info`` signals (see module docstring).
+
+    Reads ``reward_components`` from ``cfg``: a mapping from component name to
+    either a scalar weight or a dict with keys ``weight`` (required),
+    ``transform`` (one of ``none``/``neg``/``neg_exp``/``one_minus_tanh``,
+    default ``none``), ``scale`` (float, default 1.0), and ``requires`` (list
+    of boolean ``info`` keys that must all hold for the component to count).
+    """
+    components = _cfg_get(cfg, "reward_components")
+    if not components:
+        raise ValueError(
+            "reward_mode 'weighted_components' requires a non-empty "
+            "env.<split>.reward_components mapping in the config."
+        )
+
+    reward = torch.zeros_like(torch.as_tensor(raw_reward), dtype=torch.float32)
+    for name, spec in components.items():
+        if isinstance(spec, (int, float)):
+            weight, transform, scale, requires = float(spec), "none", 1.0, []
+        else:
+            weight = float(_cfg_get(spec, "weight"))
+            transform = str(_cfg_get(spec, "transform", "none"))
+            scale = float(_cfg_get(spec, "scale", 1.0))
+            requires = list(_cfg_get(spec, "requires", []) or [])
+
+        if transform not in _TRANSFORMS:
+            raise ValueError(
+                f"Unknown transform '{transform}' for reward component "
+                f"'{name}'. Available: {sorted(_TRANSFORMS.keys())}"
+            )
+
+        value = _TRANSFORMS[transform](_component_value(name, raw_reward, info), scale)
+        for req in requires:
+            value = value * _component_value(req, raw_reward, info)
+        reward = reward + weight * value
+    return reward

--- a/rlinf/envs/rewards/registry.py
+++ b/rlinf/envs/rewards/registry.py
@@ -1,0 +1,86 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry for embodied environment step-reward functions.
+
+A step-reward function converts the raw simulator reward and the per-step
+``info`` dict emitted by an environment into the scalar reward used for
+training (e.g. GRPO/PPO rollouts). Registering a function here lets users
+select it from YAML via ``env.<split>.reward_mode`` without modifying the
+environment code.
+
+A reward function must accept keyword arguments::
+
+    fn(*, raw_reward: torch.Tensor, info: dict, cfg) -> torch.Tensor
+
+where ``raw_reward`` is the ``[num_envs]`` reward returned by the underlying
+simulator, ``info`` is the step info dict (containing tensors such as
+``success`` or task-specific signals like ``is_src_obj_grasped``), and
+``cfg`` is the environment config node (so functions can read options such as
+``reward_components``). It must return a float tensor of shape
+``[num_envs]``.
+"""
+
+import importlib
+from typing import Callable, Optional
+
+ENV_REWARD_REGISTRY: dict[str, Callable] = {}
+
+
+def register_env_reward(name: str) -> Callable:
+    """Decorator registering a step-reward function under ``name``.
+
+    The name is case-normalized to lowercase and is the value users put in
+    ``env.<split>.reward_mode``.
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        key = name.lower()
+        assert key not in ENV_REWARD_REGISTRY, f"Env reward '{key}' already registered"
+        ENV_REWARD_REGISTRY[key] = fn
+        return fn
+
+    return decorator
+
+
+def get_env_reward_fn(name: str, module: Optional[str] = None) -> Callable:
+    """Retrieve a registered step-reward function by name.
+
+    Args:
+        name: Registered reward name (matched case-insensitively).
+        module: Optional dotted module path (e.g. ``my_pkg.my_rewards``) that
+            is imported first so its ``@register_env_reward`` decorators run.
+            This lets users ship custom rewards outside the RLinf tree and
+            point to them from YAML via ``env.<split>.reward_fn_module``.
+
+    Returns:
+        The registered reward callable.
+    """
+    if module:
+        importlib.import_module(module)
+    key = name.lower()
+    if key not in ENV_REWARD_REGISTRY:
+        raise ValueError(
+            f"Env reward '{name}' not registered. "
+            f"Available: {sorted(ENV_REWARD_REGISTRY.keys())}. "
+            "Register your own with rlinf.envs.rewards.register_env_reward, "
+            "and set env.<split>.reward_fn_module to its module path if it "
+            "lives outside RLinf."
+        )
+    return ENV_REWARD_REGISTRY[key]
+
+
+def list_env_rewards() -> list[str]:
+    """Return the names of all registered step-reward functions."""
+    return sorted(ENV_REWARD_REGISTRY.keys())

--- a/tests/unit_tests/test_env_reward_registry.py
+++ b/tests/unit_tests/test_env_reward_registry.py
@@ -1,0 +1,230 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the embodied env step-reward registry and built-ins."""
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from rlinf.envs.rewards import (
+    ENV_REWARD_REGISTRY,
+    get_env_reward_fn,
+    list_env_rewards,
+    register_env_reward,
+)
+
+
+@pytest.fixture
+def raw_reward():
+    return torch.tensor([0.5, 1.5, 2.5], dtype=torch.float32)
+
+
+@pytest.fixture
+def info():
+    return {
+        "success": torch.tensor([False, True, True]),
+        "is_src_obj_grasped": torch.tensor([True, True, False]),
+        "gripper_obj_dist": torch.tensor([0.0, 0.2, 1.0]),
+    }
+
+
+def test_builtins_registered():
+    for name in ("raw", "only_success", "weighted_components"):
+        assert name in list_env_rewards()
+        assert callable(get_env_reward_fn(name))
+
+
+def test_raw_passthrough(raw_reward, info):
+    fn = get_env_reward_fn("raw")
+    reward = fn(raw_reward=raw_reward, info=info, cfg=None)
+    assert reward.dtype == torch.float32
+    assert torch.allclose(reward, raw_reward)
+
+
+def test_only_success(raw_reward, info):
+    fn = get_env_reward_fn("only_success")
+    reward = fn(raw_reward=raw_reward, info=info, cfg=None)
+    assert torch.allclose(reward, torch.tensor([0.0, 1.0, 1.0]))
+
+
+def test_weighted_components_scalar_weights(raw_reward, info):
+    # The layered structure from RLinf issue #1422: contact 0.3 + task
+    # completion 1.0 as plain weights.
+    cfg = OmegaConf.create(
+        {
+            "reward_components": {
+                "is_src_obj_grasped": 0.3,
+                "success": 1.0,
+            }
+        }
+    )
+    fn = get_env_reward_fn("weighted_components")
+    reward = fn(raw_reward=raw_reward, info=info, cfg=cfg)
+    expected = torch.tensor([0.3, 1.3, 1.0])
+    assert torch.allclose(reward, expected)
+
+
+def test_weighted_components_dense_transform(raw_reward, info):
+    cfg = OmegaConf.create(
+        {
+            "reward_components": {
+                "gripper_obj_dist": {
+                    "weight": 0.5,
+                    "transform": "one_minus_tanh",
+                    "scale": 5.0,
+                }
+            }
+        }
+    )
+    fn = get_env_reward_fn("weighted_components")
+    reward = fn(raw_reward=raw_reward, info=info, cfg=cfg)
+    expected = 0.5 * (1.0 - torch.tanh(5.0 * info["gripper_obj_dist"]))
+    assert torch.allclose(reward, expected)
+
+
+def test_weighted_components_neg_and_neg_exp(raw_reward, info):
+    cfg = OmegaConf.create(
+        {
+            "reward_components": {
+                "gripper_obj_dist": {"weight": 1.0, "transform": "neg"},
+            }
+        }
+    )
+    fn = get_env_reward_fn("weighted_components")
+    reward = fn(raw_reward=raw_reward, info=info, cfg=cfg)
+    assert torch.allclose(reward, -info["gripper_obj_dist"])
+
+    cfg = OmegaConf.create(
+        {
+            "reward_components": {
+                "gripper_obj_dist": {
+                    "weight": 1.0,
+                    "transform": "neg_exp",
+                    "scale": 2.0,
+                },
+            }
+        }
+    )
+    reward = fn(raw_reward=raw_reward, info=info, cfg=cfg)
+    assert torch.allclose(reward, torch.exp(-2.0 * info["gripper_obj_dist"]))
+
+
+def test_weighted_components_hierarchical_gating(raw_reward, info):
+    # Task completion only counts when the grasp stage holds, mirroring the
+    # hardcoded (success & is_src_obj_grasped) hierarchy of the default mode.
+    cfg = OmegaConf.create(
+        {
+            "reward_components": {
+                "success": {
+                    "weight": 1.0,
+                    "requires": ["is_src_obj_grasped"],
+                },
+            }
+        }
+    )
+    fn = get_env_reward_fn("weighted_components")
+    reward = fn(raw_reward=raw_reward, info=info, cfg=cfg)
+    # env 1 has success & grasp; env 2 has success but no grasp.
+    assert torch.allclose(reward, torch.tensor([0.0, 1.0, 0.0]))
+
+
+def test_weighted_components_raw_component(raw_reward, info):
+    cfg = OmegaConf.create({"reward_components": {"raw": 0.1, "success": 1.0}})
+    fn = get_env_reward_fn("weighted_components")
+    reward = fn(raw_reward=raw_reward, info=info, cfg=cfg)
+    expected = 0.1 * raw_reward + info["success"].float()
+    assert torch.allclose(reward, expected)
+
+
+def test_weighted_components_maniskill_default_equivalence(raw_reward, info):
+    # The YAML equivalent of ManiskillEnv's hardcoded "default" reward.
+    info = dict(info, consecutive_grasp=torch.tensor([False, True, False]))
+    cfg = OmegaConf.create(
+        {
+            "reward_components": {
+                "is_src_obj_grasped": 0.1,
+                "consecutive_grasp": 0.1,
+                "success": {"weight": 1.0, "requires": ["is_src_obj_grasped"]},
+            }
+        }
+    )
+    fn = get_env_reward_fn("weighted_components")
+    reward = fn(raw_reward=raw_reward, info=info, cfg=cfg)
+    expected = (
+        info["is_src_obj_grasped"] * 0.1
+        + info["consecutive_grasp"] * 0.1
+        + (info["success"] & info["is_src_obj_grasped"]) * 1.0
+    ).float()
+    assert torch.allclose(reward, expected)
+
+
+def test_weighted_components_errors(raw_reward, info):
+    fn = get_env_reward_fn("weighted_components")
+    with pytest.raises(ValueError, match="reward_components"):
+        fn(raw_reward=raw_reward, info=info, cfg=OmegaConf.create({}))
+    with pytest.raises(KeyError, match="not found in env info"):
+        fn(
+            raw_reward=raw_reward,
+            info=info,
+            cfg=OmegaConf.create({"reward_components": {"missing_key": 1.0}}),
+        )
+    with pytest.raises(ValueError, match="Unknown transform"):
+        fn(
+            raw_reward=raw_reward,
+            info=info,
+            cfg=OmegaConf.create(
+                {
+                    "reward_components": {
+                        "success": {"weight": 1.0, "transform": "bogus"}
+                    }
+                }
+            ),
+        )
+
+
+def test_register_custom_reward(raw_reward, info):
+    @register_env_reward("test_custom_reward")
+    def custom_fn(*, raw_reward, info, cfg=None):
+        return raw_reward * 2.0
+
+    try:
+        fn = get_env_reward_fn("TEST_CUSTOM_REWARD")  # case-insensitive
+        assert torch.allclose(fn(raw_reward=raw_reward, info=info), raw_reward * 2.0)
+        with pytest.raises(AssertionError, match="already registered"):
+            register_env_reward("test_custom_reward")(custom_fn)
+    finally:
+        ENV_REWARD_REGISTRY.pop("test_custom_reward", None)
+
+
+def test_unknown_reward_name():
+    with pytest.raises(ValueError, match="not registered"):
+        get_env_reward_fn("does_not_exist")
+
+
+def test_reward_fn_module_import(tmp_path, monkeypatch, raw_reward, info):
+    module_file = tmp_path / "my_custom_rewards.py"
+    module_file.write_text(
+        "from rlinf.envs.rewards import register_env_reward\n"
+        "\n"
+        "@register_env_reward('test_module_reward')\n"
+        "def module_reward(*, raw_reward, info, cfg=None):\n"
+        "    return raw_reward + 1.0\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    try:
+        fn = get_env_reward_fn("test_module_reward", module="my_custom_rewards")
+        assert torch.allclose(fn(raw_reward=raw_reward, info=info), raw_reward + 1.0)
+    finally:
+        ENV_REWARD_REGISTRY.pop("test_module_reward", None)


### PR DESCRIPTION
### Description

Add a step-reward registry for embodied environments (`rlinf/envs/rewards/`) so dense, hierarchical, or fully custom per-step rewards can be selected from YAML via `env.<split>.reward_mode`, without modifying environment code.

- New `register_env_reward` / `get_env_reward_fn` registry, following the style of the existing advantage/loss registries; the optional `env.<split>.reward_fn_module` config key lazily imports user reward modules living outside the RLinf tree.
- New built-in `weighted_components` reward: a config-driven weighted sum of env `info` signals, with dense shaping transforms (`neg`, `neg_exp`, `one_minus_tanh` for distance signals) and `requires` gating to express hierarchical (staged) reward structures, e.g. contact detection 0.3 + pose-alignment shaping 0.5 + gated task completion 1.0.
- Built-in `raw` and `only_success` rewards; `ManiskillEnv._calc_step_reward` now routes every non-`default` reward mode through the registry (`raw`/`only_success` behavior unchanged, `default` keeps the existing hardcoded formula for backward compatibility; `ManiskillRLTEnv` inherits the behavior).
- New EN/ZH docs page "Custom Environment Rewards" under Extending, wired into the section index.
- New unit tests in `tests/unit_tests/test_env_reward_registry.py`.

### Motivation and Context

RLinf issue [#1422](https://github.com/RLinf/RLinf/issues/1422) asks for customizable reward functions for GRPO training: dense rewards and layered reward structures with weighted components (e.g. contact 0.3, pose alignment 0.5, task completion 1.0). Today each env hardcodes its reward in `_calc_step_reward` (ManiSkill's `default` mode is a fixed grasp 0.1 + consecutive-grasp 0.1 + gated success 1.0 formula), so any custom shaping requires forking env code. This PR makes the reward a pluggable, config-selected function while keeping all existing modes bit-identical. Fixes #1422.

### How has this been tested?

`python -m pytest tests/unit_tests/test_env_reward_registry.py -q` — 13 passed, covering the registry (registration, case-insensitive lookup, duplicate/unknown errors, external module import via `reward_fn_module`) and the built-ins (scalar weights, dense transforms, hierarchical `requires` gating, `raw` component, error paths), including a test asserting `weighted_components` reproduces ManiskillEnv's hardcoded `default` reward exactly. `ruff check` and `ruff format --check` pass on all changed files. No existing config changes behavior: `default`, `raw`, and `only_success` reward modes are numerically unchanged.

### Additional information (optional, e.g., figures and logs):

Example YAML for the layered reward requested in the issue:

```yaml
env:
  train:
    reward_mode: weighted_components
    reward_components:
      is_src_obj_grasped: 0.3
      gripper_carrot_dist:
        weight: 0.5
        transform: one_minus_tanh
        scale: 5.0
      success:
        weight: 1.0
        requires: [is_src_obj_grasped]
```

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xqjZS6b4UxsYZuTjcPBFN
