### PR TITLE
fix(algorithms): report a live critic value_clip_ratio

### DIFF
--- a/rlinf/algorithms/losses.py
+++ b/rlinf/algorithms/losses.py
@@ -360,8 +360,18 @@ def compute_ppo_critic_loss(
     value_loss = torch.max(value_loss_original, value_loss_clipped)
     value_loss = loss_agg_func(value_loss, loss_mask, loss_mask_ratio)
 
-    value_clip_indicator = (value_pred_clipped - prev_values).abs() > value_clip
-    value_clip_ratio = value_clip_indicator.float().mean()
+    # Measure the update *before* clipping: ``value_pred_clipped - prev_values``
+    # is a clamp to +/- ``value_clip`` by construction, so comparing it against
+    # ``value_clip`` can never be true. Padded entries are excluded so the ratio
+    # stays comparable with ``critic/value_loss`` and ``critic/explained_variance``.
+    value_clip_indicator = ((values - prev_values).detach().abs() > value_clip).float()
+    if loss_mask is None:
+        value_clip_ratio = value_clip_indicator.mean()
+    else:
+        clip_mask = loss_mask.to(device=value_clip_indicator.device, dtype=torch.bool)
+        if clip_mask.shape != value_clip_indicator.shape:
+            clip_mask = torch.broadcast_to(clip_mask, value_clip_indicator.shape)
+        value_clip_ratio = masked_mean(value_clip_indicator, clip_mask)
 
     explained_variance_stats = compute_critic_explained_variance_stats(
         returns=returns,

--- a/tests/unit_tests/test_ppo_critic_loss_metrics.py
+++ b/tests/unit_tests/test_ppo_critic_loss_metrics.py
@@ -1,0 +1,146 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the critic metrics reported by ``compute_ppo_critic_loss``."""
+
+import pytest
+import torch
+
+from rlinf.algorithms.losses import compute_ppo_critic_loss
+
+VALUE_CLIP = 0.2
+HUBER_DELTA = 10.0
+
+
+def _critic_metrics(values, prev_values, returns, loss_mask=None):
+    _, metrics = compute_ppo_critic_loss(
+        values=values,
+        returns=returns,
+        prev_values=prev_values,
+        value_clip=VALUE_CLIP,
+        huber_delta=HUBER_DELTA,
+        loss_mask=loss_mask,
+    )
+    return metrics
+
+
+def test_value_clip_ratio_is_zero_when_no_update_is_clipped():
+    prev_values = torch.zeros(4, 8)
+    values = torch.full((4, 8), VALUE_CLIP / 2)
+    returns = torch.zeros(4, 8)
+
+    metrics = _critic_metrics(values, prev_values, returns)
+
+    assert float(metrics["critic/value_clip_ratio"]) == pytest.approx(0.0)
+
+
+def test_value_clip_ratio_reports_the_fraction_of_clipped_updates():
+    prev_values = torch.zeros(4, 8)
+    returns = torch.zeros(4, 8)
+    # Half of the entries move outside the trust region, half stay inside.
+    values = torch.full((4, 8), VALUE_CLIP / 2)
+    values[:, :4] = 10 * VALUE_CLIP
+
+    metrics = _critic_metrics(values, prev_values, returns)
+
+    assert float(metrics["critic/value_clip_ratio"]) == pytest.approx(0.5)
+
+
+def test_value_clip_ratio_grows_with_the_size_of_the_value_update():
+    prev_values = torch.zeros(4, 8)
+    returns = torch.zeros(4, 8)
+
+    ratios = [
+        float(
+            _critic_metrics(torch.full((4, 8), scale), prev_values, returns)[
+                "critic/value_clip_ratio"
+            ]
+        )
+        for scale in (0.5 * VALUE_CLIP, 2 * VALUE_CLIP)
+    ]
+
+    assert ratios == [pytest.approx(0.0), pytest.approx(1.0)]
+
+
+def test_value_clip_ratio_ignores_masked_out_entries():
+    prev_values = torch.zeros(4, 8)
+    returns = torch.zeros(4, 8)
+    loss_mask = torch.zeros(4, 8, dtype=torch.bool)
+    loss_mask[:, :2] = True
+
+    # Every valid entry is clipped; every padded entry is not.
+    values = torch.zeros(4, 8)
+    values[:, :2] = 10 * VALUE_CLIP
+
+    metrics = _critic_metrics(values, prev_values, returns, loss_mask=loss_mask)
+
+    assert float(metrics["critic/value_clip_ratio"]) == pytest.approx(1.0)
+
+
+def test_value_clip_ratio_broadcasts_a_narrower_loss_mask():
+    prev_values = torch.zeros(4, 8, 3)
+    returns = torch.zeros(4, 8, 3)
+    loss_mask = torch.zeros(4, 8, 1, dtype=torch.bool)
+    loss_mask[:, :4] = True
+
+    values = torch.zeros(4, 8, 3)
+    values[:, :2] = 10 * VALUE_CLIP
+
+    metrics = _critic_metrics(values, prev_values, returns, loss_mask=loss_mask)
+
+    # 2 of the 4 unmasked steps are clipped.
+    assert float(metrics["critic/value_clip_ratio"]) == pytest.approx(0.5)
+
+
+def test_value_clip_ratio_is_zero_when_every_entry_is_masked_out():
+    prev_values = torch.zeros(4, 8)
+    returns = torch.zeros(4, 8)
+    loss_mask = torch.zeros(4, 8, dtype=torch.bool)
+    values = torch.full((4, 8), 10 * VALUE_CLIP)
+
+    metrics = _critic_metrics(values, prev_values, returns, loss_mask=loss_mask)
+
+    assert float(metrics["critic/value_clip_ratio"]) == pytest.approx(0.0)
+
+
+def test_value_loss_is_unchanged_by_the_metric_computation():
+    torch.manual_seed(0)
+    prev_values = torch.randn(4, 8)
+    values = torch.randn(4, 8, requires_grad=True)
+    returns = torch.randn(4, 8)
+
+    loss, metrics = compute_ppo_critic_loss(
+        values=values,
+        returns=returns,
+        prev_values=prev_values,
+        value_clip=VALUE_CLIP,
+        huber_delta=HUBER_DELTA,
+        loss_mask=None,
+    )
+
+    value_pred_clipped = prev_values + (values - prev_values).clamp(
+        -VALUE_CLIP, VALUE_CLIP
+    )
+    expected = torch.max(
+        torch.nn.functional.huber_loss(
+            values, returns, delta=HUBER_DELTA, reduction="none"
+        ),
+        torch.nn.functional.huber_loss(
+            value_pred_clipped, returns, delta=HUBER_DELTA, reduction="none"
+        ),
+    ).mean()
+
+    assert float(loss.detach()) == pytest.approx(float(expected.detach()), abs=1e-6)
+    assert loss.requires_grad
+    assert not metrics["critic/value_clip_ratio"].requires_grad


### PR DESCRIPTION
### Description

`critic/value_clip_ratio` decided whether an update had been clipped by inspecting the
**already-clipped** prediction:

```python
value_pred_clipped = prev_values + (values - prev_values).clamp(-value_clip, value_clip)
...
value_clip_indicator = (value_pred_clipped - prev_values).abs() > value_clip
value_clip_ratio = value_clip_indicator.float().mean()
```

`value_pred_clipped - prev_values` is that clamp by construction, so its absolute value is
`<= value_clip` for every element and the strict `>` can never be true. The metric was pinned
at `0.0` on every run regardless of how far the value head moved.

This takes the indicator from the pre-clip update `values - prev_values`, and normalizes it
over `loss_mask` instead of over all elements, so padded timesteps no longer dilute the ratio.
`critic/value_loss` (via `loss_agg_func`) and `critic/explained_variance` (via
`compute_critic_explained_variance_stats`) already respect `loss_mask` in this same function,
and the broadcast rule here matches the latter.

The change is metrics-only — the returned value loss and its gradient are untouched.

### Motivation and Context

Fixes #1529.

`critic/value_clip_ratio` is the diagnostic users read to tell whether `algorithm.value_clip`
is set too tight, and it is documented in `docs/.../reference/metrics.rst` (EN and ZH) as
"Fraction of value targets whose update was clipped". Reading a constant `0.0` makes it look
like the trust region is never binding, on any run. The metric is emitted by every config
selecting `loss_type: actor_critic` or `decoupled_actor_critic` — 106 of the configs shipped
under `examples/` and `tests/`.

### How has this been tested?

- New `tests/unit_tests/test_ppo_critic_loss_metrics.py` (7 tests). Against the current `main`
  implementation, 4 of them fail and 3 pass; with this change all 7 pass. The 3 that pass
  either way are the invariants worth locking down: zero when nothing is clipped, zero when
  every entry is masked out, and the value loss / grad-mode assertions.
- `pytest tests/unit_tests/test_ppo_critic_loss_metrics.py tests/unit_tests/test_metric_utils.py`
  → 10 passed (Python 3.14.6, `torch 2.13.0`, CPU only — no GPU is needed for either the bug
  or the fix).
- `ruff format` and `ruff check` clean on both changed files.

### Additional information (optional, e.g., figures and logs):

Same inputs before and after, `value_clip = 0.2`, `prev_values = 0`, sweeping the size of the
value update:

| `\|values - prev_values\|` | before | after | true fraction clipped |
|---|---:|---:|---:|
| 0.0 | 0.000000 | 0.000000 | 0.000000 |
| 0.1 | 0.000000 | 0.000000 | 0.000000 |
| 0.2 | 0.000000 | 0.000000 | 0.000000 |
| 0.5 | 0.000000 | **1.000000** | 1.000000 |
| 1.0 | 0.000000 | **1.000000** | 1.000000 |
| 10.0 | 0.000000 | **1.000000** | 1.000000 |

Masking half, with only the first 2 of 8 timesteps valid and every valid timestep outside the
trust region: before `0.0`, after `1.0`; the unmasked mean would have been `0.25`.

`critic/value_loss` is bit-identical across the change in all of the above.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
