### PR TITLE
fix(scheduler): avoid resending inherited env

### DIFF
--- a/rlinf/scheduler/cluster/cluster.py
+++ b/rlinf/scheduler/cluster/cluster.py
@@ -832,13 +832,18 @@ class Cluster:
                 merged_env_vars,
                 self._runtime_code_sync_strip_roots,
             )
+        runtime_env_vars = {
+            key: value
+            for key, value in merged_env_vars.items()
+            if node.default_env_vars.get(key) != value
+        }
         runtime_env_worker = Cluster._combine_ray_runtime_env(
             Cluster._job_code_sync_fragment_for_child_runtime_env(
                 self._ray_code_sync_fragment
             ),
             {
                 "py_executable": python_interpreter_path,
-                "env_vars": merged_env_vars,
+                "env_vars": runtime_env_vars,
             },
         )
 

--- a/tests/unit_tests/test_cluster_config.py
+++ b/tests/unit_tests/test_cluster_config.py
@@ -1040,6 +1040,35 @@ def test_cluster_env_configs_applied_in_worker_launch():
     assert pythonpath_values[0].split(os.pathsep)[0] == str(tests_root)
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-specific argv limit")
+def test_worker_launch_with_large_inherited_environment(monkeypatch):
+    inherited_env = {
+        f"RLINF_TEST_INHERITED_{index:04d}": "x" * 64 for index in range(3000)
+    }
+    for key, value in inherited_env.items():
+        monkeypatch.setenv(key, value)
+
+    _reset_cluster_singleton()
+    cluster = Cluster(num_nodes=1)
+    placement = NodePlacementStrategy([0])
+    worker_group = EnvConfigCheckWorker.create_group().launch(
+        cluster=cluster,
+        placement_strategy=placement,
+        name="large_inherited_env_launch",
+    )
+
+    try:
+        first_key = next(iter(inherited_env))
+        last_key = next(reversed(inherited_env))
+        assert worker_group.get_env_marker(first_key).wait() == [
+            inherited_env[first_key]
+        ]
+        assert worker_group.get_env_marker(last_key).wait() == [inherited_env[last_key]]
+    finally:
+        worker_group._close()
+        _reset_cluster_singleton()
+
+
 def test_cluster_env_configs_path_append_mode_in_worker_launch():
     path_env_key = path_merge_test_env_var()
     custom_path = "/tmp/rlinf-custom-path-append"


### PR DESCRIPTION
### Description

- Keep the existing worker environment merge order.
- Pass only values that differ from the node's inherited environment through Ray `runtime_env`.
- Add a regression test for worker startup with a large inherited environment.

### Motivation and Context

Closes #1531.

Ray workers already inherit the environment captured when the raylet starts. Sending the same environment again through `runtime_env` serializes it into a single worker command-line argument. On Linux, a large Kubernetes-injected environment can exceed `MAX_ARG_STRLEN`, so the worker never starts and eventually times out during registration.

### How has this been tested?

Tested on Linux with Python 3.11 and Ray 2.58.0:

- `pytest -q tests/unit_tests/test_cluster_config.py::test_worker_launch_with_large_inherited_environment`
- `pytest -q tests/unit_tests/test_cluster_config.py::test_cluster_env_configs_applied_in_worker_launch`
- Ruff lint and format checks on both changed files

### Additional information (optional, e.g., figures and logs):

In the original ACP reproduction, the node had 6,268 inherited environment variables. Worker registration timed out before this change; after filtering inherited values, ten workers started successfully while explicit environment overrides remained available.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
