### PR TITLE
fix(vllm): pass the whole output list to print_vllm_outputs

### DIFF
--- a/rlinf/workers/rollout/vllm/vllm_worker.py
+++ b/rlinf/workers/rollout/vllm/vllm_worker.py
@@ -165,8 +165,7 @@ class VLLMWorker(Worker):
                 input_ids=prompt_ids,
                 sampling_params=self._validate_sampling_params,
             )
-        for request_output in vllm_outputs:
-            print_vllm_outputs(request_output, self._tokenizer)
+        print_vllm_outputs(vllm_outputs)
 
     async def offload_engine(self) -> None:
         """


### PR DESCRIPTION
### Problem

`VLLMWorker._validate_weight_at_first()` cannot print anything — it raises
`TypeError` on the first output.

```python
# rlinf/workers/rollout/vllm/vllm_worker.py:168
for request_output in vllm_outputs:
    print_vllm_outputs(request_output, self._tokenizer)
```

but the helper takes exactly one argument, the *list*, and does the iteration itself:

```python
# rlinf/workers/rollout/utils.py:54
def print_vllm_outputs(outputs: list["RequestOutput"]):
    for output in outputs:
        prompt = output.prompt
        generated_text = output.outputs[0].text
        ...
```

So the call site is wrong twice over: it passes a second positional argument the helper
does not accept, and it passes a single `RequestOutput` where a list is expected.
There is no tokenizer parameter — unlike `print_sglang_outputs(prompts, outputs, tokenizer)`,
which is presumably where the extra argument was copied from.

The only other caller in the tree gets it right:

```python
# rlinf/workers/rollout/utils.py:70
def print_multi_outputs(resps_all: list[list["RequestOutput"]]):
    for i, resps in enumerate(resps_all):
        with sharp_cover(f"vllm dp {i}"):
            print_vllm_outputs(resps)          # <- one arg, the list
```

### Fix

Drop the loop and hand the list straight to the helper, matching `print_multi_outputs`.

### Verification

The defect is a signature mismatch, so no engine run is needed to demonstrate it. I extracted
`print_vllm_outputs`'s signature from `main` (`66604ba`) via AST and replayed both call shapes
through `inspect.Signature.bind`:

```
   TypeError call site vllm_worker.py:169  print_vllm_outputs(o, tok)   (outputs)
              -> too many positional arguments
   OK        sibling  utils.py:70          print_vllm_outputs(resps)    (outputs)
```

### One thing I did not change

For symmetry: `SGLangWorker` gates its `_validate_weight_at_first()` behind
`if self._cfg_rollout.validate_weight:` in `init_worker` (`sglang_worker.py:285`), but
`VLLMWorker.init_worker` never calls its own `_validate_weight_at_first()` — the vLLM path only
reads `cfg.rollout.validate_weight` to pick `load_format` (`vllm_worker.py:346`). That is why
this TypeError has not been hit in practice. Wiring the call up looked like a behavior change
rather than a bug fix, so I left it alone — happy to add it in this PR if you'd like the two
backends to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
