### PR TITLE
feat(eval): add ApxInf backend for OpenPI LIBERO evaluation

### DIFF
--- a/docs/source-en/rst_source/evaluations/guides/libero.rst
+++ b/docs/source-en/rst_source/evaluations/guides/libero.rst
@@ -63,6 +63,9 @@ Available under ``evaluations/libero/``:
    * - ``libero_10_openpi_pi05_eval.yaml``
      - Long (libero_10)
      - π₀.₅
+   * - ``libero_10_apxinf_pi05_eval.yaml``
+     - Long (libero_10)
+     - π₀.₅ (ApxInf backend)
    * - ``libero_10_openvlaoft_eval.yaml``
      - Long (libero_10)
      - OpenVLA-OFT
@@ -97,6 +100,29 @@ Copy or edit the target YAML and set at least ``rollout.model.model_path``. See 
 **Step 4: Check results**
 
 The terminal prints ``eval/success_once``; see :doc:`../reference/results` for logs.
+
+ApxInf Backend
+--------------
+
+The ApxInf path is evaluation-only. Install the official
+`ApxInf <https://github.com/infinigence/ApxInf>`_ Python frontend and CUDA
+binding in the RLinf runtime, then point ``APXINF_PI05_MODEL_DIR`` at a
+checkpoint directory containing ``config.json``, ``model.safetensors``,
+``tokenizer.model``, and ``norm_stats.json``:
+
+.. code-block:: bash
+
+   export APXINF_PI05_MODEL_DIR=/path/to/pi05_libero_base
+   bash evaluations/run_eval.sh libero libero_10_apxinf_pi05_eval
+
+This config keeps the native OpenPI contract: two already-oriented LIBERO
+images, an 8-D state, a state-free PI0.5 prompt, 5 flow steps, a 10-action
+prediction horizon, and execution of only the first 5 actions. ApxInf owns
+resize, tokenization, checkpoint normalization, inference, and action
+unnormalization. Set ``rollout.model.apxinf.noise_source=observation`` and pass
+an explicit ``[B,10,32]`` noise tensor when doing paired numerical parity tests.
+The default 10 environments x 10 rollout epochs evaluate 10 reset states for
+each LIBERO-10 task (100 trajectories total).
 
 .. _libero-eval-config:
 

--- a/docs/source-en/rst_source/evaluations/guides/libero.rst
+++ b/docs/source-en/rst_source/evaluations/guides/libero.rst
@@ -117,10 +117,12 @@ checkpoint directory containing ``config.json``, ``model.safetensors``,
 
 This config keeps the native OpenPI contract: two already-oriented LIBERO
 images, an 8-D state, a state-free PI0.5 prompt, 5 flow steps, a 10-action
-prediction horizon, and execution of only the first 5 actions. ApxInf owns
-resize, tokenization, checkpoint normalization, inference, and action
-unnormalization. Set ``rollout.model.apxinf.noise_source=observation`` and pass
-an explicit ``[B,10,32]`` noise tensor when doing paired numerical parity tests.
+prediction horizon, and execution of only the first 5 actions. RLinf's OpenPI
+transforms own resize, tokenization, checkpoint normalization and action
+unnormalization. ApxInf's low-level ``Model.infer_rgb`` API owns only model
+inference and, by default, initial Gaussian noise sampling. Set
+``rollout.model.apxinf.noise_source=observation`` and pass an explicit
+``[B,10,32]`` noise tensor when doing paired numerical parity tests.
 The default 10 environments x 10 rollout epochs evaluate 10 reset states for
 each LIBERO-10 task (100 trajectories total).
 

--- a/docs/source-zh/rst_source/evaluations/guides/libero.rst
+++ b/docs/source-zh/rst_source/evaluations/guides/libero.rst
@@ -116,8 +116,9 @@ ApxInf 接入仅用于评测。先在 RLinf 运行环境中安装官方
 
 该配置保持原生 OpenPI 语义：两路已经完成方向处理的 LIBERO 图像、8 维
 state、PI0.5 的无 state prompt、5 个 flow step、预测 10 步并只执行前 5 步。
-resize、tokenize、checkpoint 归一化、模型推理及 action 反归一化均由 ApxInf
-负责。做成对数值对齐时，可设置
+resize、tokenize、checkpoint 归一化与 action 反归一化由 RLinf 原生 OpenPI
+transforms 负责；ApxInf 的底层 ``Model.infer_rgb`` 只负责模型推理，并默认
+负责初始高斯 noise 采样。做成对数值对齐时，可设置
 ``rollout.model.apxinf.noise_source=observation``，并传入显式的
 ``[B,10,32]`` noise tensor。
 默认使用 10 个环境执行 10 个 rollout epoch，对 LIBERO-10 的每个任务评测

--- a/docs/source-zh/rst_source/evaluations/guides/libero.rst
+++ b/docs/source-zh/rst_source/evaluations/guides/libero.rst
@@ -63,6 +63,9 @@ LIBERO 是基于 robosuite（MuJoCo）的机器人操作仿真基准，涵盖 Sp
    * - ``libero_10_openpi_pi05_eval.yaml``
      - Long (libero_10)
      - π₀.₅
+   * - ``libero_10_apxinf_pi05_eval.yaml``
+     - Long (libero_10)
+     - π₀.₅（ApxInf backend）
    * - ``libero_10_openvlaoft_eval.yaml``
      - Long (libero_10)
      - OpenVLA-OFT
@@ -97,6 +100,28 @@ DreamZero SGLang backend 见 :doc:`dreamzero_sglang`。Cosmos3 SGLang backend �
 **Step 4：查看结果**
 
 终端输出 ``eval/success_once``；日志见 :doc:`../reference/results`。
+
+ApxInf 推理后端
+---------------
+
+ApxInf 接入仅用于评测。先在 RLinf 运行环境中安装官方
+`ApxInf <https://github.com/infinigence/ApxInf>`_ Python 前端与 CUDA binding，
+再将 ``APXINF_PI05_MODEL_DIR`` 指向包含 ``config.json``、
+``model.safetensors``、``tokenizer.model`` 与 ``norm_stats.json`` 的 checkpoint：
+
+.. code-block:: bash
+
+   export APXINF_PI05_MODEL_DIR=/path/to/pi05_libero_base
+   bash evaluations/run_eval.sh libero libero_10_apxinf_pi05_eval
+
+该配置保持原生 OpenPI 语义：两路已经完成方向处理的 LIBERO 图像、8 维
+state、PI0.5 的无 state prompt、5 个 flow step、预测 10 步并只执行前 5 步。
+resize、tokenize、checkpoint 归一化、模型推理及 action 反归一化均由 ApxInf
+负责。做成对数值对齐时，可设置
+``rollout.model.apxinf.noise_source=observation``，并传入显式的
+``[B,10,32]`` noise tensor。
+默认使用 10 个环境执行 10 个 rollout epoch，对 LIBERO-10 的每个任务评测
+10 个 reset state，共 100 条轨迹。
 
 .. _libero-eval-config:
 

--- a/evaluations/eval_embodied_agent.py
+++ b/evaluations/eval_embodied_agent.py
@@ -43,12 +43,21 @@ def main(cfg) -> None:
     component_placement = HybridComponentPlacement(cfg, cluster)
 
     # Create rollout worker group. Select the worker by ``rollout_backend``:
-    # only ``sglang`` and ``huggingface`` are supported here (vllm is intentionally not wired in);
+    # ``apxinf`` is an eval-only in-process backend. vLLM is intentionally not
+    # wired into embodied evaluation.
     rollout_placement = component_placement.get_strategy("rollout")
     rollout_backend = cfg.rollout.get("rollout_backend", "huggingface")
     # Default env worker; RTC on the huggingface path overrides it below.
     env_worker_cls = EnvWorker
-    if rollout_backend == "sglang":
+    if rollout_backend == "apxinf":
+        from rlinf.workers.rollout.apxinf import ApxInfRolloutWorker
+
+        rollout_group = ApxInfRolloutWorker.create_group(cfg).launch(
+            cluster,
+            name=cfg.rollout.group_name,
+            placement_strategy=rollout_placement,
+        )
+    elif rollout_backend == "sglang":
         from rlinf.workers.rollout.utils import get_rollout_backend_worker
 
         rollout_group = (

--- a/evaluations/libero/libero_10_apxinf_pi05_eval.yaml
+++ b/evaluations/libero/libero_10_apxinf_pi05_eval.yaml
@@ -83,6 +83,3 @@ rollout:
       # ApxInf owns initial Gaussian sampling. For paired parity tests set this
       # to "observation" and provide an explicit [B,10,32] noise tensor.
       noise_source: "apxinf"
-      discrete_state: false
-      norm_key: "actions"
-      num_views: 2

--- a/evaluations/libero/libero_10_apxinf_pi05_eval.yaml
+++ b/evaluations/libero/libero_10_apxinf_pi05_eval.yaml
@@ -1,0 +1,88 @@
+defaults:
+  - env/libero_10@env.eval
+  - model/pi0_5@rollout.model
+  - override hydra/job_logging: stdout
+  - _self_
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  searchpath:
+    - file://${oc.env:EMBODIED_PATH}/config/
+
+cluster:
+  num_nodes: 1
+  component_placement:
+    env,rollout: all
+
+runner:
+  task_type: embodied_eval
+  logger:
+    log_path: "../results"
+    project_name: rlinf
+    experiment_name: "libero_10_apxinf_pi05_eval"
+    logger_backends: ["tensorboard"]
+  max_epochs: 1000
+  max_steps: -1
+  only_eval: true
+  val_check_interval: -1
+  save_interval: -1
+  resume_dir: null
+  ckpt_path: null
+
+env:
+  group_name: "EnvGroup"
+  eval:
+    # ApxInf currently exposes a single-sample PI0.5 policy. Keep the simulator
+    # fan-out bounded and evaluate 10 reset states per LIBERO-10 task (100 total).
+    rollout_epoch: 10
+    total_num_envs: 10
+    auto_reset: true
+    ignore_terminations: true
+    max_episode_steps: 520
+    max_steps_per_rollout_epoch: 520
+    group_size: 1
+    is_eval: true
+    video_cfg:
+      save_video: false
+      video_base_dir: ${runner.logger.log_path}/video/eval
+
+rollout:
+  group_name: "RolloutGroup"
+  rollout_backend: "apxinf"
+  generation_backend: "apxinf"
+  recompute_logprobs: false
+  unnorm_key: libero_10
+  enable_offload: false
+  pipeline_stage_num: 1
+
+  model:
+    # Official lerobot/pi05_libero_base assets converted for ApxInf. The folder
+    # must contain config.json, tokenizer.model, norm_stats.json and weights.
+    model_path: ${oc.env:APXINF_PI05_MODEL_DIR}
+    model_type: "openpi"
+    precision: null
+    num_action_chunks: 5
+    action_dim: 7
+    openpi:
+      config_name: "pi05_libero"
+      num_images_in_input: 2
+      num_steps: 5
+      noise_method: "flow_sde"
+      noise_level: 0.3
+      action_chunk: ${..num_action_chunks}
+      action_env_dim: ${..action_dim}
+    apxinf:
+      model_type: "pi05"
+      precision: "bf16"
+      action_horizon: 10
+      num_flow_steps: ${..openpi.num_steps}
+      flow_start_time: 1.0
+      seed: 0
+      # ApxInf owns initial Gaussian sampling. For paired parity tests set this
+      # to "observation" and provide an explicit [B,10,32] noise tensor.
+      noise_source: "apxinf"
+      discrete_state: false
+      norm_key: "actions"
+      num_views: 2

--- a/rlinf/models/embodiment/openpi/apxinf_adapter.py
+++ b/rlinf/models/embodiment/openpi/apxinf_adapter.py
@@ -1,0 +1,269 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapter from RLinf's OpenPI observation contract to ApxInf's PI0.5 policy.
+
+The LIBERO environment already owns embodiment-specific processing: camera
+selection/orientation and the 8-D state layout.  This adapter deliberately does
+not repeat those transforms.  ApxInf owns model-specific processing (resize,
+tokenization, optional state normalization, flow inference and action
+unnormalization) through ``AutoPolicy``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+import torch
+from omegaconf import DictConfig
+
+
+def _to_numpy(value: Any) -> np.ndarray:
+    if torch.is_tensor(value):
+        value = value.detach().cpu().numpy()
+    return np.ascontiguousarray(value)
+
+
+class OpenPIApxInfAdapter:
+    """Run an ApxInf PI0.5 policy behind RLinf's batched eval interface."""
+
+    IMAGE_KEYS = ("observation/image", "observation/wrist_image")
+
+    def __init__(
+        self,
+        model_cfg: DictConfig | Mapping[str, Any],
+        device: str,
+        *,
+        policy: Any | None = None,
+    ) -> None:
+        self.model_cfg = model_cfg
+        self.apxinf_cfg = model_cfg.get("apxinf", {})
+        self.action_dim = int(model_cfg.get("action_dim", 7))
+        self.num_action_chunks = int(model_cfg.get("num_action_chunks"))
+        self.action_horizon = int(self.apxinf_cfg.get("action_horizon", 10))
+        self.num_flow_steps = int(
+            self.apxinf_cfg.get(
+                "num_flow_steps", model_cfg.get("openpi", {}).get("num_steps", 10)
+            )
+        )
+        self.noise_source = str(self.apxinf_cfg.get("noise_source", "apxinf"))
+        self.seed = int(self.apxinf_cfg.get("seed", 0))
+        self.device = str(device)
+
+        self._validate_config()
+        self._noise_generator = None
+        if self.noise_source == "torch":
+            self._noise_generator = torch.Generator(device=self.device)
+            self._noise_generator.manual_seed(self.seed)
+
+        self.policy = policy if policy is not None else self._load_policy()
+        self._validate_policy_contract()
+
+    def _validate_config(self) -> None:
+        if self.num_action_chunks <= 0:
+            raise ValueError("rollout.model.num_action_chunks must be positive")
+        if self.action_horizon < self.num_action_chunks:
+            raise ValueError(
+                "ApxInf action_horizon must be at least num_action_chunks; got "
+                f"{self.action_horizon} < {self.num_action_chunks}"
+            )
+        if self.action_dim <= 0:
+            raise ValueError("rollout.model.action_dim must be positive")
+        if self.num_flow_steps <= 0:
+            raise ValueError("ApxInf num_flow_steps must be positive")
+        if self.noise_source not in {"apxinf", "torch", "observation"}:
+            raise ValueError(
+                "ApxInf noise_source must be one of: apxinf, torch, observation"
+            )
+
+        openpi_cfg = self.model_cfg.get("openpi", {})
+        config_name = str(openpi_cfg.get("config_name", "pi05_libero"))
+        if config_name != "pi05_libero":
+            raise ValueError(
+                "The initial ApxInf backend supports only OpenPI pi05_libero; "
+                f"got {config_name!r}"
+            )
+        configured_steps = int(openpi_cfg.get("num_steps", self.num_flow_steps))
+        if configured_steps != self.num_flow_steps:
+            raise ValueError(
+                "ApxInf num_flow_steps must match OpenPI num_steps for parity; "
+                f"got {self.num_flow_steps} and {configured_steps}"
+            )
+        noise_method = str(openpi_cfg.get("noise_method", "flow_ode"))
+        if noise_method not in {"flow_ode", "flow_sde"}:
+            raise ValueError(
+                "ApxInf PI0.5 currently implements flow ODE inference; only "
+                "flow_ode, or RLinf eval-mode flow_sde (which resolves to ODE), "
+                f"is supported, got {noise_method!r}"
+            )
+
+    def _load_policy(self):
+        try:
+            from apxinf import AutoPolicy
+        except ImportError as error:
+            raise ImportError(
+                "ApxInf is not importable in the rollout worker. Install the "
+                "official infinigence/ApxInf Python package and apxinf_py binding "
+                "in the RLinf runtime environment."
+            ) from error
+
+        model_path = self.model_cfg.get("model_path")
+        if not model_path:
+            raise ValueError("rollout.model.model_path is required for ApxInf")
+
+        kwargs: dict[str, Any] = {
+            "model_type": str(self.apxinf_cfg.get("model_type", "pi05")),
+            "device": self.device,
+            "precision": str(self.apxinf_cfg.get("precision", "bf16")),
+            "norm_key": str(self.apxinf_cfg.get("norm_key", "actions")),
+            "action_dim": self.action_dim,
+            "action_horizon": self.action_horizon,
+            "num_flow_steps": self.num_flow_steps,
+            "flow_start_time": float(self.apxinf_cfg.get("flow_start_time", 1.0)),
+            "seed": self.seed,
+            "discrete_state": bool(self.apxinf_cfg.get("discrete_state", False)),
+            "image_keys": self.IMAGE_KEYS,
+            "state_key": "observation/state",
+            "prompt_key": "prompt",
+            "metadata": {"backend": "rlinf-apxinf"},
+        }
+        for key in ("checkpoint", "calibration", "tactics", "tokenizer_path"):
+            value = self.apxinf_cfg.get(key, None)
+            if value:
+                kwargs[key] = str(value)
+        if self.apxinf_cfg.get("num_views", None) is not None:
+            kwargs["num_views"] = int(self.apxinf_cfg.get("num_views"))
+        if bool(self.apxinf_cfg.get("autotune", False)):
+            kwargs["autotune"] = True
+        return AutoPolicy.from_pretrained(str(model_path), **kwargs)
+
+    def _validate_policy_contract(self) -> None:
+        actual_horizon = int(self.policy.action_horizon)
+        actual_dim = int(self.policy.action_dim)
+        if actual_horizon != self.action_horizon:
+            raise ValueError(
+                f"ApxInf loaded action_horizon={actual_horizon}, expected "
+                f"{self.action_horizon}"
+            )
+        if actual_dim != self.action_dim:
+            raise ValueError(
+                f"ApxInf loaded action_dim={actual_dim}, expected {self.action_dim}"
+            )
+
+    @staticmethod
+    def _batch_size(env_obs: Mapping[str, Any]) -> int:
+        for value in env_obs.values():
+            if torch.is_tensor(value) or isinstance(value, np.ndarray):
+                return int(value.shape[0])
+            if isinstance(value, (list, tuple)):
+                return len(value)
+        raise ValueError("Cannot infer batch size from RLinf observation")
+
+    @staticmethod
+    def _item(value: Any, index: int) -> Any:
+        if torch.is_tensor(value):
+            return _to_numpy(value[index])
+        if isinstance(value, np.ndarray):
+            return np.ascontiguousarray(value[index])
+        if isinstance(value, (list, tuple)):
+            return value[index]
+        raise TypeError(f"Unsupported batched observation value: {type(value)!r}")
+
+    def _sample_noise(self, batch_size: int) -> np.ndarray | None:
+        if self.noise_source != "torch":
+            return None
+        model_dim = int(self.policy.metadata["model_action_dim"])
+        noise = torch.normal(
+            mean=0.0,
+            std=1.0,
+            size=(batch_size, self.action_horizon, model_dim),
+            generator=self._noise_generator,
+            device=self.device,
+            dtype=torch.float32,
+        )
+        return noise.cpu().numpy()
+
+    def predict_action_batch(
+        self, env_obs: Mapping[str, Any], *, mode: str = "eval"
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Convert and infer a batch without duplicating embodiment transforms."""
+        if mode != "eval":
+            raise ValueError("OpenPIApxInfAdapter is eval-only")
+        required = ("main_images", "wrist_images", "states", "task_descriptions")
+        missing = [key for key in required if key not in env_obs]
+        if missing:
+            raise KeyError(f"RLinf observation is missing keys: {missing}")
+        if env_obs.get("extra_view_images") is not None:
+            raise ValueError("pi05_libero ApxInf expects exactly two camera views")
+
+        batch_size = self._batch_size(env_obs)
+        for key in required:
+            value = env_obs[key]
+            if self._batch_size({key: value}) != batch_size:
+                raise ValueError(
+                    f"Observation field {key!r} has a mismatched batch size"
+                )
+
+        explicit_noise = env_obs.get("noise")
+        if self.noise_source == "observation" and explicit_noise is None:
+            raise ValueError("noise_source=observation requires env_obs['noise']")
+        sampled_noise = (
+            None if explicit_noise is not None else self._sample_noise(batch_size)
+        )
+
+        action_rows = []
+        timings = []
+        for index in range(batch_size):
+            observation = {
+                # LIBERO already rotated both images by 180 degrees. ApxInf's
+                # policy receives them unchanged and performs only model-level
+                # parse/resize processing.
+                "observation/image": self._item(env_obs["main_images"], index),
+                "observation/wrist_image": self._item(env_obs["wrist_images"], index),
+                "observation/state": self._item(env_obs["states"], index),
+                "prompt": self._item(env_obs["task_descriptions"], index),
+            }
+            noise = None
+            if explicit_noise is not None:
+                noise = self._item(explicit_noise, index)
+            elif sampled_noise is not None:
+                noise = sampled_noise[index]
+            result = self.policy.infer(observation, noise=noise)
+            actions = np.asarray(result["actions"], dtype=np.float32)
+            if actions.ndim != 2:
+                raise ValueError(
+                    f"ApxInf actions must have shape [horizon, dim], got {actions.shape}"
+                )
+            if actions.shape[0] < self.num_action_chunks:
+                raise ValueError(
+                    f"ApxInf returned {actions.shape[0]} actions, but RLinf must "
+                    f"execute {self.num_action_chunks}"
+                )
+            if actions.shape[1] != self.action_dim:
+                raise ValueError(
+                    f"ApxInf returned action_dim={actions.shape[1]}, expected "
+                    f"{self.action_dim}"
+                )
+            action_rows.append(actions[: self.num_action_chunks])
+            timings.append(result.get("timing", {}))
+
+        actions = torch.from_numpy(np.stack(action_rows, axis=0))
+        return actions, {"apxinf_timing": timings}
+
+    def close(self) -> None:
+        close = getattr(self.policy, "close", None)
+        if callable(close):
+            close()

--- a/rlinf/models/embodiment/openpi/apxinf_adapter.py
+++ b/rlinf/models/embodiment/openpi/apxinf_adapter.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Adapter from RLinf's OpenPI observation contract to ApxInf's PI0.5 policy.
+"""OpenPI-specific adapter for the ApxInf bare-model rollout backend.
 
-The LIBERO environment already owns embodiment-specific processing: camera
-selection/orientation and the 8-D state layout.  This adapter deliberately does
-not repeat those transforms.  ApxInf owns model-specific processing (resize,
-tokenization, optional state normalization, flow inference and action
-unnormalization) through ``AutoPolicy``.
+RLinf owns the complete OpenPI input/output transform chain. ApxInf receives
+only resized uint8 RGB views, token ids and optional flow noise through its L1
+``Model.infer_rgb`` API, and returns normalized model-space actions.
 """
 
 from __future__ import annotations
 
+import dataclasses
+import pathlib
+import time
 from collections.abc import Mapping
 from typing import Any
 
@@ -37,17 +38,262 @@ def _to_numpy(value: Any) -> np.ndarray:
     return np.ascontiguousarray(value)
 
 
-class OpenPIApxInfAdapter:
-    """Run an ApxInf PI0.5 policy behind RLinf's batched eval interface."""
+def _batch_size(env_obs: Mapping[str, Any]) -> int:
+    for value in env_obs.values():
+        if torch.is_tensor(value) or isinstance(value, np.ndarray):
+            return int(value.shape[0])
+        if isinstance(value, (list, tuple)):
+            return len(value)
+    raise ValueError("Cannot infer batch size from RLinf observation")
 
-    IMAGE_KEYS = ("observation/image", "observation/wrist_image")
+
+def _item(value: Any, index: int) -> Any:
+    if torch.is_tensor(value):
+        return _to_numpy(value[index])
+    if isinstance(value, np.ndarray):
+        return np.ascontiguousarray(value[index])
+    if isinstance(value, (list, tuple)):
+        return value[index]
+    raise TypeError(f"Unsupported batched observation value: {type(value)!r}")
+
+
+def _active_token_ids(transformed: Mapping[str, Any]) -> np.ndarray:
+    padded_token_ids = np.asarray(transformed["tokenized_prompt"])
+    token_mask = np.asarray(transformed["tokenized_prompt_mask"], dtype=np.bool_)
+    if padded_token_ids.shape != token_mask.shape:
+        raise ValueError(
+            "RLinf OpenPI token ids and mask have different shapes: "
+            f"{padded_token_ids.shape} and {token_mask.shape}"
+        )
+    # OpenPI pads prompts to max_token_len and passes a separate mask to its
+    # PyTorch model. ApxInf L1 has no mask argument, so give it only the active
+    # prefix; otherwise padding would become real text tokens.
+    token_ids = np.ascontiguousarray(padded_token_ids[token_mask], dtype=np.uint32)
+    if token_ids.size == 0:
+        raise ValueError("RLinf OpenPI produced an empty token sequence")
+    return token_ids
+
+
+class _RLInfOpenPITransforms:
+    """Build and run RLinf's native OpenPI transforms without PyTorch weights."""
+
+    def __init__(self, model_cfg: DictConfig | Mapping[str, Any]) -> None:
+        import openpi.shared.download as download
+        import openpi.transforms as transforms
+        from openpi.models.model import IMAGE_KEYS
+        from openpi.shared import normalize as normalize_lib
+        from openpi.training import checkpoints
+
+        from rlinf.models.embodiment.openpi.dataconfig import get_openpi_config
+
+        self.model_cfg = model_cfg
+        self.num_action_chunks = int(model_cfg.get("num_action_chunks"))
+        self.action_dim = int(model_cfg.get("action_dim"))
+        openpi_cfg = model_cfg.get("openpi", {})
+        config_name = str(openpi_cfg.get("config_name", "pi05_libero"))
+        data_kwargs = model_cfg.get("openpi_data", None)
+        train_config = get_openpi_config(
+            config_name,
+            model_path=model_cfg.get("model_path"),
+            data_kwargs=data_kwargs,
+        )
+
+        # Apply only genuine OpenPI model-config overrides. RLinf-only sampling
+        # fields (for example noise_method) are intentionally ignored here.
+        model_config = train_config.model
+        model_fields = {field.name for field in dataclasses.fields(model_config)}
+        overrides = {
+            key: value for key, value in openpi_cfg.items() if key in model_fields
+        }
+        if overrides:
+            model_config = dataclasses.replace(model_config, **overrides)
+
+        checkpoint_dir = pathlib.Path(
+            download.maybe_download(str(model_cfg.get("model_path")))
+        )
+        data_config = train_config.data.create(
+            train_config.assets_dirs,
+            model_config,
+        )
+
+        norm_stats_path = (
+            data_kwargs.get("norm_stats_path", None)
+            if data_kwargs is not None
+            else None
+        )
+        if norm_stats_path:
+            norm_dir = pathlib.Path(str(norm_stats_path)).expanduser()
+            if norm_dir.is_file():
+                norm_dir = norm_dir.parent
+            norm_stats = normalize_lib.load(norm_dir)
+        elif (checkpoint_dir / "norm_stats.json").is_file():
+            # Converted LeRobot/ApxInf checkpoints keep stats at the root.
+            norm_stats = normalize_lib.load(checkpoint_dir)
+        elif data_config.norm_stats is not None:
+            norm_stats = data_config.norm_stats
+        else:
+            if data_config.asset_id is None:
+                raise ValueError("OpenPI asset_id is required to load norm stats")
+            norm_stats = checkpoints.load_norm_stats(
+                checkpoint_dir,
+                data_config.asset_id,
+            )
+
+        self._input_transform = transforms.compose(
+            [
+                transforms.InjectDefaultPrompt(None),
+                *data_config.data_transforms.inputs,
+                transforms.Normalize(
+                    norm_stats,
+                    use_quantiles=data_config.use_quantile_norm,
+                ),
+                *data_config.model_transforms.inputs,
+            ]
+        )
+        self._output_transform = transforms.compose(
+            [
+                *data_config.model_transforms.outputs,
+                transforms.Unnormalize(
+                    norm_stats,
+                    use_quantiles=data_config.use_quantile_norm,
+                ),
+                *data_config.data_transforms.outputs,
+            ]
+        )
+        self._image_keys = tuple(IMAGE_KEYS)
+        self._config_name = config_name
+        state_indices = openpi_cfg.get("state_indices", None)
+        self._state_indices = list(state_indices) if state_indices else None
+
+    def _select_state(self, states: Any) -> Any:
+        if not self._state_indices:
+            return states
+        state_dim = int(states.shape[-1])
+        if state_dim == len(self._state_indices):
+            return states
+        if state_dim <= max(self._state_indices):
+            raise ValueError(
+                f"Cannot select state_indices={self._state_indices} "
+                f"from state dim {state_dim}"
+            )
+        if torch.is_tensor(states):
+            indices = torch.as_tensor(self._state_indices, device=states.device)
+            return states.index_select(-1, indices)
+        return np.asarray(states)[..., self._state_indices]
+
+    def _policy_observation(self, env_obs: Mapping[str, Any]) -> dict[str, Any]:
+        required = ("main_images", "states", "task_descriptions")
+        missing = [key for key in required if key not in env_obs]
+        if missing:
+            raise KeyError(f"RLinf observation is missing keys: {missing}")
+
+        states = self._select_state(env_obs["states"])
+        observation: dict[str, Any] = {
+            "observation/image": env_obs["main_images"],
+            "prompt": env_obs["task_descriptions"],
+        }
+        if "calvin" in self._config_name:
+            observation["observation/state_ee_pos"] = states[:, :3]
+            observation["observation/state_ee_rot"] = states[:, 3:6]
+            observation["observation/state_gripper"] = states[:, 6:7]
+        else:
+            observation["observation/state"] = states
+        if env_obs.get("wrist_images") is not None:
+            observation["observation/wrist_image"] = env_obs["wrist_images"]
+        if env_obs.get("extra_view_images") is not None:
+            observation["observation/extra_view_image"] = env_obs["extra_view_images"]
+        return observation
+
+    def preprocess_batch(
+        self,
+        env_obs: Mapping[str, Any],
+        *,
+        num_views: int,
+        image_size: int,
+    ) -> list[dict[str, np.ndarray]]:
+        """Return one L1 ApxInf request and postprocess context per env."""
+        policy_obs = self._policy_observation(env_obs)
+        batch_size = _batch_size(policy_obs)
+        for key, value in policy_obs.items():
+            if _batch_size({key: value}) != batch_size:
+                raise ValueError(f"Observation field {key!r} has mismatched batch size")
+
+        prepared = []
+        for index in range(batch_size):
+            sample = {key: _item(value, index) for key, value in policy_obs.items()}
+            transformed = self._input_transform(sample)
+            images = transformed["image"]
+            masks = transformed["image_mask"]
+            active_keys = [key for key in self._image_keys if bool(masks[key])]
+            if len(active_keys) != num_views:
+                raise ValueError(
+                    "RLinf OpenPI transforms produced "
+                    f"{len(active_keys)} active camera views {active_keys}, but "
+                    f"the ApxInf checkpoint expects {num_views}"
+                )
+            rgb_u8 = np.ascontiguousarray(
+                np.stack([images[key] for key in active_keys]),
+                dtype=np.uint8,
+            )
+            expected_rgb_shape = (num_views, image_size, image_size, 3)
+            if rgb_u8.shape != expected_rgb_shape:
+                raise ValueError(
+                    f"RLinf OpenPI RGB shape {rgb_u8.shape}, expected "
+                    f"{expected_rgb_shape}"
+                )
+            token_ids = _active_token_ids(transformed)
+            prepared.append(
+                {
+                    "rgb_u8": rgb_u8,
+                    "token_ids": token_ids,
+                    "state": np.ascontiguousarray(transformed["state"]),
+                }
+            )
+        return prepared
+
+    def postprocess_batch(
+        self,
+        normalized_actions: np.ndarray,
+        prepared: list[dict[str, np.ndarray]],
+    ) -> torch.Tensor:
+        """Run RLinf's native OpenPI output transforms on normalized actions."""
+        rows = []
+        for actions, context in zip(normalized_actions, prepared, strict=True):
+            output = self._output_transform(
+                {
+                    "actions": np.asarray(actions, dtype=np.float32),
+                    "state": context["state"],
+                }
+            )
+            row = np.asarray(output["actions"], dtype=np.float32)
+            if row.ndim != 2:
+                raise ValueError(
+                    f"RLinf OpenPI actions must be rank 2, got {row.shape}"
+                )
+            if row.shape[0] < self.num_action_chunks:
+                raise ValueError(
+                    f"RLinf OpenPI postprocess returned {row.shape[0]} actions, "
+                    f"but {self.num_action_chunks} must be executed"
+                )
+            if row.shape[1] != self.action_dim:
+                raise ValueError(
+                    f"RLinf OpenPI postprocess returned action_dim={row.shape[1]}, "
+                    f"expected {self.action_dim}"
+                )
+            rows.append(row[: self.num_action_chunks])
+        return torch.from_numpy(np.stack(rows))
+
+
+class OpenPIApxInfAdapter:
+    """Run ApxInf bare PI0.5 inference behind RLinf's OpenPI transforms."""
 
     def __init__(
         self,
         model_cfg: DictConfig | Mapping[str, Any],
         device: str,
         *,
-        policy: Any | None = None,
+        model: Any | None = None,
+        processor: Any | None = None,
     ) -> None:
         self.model_cfg = model_cfg
         self.apxinf_cfg = model_cfg.get("apxinf", {})
@@ -64,13 +310,25 @@ class OpenPIApxInfAdapter:
         self.device = str(device)
 
         self._validate_config()
+        self.model = model if model is not None else self._load_model()
+        self.processor = (
+            processor if processor is not None else _RLInfOpenPITransforms(model_cfg)
+        )
+        self._validate_model_contract()
+
         self._noise_generator = None
         if self.noise_source == "torch":
             self._noise_generator = torch.Generator(device=self.device)
             self._noise_generator.manual_seed(self.seed)
 
-        self.policy = policy if policy is not None else self._load_policy()
-        self._validate_policy_contract()
+        self.metadata = {
+            "backend": "rlinf-apxinf-l1",
+            "model_type": "pi05",
+            "action_horizon": int(self.model.action_horizon),
+            "model_action_dim": int(self.model.action_dim),
+            "num_views": int(self.model.num_views),
+            "image_size": int(self.model.image_size),
+        }
 
     def _validate_config(self) -> None:
         if self.num_action_chunks <= 0:
@@ -91,10 +349,10 @@ class OpenPIApxInfAdapter:
 
         openpi_cfg = self.model_cfg.get("openpi", {})
         config_name = str(openpi_cfg.get("config_name", "pi05_libero"))
-        if config_name != "pi05_libero":
+        if not config_name.startswith("pi05_"):
             raise ValueError(
-                "The initial ApxInf backend supports only OpenPI pi05_libero; "
-                f"got {config_name!r}"
+                "The ApxInf bare-model adapter currently supports PI0.5 OpenPI "
+                f"configs; got {config_name!r}"
             )
         configured_steps = int(openpi_cfg.get("num_steps", self.num_flow_steps))
         if configured_steps != self.num_flow_steps:
@@ -105,91 +363,82 @@ class OpenPIApxInfAdapter:
         noise_method = str(openpi_cfg.get("noise_method", "flow_ode"))
         if noise_method not in {"flow_ode", "flow_sde"}:
             raise ValueError(
-                "ApxInf PI0.5 currently implements flow ODE inference; only "
-                "flow_ode, or RLinf eval-mode flow_sde (which resolves to ODE), "
-                f"is supported, got {noise_method!r}"
+                "ApxInf PI0.5 implements flow ODE inference; only flow_ode, or "
+                "RLinf eval-mode flow_sde (which resolves to ODE), is supported; "
+                f"got {noise_method!r}"
             )
 
-    def _load_policy(self):
+    def _load_model(self):
         try:
-            from apxinf import AutoPolicy
+            import apxinf_py
         except ImportError as error:
             raise ImportError(
-                "ApxInf is not importable in the rollout worker. Install the "
-                "official infinigence/ApxInf Python package and apxinf_py binding "
-                "in the RLinf runtime environment."
+                "apxinf_py is not importable in the rollout worker. Install the "
+                "official infinigence/ApxInf CUDA Python binding."
             ) from error
 
         model_path = self.model_cfg.get("model_path")
         if not model_path:
             raise ValueError("rollout.model.model_path is required for ApxInf")
+        model_dir = pathlib.Path(str(model_path))
+        checkpoint = self.apxinf_cfg.get("checkpoint", None)
+        checkpoint_path = (
+            pathlib.Path(str(checkpoint))
+            if checkpoint
+            else model_dir / "model.safetensors"
+        )
+
+        tactics = self.apxinf_cfg.get("tactics", None)
+        if tactics is None:
+            try:
+                from apxinf._tactics import resolve_pi05_tactics
+
+                tactics = resolve_pi05_tactics(
+                    self.device,
+                    str(self.apxinf_cfg.get("precision", "bf16")),
+                    model_dir=model_dir,
+                    override=None,
+                    allow_missing=bool(self.apxinf_cfg.get("autotune", False)),
+                )
+            except ImportError:
+                tactics = None
 
         kwargs: dict[str, Any] = {
-            "model_type": str(self.apxinf_cfg.get("model_type", "pi05")),
             "device": self.device,
             "precision": str(self.apxinf_cfg.get("precision", "bf16")),
-            "norm_key": str(self.apxinf_cfg.get("norm_key", "actions")),
-            "action_dim": self.action_dim,
+            "autotune": bool(self.apxinf_cfg.get("autotune", False)),
             "action_horizon": self.action_horizon,
             "num_flow_steps": self.num_flow_steps,
             "flow_start_time": float(self.apxinf_cfg.get("flow_start_time", 1.0)),
-            "seed": self.seed,
-            "discrete_state": bool(self.apxinf_cfg.get("discrete_state", False)),
-            "image_keys": self.IMAGE_KEYS,
-            "state_key": "observation/state",
-            "prompt_key": "prompt",
-            "metadata": {"backend": "rlinf-apxinf"},
+            "sampling_seed": self.seed,
         }
-        for key in ("checkpoint", "calibration", "tactics", "tokenizer_path"):
-            value = self.apxinf_cfg.get(key, None)
-            if value:
-                kwargs[key] = str(value)
+        calibration = self.apxinf_cfg.get("calibration", None)
+        if calibration:
+            kwargs["calibration"] = str(calibration)
+        if tactics:
+            kwargs["tactics"] = str(tactics)
         if self.apxinf_cfg.get("num_views", None) is not None:
             kwargs["num_views"] = int(self.apxinf_cfg.get("num_views"))
-        if bool(self.apxinf_cfg.get("autotune", False)):
-            kwargs["autotune"] = True
-        return AutoPolicy.from_pretrained(str(model_path), **kwargs)
+        return apxinf_py.Model.load("pi05", str(checkpoint_path), **kwargs)
 
-    def _validate_policy_contract(self) -> None:
-        actual_horizon = int(self.policy.action_horizon)
-        actual_dim = int(self.policy.action_dim)
-        if actual_horizon != self.action_horizon:
+    def _validate_model_contract(self) -> None:
+        if int(self.model.action_horizon) != self.action_horizon:
             raise ValueError(
-                f"ApxInf loaded action_horizon={actual_horizon}, expected "
-                f"{self.action_horizon}"
+                f"ApxInf loaded action_horizon={self.model.action_horizon}, "
+                f"expected {self.action_horizon}"
             )
-        if actual_dim != self.action_dim:
-            raise ValueError(
-                f"ApxInf loaded action_dim={actual_dim}, expected {self.action_dim}"
-            )
-
-    @staticmethod
-    def _batch_size(env_obs: Mapping[str, Any]) -> int:
-        for value in env_obs.values():
-            if torch.is_tensor(value) or isinstance(value, np.ndarray):
-                return int(value.shape[0])
-            if isinstance(value, (list, tuple)):
-                return len(value)
-        raise ValueError("Cannot infer batch size from RLinf observation")
-
-    @staticmethod
-    def _item(value: Any, index: int) -> Any:
-        if torch.is_tensor(value):
-            return _to_numpy(value[index])
-        if isinstance(value, np.ndarray):
-            return np.ascontiguousarray(value[index])
-        if isinstance(value, (list, tuple)):
-            return value[index]
-        raise TypeError(f"Unsupported batched observation value: {type(value)!r}")
+        if int(self.model.action_dim) <= 0:
+            raise ValueError("ApxInf loaded an invalid model action dimension")
+        if int(self.model.num_views) <= 0:
+            raise ValueError("ApxInf loaded an invalid camera-view count")
 
     def _sample_noise(self, batch_size: int) -> np.ndarray | None:
         if self.noise_source != "torch":
             return None
-        model_dim = int(self.policy.metadata["model_action_dim"])
         noise = torch.normal(
             mean=0.0,
             std=1.0,
-            size=(batch_size, self.action_horizon, model_dim),
+            size=(batch_size, self.action_horizon, int(self.model.action_dim)),
             generator=self._noise_generator,
             device=self.device,
             dtype=torch.float32,
@@ -199,24 +448,16 @@ class OpenPIApxInfAdapter:
     def predict_action_batch(
         self, env_obs: Mapping[str, Any], *, mode: str = "eval"
     ) -> tuple[torch.Tensor, dict[str, Any]]:
-        """Convert and infer a batch without duplicating embodiment transforms."""
+        """Run RLinf transforms -> ApxInf L1 -> RLinf output transforms."""
         if mode != "eval":
             raise ValueError("OpenPIApxInfAdapter is eval-only")
-        required = ("main_images", "wrist_images", "states", "task_descriptions")
-        missing = [key for key in required if key not in env_obs]
-        if missing:
-            raise KeyError(f"RLinf observation is missing keys: {missing}")
-        if env_obs.get("extra_view_images") is not None:
-            raise ValueError("pi05_libero ApxInf expects exactly two camera views")
 
-        batch_size = self._batch_size(env_obs)
-        for key in required:
-            value = env_obs[key]
-            if self._batch_size({key: value}) != batch_size:
-                raise ValueError(
-                    f"Observation field {key!r} has a mismatched batch size"
-                )
-
+        prepared = self.processor.preprocess_batch(
+            env_obs,
+            num_views=int(self.model.num_views),
+            image_size=int(self.model.image_size),
+        )
+        batch_size = len(prepared)
         explicit_noise = env_obs.get("noise")
         if self.noise_source == "observation" and explicit_noise is None:
             raise ValueError("noise_source=observation requires env_obs['noise']")
@@ -224,46 +465,44 @@ class OpenPIApxInfAdapter:
             None if explicit_noise is not None else self._sample_noise(batch_size)
         )
 
-        action_rows = []
+        normalized_rows = []
         timings = []
-        for index in range(batch_size):
-            observation = {
-                # LIBERO already rotated both images by 180 degrees. ApxInf's
-                # policy receives them unchanged and performs only model-level
-                # parse/resize processing.
-                "observation/image": self._item(env_obs["main_images"], index),
-                "observation/wrist_image": self._item(env_obs["wrist_images"], index),
-                "observation/state": self._item(env_obs["states"], index),
-                "prompt": self._item(env_obs["task_descriptions"], index),
-            }
+        for index, model_input in enumerate(prepared):
             noise = None
             if explicit_noise is not None:
-                noise = self._item(explicit_noise, index)
+                noise = _item(explicit_noise, index)
             elif sampled_noise is not None:
                 noise = sampled_noise[index]
-            result = self.policy.infer(observation, noise=noise)
-            actions = np.asarray(result["actions"], dtype=np.float32)
-            if actions.ndim != 2:
-                raise ValueError(
-                    f"ApxInf actions must have shape [horizon, dim], got {actions.shape}"
-                )
-            if actions.shape[0] < self.num_action_chunks:
-                raise ValueError(
-                    f"ApxInf returned {actions.shape[0]} actions, but RLinf must "
-                    f"execute {self.num_action_chunks}"
-                )
-            if actions.shape[1] != self.action_dim:
-                raise ValueError(
-                    f"ApxInf returned action_dim={actions.shape[1]}, expected "
-                    f"{self.action_dim}"
-                )
-            action_rows.append(actions[: self.num_action_chunks])
-            timings.append(result.get("timing", {}))
 
-        actions = torch.from_numpy(np.stack(action_rows, axis=0))
+            started = time.perf_counter()
+            normalized = np.asarray(
+                self.model.infer_rgb(
+                    model_input["rgb_u8"],
+                    "nhwc",
+                    model_input["token_ids"],
+                    noise=noise,
+                ),
+                dtype=np.float32,
+            )
+            model_ms = (time.perf_counter() - started) * 1000.0
+            expected_shape = (self.action_horizon, int(self.model.action_dim))
+            if normalized.shape != expected_shape:
+                raise ValueError(
+                    f"ApxInf normalized actions have shape {normalized.shape}, "
+                    f"expected {expected_shape}"
+                )
+            if not np.isfinite(normalized).all():
+                raise FloatingPointError("ApxInf returned non-finite actions")
+            normalized_rows.append(normalized)
+            timings.append({"model_ms": model_ms})
+
+        actions = self.processor.postprocess_batch(
+            np.stack(normalized_rows),
+            prepared,
+        )
         return actions, {"apxinf_timing": timings}
 
     def close(self) -> None:
-        close = getattr(self.policy, "close", None)
+        close = getattr(self.model, "close", None)
         if callable(close):
             close()

--- a/rlinf/models/embodiment/openpi/apxinf_adapter.py
+++ b/rlinf/models/embodiment/openpi/apxinf_adapter.py
@@ -458,12 +458,12 @@ class OpenPIApxInfAdapter:
             image_size=int(self.model.image_size),
         )
         batch_size = len(prepared)
-        explicit_noise = env_obs.get("noise")
-        if self.noise_source == "observation" and explicit_noise is None:
-            raise ValueError("noise_source=observation requires env_obs['noise']")
-        sampled_noise = (
-            None if explicit_noise is not None else self._sample_noise(batch_size)
-        )
+        explicit_noise = None
+        if self.noise_source == "observation":
+            explicit_noise = env_obs.get("noise")
+            if explicit_noise is None:
+                raise ValueError("noise_source=observation requires env_obs['noise']")
+        sampled_noise = self._sample_noise(batch_size)
 
         normalized_rows = []
         timings = []

--- a/rlinf/workers/rollout/apxinf/__init__.py
+++ b/rlinf/workers/rollout/apxinf/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .apxinf_worker import ApxInfRolloutWorker
+
+__all__ = ["ApxInfRolloutWorker"]

--- a/rlinf/workers/rollout/apxinf/apxinf_worker.py
+++ b/rlinf/workers/rollout/apxinf/apxinf_worker.py
@@ -70,7 +70,7 @@ class ApxInfRolloutWorker(Worker):
         )
         self.log_info(
             "ApxInf policy loaded: "
-            f"device={device}, metadata={dict(self.apxinf_adapter.policy.metadata)}"
+            f"device={device}, metadata={dict(self.apxinf_adapter.metadata)}"
         )
 
     @staticmethod

--- a/rlinf/workers/rollout/apxinf/apxinf_worker.py
+++ b/rlinf/workers/rollout/apxinf/apxinf_worker.py
@@ -1,0 +1,141 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Eval-only ApxInf rollout worker for embodied environments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from omegaconf import DictConfig
+from tqdm import tqdm
+
+from rlinf.scheduler import Worker
+from rlinf.utils.obs_compression import decompress_obs, infer_obs_batch_size
+
+
+class ApxInfRolloutWorker(Worker):
+    """Drive ApxInf PI0.5 inference over RLinf eval channels."""
+
+    def __init__(self, cfg: DictConfig):
+        Worker.__init__(self)
+        self.cfg = cfg
+        self.model_cfg = cfg.rollout.model
+        assert cfg.runner.get("only_eval", True), (
+            "ApxInfRolloutWorker is eval-only; set runner.only_eval: true"
+        )
+        assert not cfg.runner.get("enable_decoupled_mode", False), (
+            "ApxInfRolloutWorker does not support runner.enable_decoupled_mode"
+        )
+
+        self.num_pipeline_stages = int(cfg.rollout.pipeline_stage_num)
+        eval_env_cfg = cfg.env.get("eval", None)
+        total_eval = int(eval_env_cfg.total_num_envs) if eval_env_cfg else 0
+        self.eval_batch_size = total_eval // self.num_pipeline_stages
+        self.eval_rollout_epoch = int(eval_env_cfg.rollout_epoch) if eval_env_cfg else 1
+        self.n_eval_chunk_steps = (
+            int(eval_env_cfg.max_steps_per_rollout_epoch)
+            // int(self.model_cfg.num_action_chunks)
+            if eval_env_cfg is not None
+            else 0
+        )
+        self.apxinf_adapter = None
+
+    def init_worker(self) -> None:
+        from rlinf.models.embodiment.openpi.apxinf_adapter import (
+            OpenPIApxInfAdapter,
+        )
+
+        current_device = self.torch_platform.current_device()
+        device = (
+            f"cuda:{current_device}"
+            if isinstance(current_device, int)
+            else str(current_device)
+        )
+        self.apxinf_adapter = OpenPIApxInfAdapter(
+            self.model_cfg,
+            device,
+        )
+        self.log_info(
+            "ApxInf policy loaded: "
+            f"device={device}, metadata={dict(self.apxinf_adapter.policy.metadata)}"
+        )
+
+    @staticmethod
+    def _infer_env_batch_size(obs_batch: dict[str, Any]) -> int:
+        return infer_obs_batch_size(obs_batch)
+
+    @staticmethod
+    def _merge_obs_batches(obs_batches: list[dict[str, Any]]) -> dict[str, Any]:
+        if not obs_batches:
+            return {}
+        obs_batches = [decompress_obs(batch) for batch in obs_batches]
+        obs_dicts = [batch["obs"] if "obs" in batch else batch for batch in obs_batches]
+        merged: dict[str, Any] = {}
+        for key in obs_dicts[0]:
+            values = [obs[key] for obs in obs_dicts]
+            first = next((value for value in values if value is not None), None)
+            if first is None:
+                merged[key] = None
+            elif isinstance(first, torch.Tensor):
+                merged[key] = torch.cat(values, dim=0)
+            elif isinstance(first, list):
+                merged[key] = [item for value in values for item in value]
+            else:
+                merged[key] = values
+        reset = any(batch.get("final_obs") is not None for batch in obs_batches)
+        return {"obs": merged, "reset": reset}
+
+    def predict(self, env_obs: dict[str, Any]) -> torch.Tensor:
+        actions, _ = self.apxinf_adapter.predict_action_batch(env_obs, mode="eval")
+        return actions.detach().cpu().contiguous()
+
+    async def evaluate(self, input_channel, output_channel):
+        for _ in tqdm(
+            range(self.eval_rollout_epoch),
+            desc="Evaluating Rollout Epochs",
+            disable=(self._rank != 0),
+        ):
+            for _ in range(self.n_eval_chunk_steps):
+                for stage_id in range(self.num_pipeline_stages):
+                    env_output = await self.recv_from(
+                        group_name=self.cfg.env.group_name,
+                        channel=input_channel,
+                        tag="eval_rollout_results",
+                        route_key=stage_id,
+                        async_op=True,
+                        batch_size=self.eval_batch_size,
+                        merge_fn=self._merge_obs_batches,
+                        infer_batch_size_fn=self._infer_env_batch_size,
+                    ).async_wait()
+                    actions = self.predict(env_output["obs"])
+                    self.send_to(
+                        group_name=self.cfg.env.group_name,
+                        channel=output_channel,
+                        data=actions,
+                        tag="eval_rollout_results",
+                        route_key=stage_id,
+                        async_op=True,
+                        batch_size=self.eval_batch_size,
+                    )
+
+    def shutdown_engine(self) -> None:
+        adapter = getattr(self, "apxinf_adapter", None)
+        if adapter is not None:
+            adapter.close()
+            self.apxinf_adapter = None
+
+    def __del__(self):
+        self.shutdown_engine()

--- a/tests/unit_tests/test_apxinf_adapter.py
+++ b/tests/unit_tests/test_apxinf_adapter.py
@@ -1,0 +1,156 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from rlinf.models.embodiment.openpi.apxinf_adapter import OpenPIApxInfAdapter
+
+
+class _FakePolicy:
+    action_horizon = 10
+    action_dim = 7
+    metadata = {"model_action_dim": 32}
+
+    def __init__(self):
+        self.calls = []
+        self.closed = False
+
+    def infer(self, observation, *, noise=None):
+        self.calls.append((observation, noise))
+        offset = len(self.calls) * 1000
+        actions = np.arange(70, dtype=np.float32).reshape(10, 7) + offset
+        return {"actions": actions, "timing": {"model_ms": 1.0}}
+
+    def close(self):
+        self.closed = True
+
+
+def _model_cfg(**apxinf_overrides):
+    apxinf = {
+        "action_horizon": 10,
+        "num_flow_steps": 5,
+        "noise_source": "apxinf",
+        "seed": 0,
+        **apxinf_overrides,
+    }
+    return OmegaConf.create(
+        {
+            "model_type": "openpi",
+            "model_path": "/not/loaded/in/unit/test",
+            "num_action_chunks": 5,
+            "action_dim": 7,
+            "openpi": {
+                "config_name": "pi05_libero",
+                "num_steps": 5,
+                "noise_method": "flow_sde",
+                "noise_level": 0.3,
+            },
+            "apxinf": apxinf,
+        }
+    )
+
+
+def _env_obs(batch_size=2):
+    main = torch.arange(batch_size * 4 * 5 * 3, dtype=torch.uint8).reshape(
+        batch_size, 4, 5, 3
+    )
+    wrist = main + 1
+    return {
+        "main_images": main,
+        "wrist_images": wrist,
+        "extra_view_images": None,
+        "states": torch.arange(batch_size * 8, dtype=torch.float32).reshape(
+            batch_size, 8
+        ),
+        "task_descriptions": [f"task {index}" for index in range(batch_size)],
+    }
+
+
+def test_maps_rlinf_batch_without_repeating_env_transforms_and_slices_time():
+    policy = _FakePolicy()
+    adapter = OpenPIApxInfAdapter(_model_cfg(), "cpu", policy=policy)
+    env_obs = _env_obs()
+
+    actions, result = adapter.predict_action_batch(env_obs, mode="eval")
+
+    assert actions.shape == (2, 5, 7)
+    assert actions.dtype == torch.float32
+    np.testing.assert_array_equal(
+        policy.calls[0][0]["observation/image"], env_obs["main_images"][0].numpy()
+    )
+    np.testing.assert_array_equal(
+        policy.calls[1][0]["observation/wrist_image"],
+        env_obs["wrist_images"][1].numpy(),
+    )
+    np.testing.assert_array_equal(
+        policy.calls[0][0]["observation/state"], env_obs["states"][0].numpy()
+    )
+    assert policy.calls[1][0]["prompt"] == "task 1"
+    assert len(result["apxinf_timing"]) == 2
+
+
+def test_explicit_noise_is_split_and_forwarded_exactly():
+    policy = _FakePolicy()
+    adapter = OpenPIApxInfAdapter(
+        _model_cfg(noise_source="observation"), "cpu", policy=policy
+    )
+    env_obs = _env_obs()
+    env_obs["noise"] = torch.arange(2 * 10 * 32, dtype=torch.float32).reshape(2, 10, 32)
+
+    adapter.predict_action_batch(env_obs)
+
+    np.testing.assert_array_equal(policy.calls[0][1], env_obs["noise"][0].numpy())
+    np.testing.assert_array_equal(policy.calls[1][1], env_obs["noise"][1].numpy())
+
+
+def test_torch_noise_is_reproducible_and_has_model_shape():
+    obs = _env_obs()
+    policy_a = _FakePolicy()
+    policy_b = _FakePolicy()
+    adapter_a = OpenPIApxInfAdapter(
+        _model_cfg(noise_source="torch", seed=7), "cpu", policy=policy_a
+    )
+    adapter_b = OpenPIApxInfAdapter(
+        _model_cfg(noise_source="torch", seed=7), "cpu", policy=policy_b
+    )
+
+    adapter_a.predict_action_batch(obs)
+    adapter_b.predict_action_batch(obs)
+
+    assert policy_a.calls[0][1].shape == (10, 32)
+    np.testing.assert_array_equal(policy_a.calls[0][1], policy_b.calls[0][1])
+    np.testing.assert_array_equal(policy_a.calls[1][1], policy_b.calls[1][1])
+
+
+def test_rejects_mismatched_openpi_and_apxinf_flow_steps():
+    with pytest.raises(ValueError, match="must match OpenPI num_steps"):
+        OpenPIApxInfAdapter(_model_cfg(num_flow_steps=10), "cpu", policy=_FakePolicy())
+
+
+def test_rejects_more_than_two_libero_views():
+    adapter = OpenPIApxInfAdapter(_model_cfg(), "cpu", policy=_FakePolicy())
+    obs = _env_obs()
+    obs["extra_view_images"] = torch.zeros_like(obs["main_images"])
+    with pytest.raises(ValueError, match="exactly two camera views"):
+        adapter.predict_action_batch(obs)
+
+
+def test_close_delegates_to_policy():
+    policy = _FakePolicy()
+    adapter = OpenPIApxInfAdapter(_model_cfg(), "cpu", policy=policy)
+    adapter.close()
+    assert policy.closed

--- a/tests/unit_tests/test_apxinf_adapter.py
+++ b/tests/unit_tests/test_apxinf_adapter.py
@@ -17,26 +17,62 @@ import pytest
 import torch
 from omegaconf import OmegaConf
 
-from rlinf.models.embodiment.openpi.apxinf_adapter import OpenPIApxInfAdapter
+from rlinf.models.embodiment.openpi.apxinf_adapter import (
+    OpenPIApxInfAdapter,
+    _active_token_ids,
+)
 
 
-class _FakePolicy:
+class _FakeModel:
     action_horizon = 10
-    action_dim = 7
-    metadata = {"model_action_dim": 32}
+    action_dim = 32
+    num_views = 2
+    image_size = 224
 
-    def __init__(self):
+    def __init__(self, output_shape=(10, 32)):
+        self.output_shape = output_shape
         self.calls = []
         self.closed = False
 
-    def infer(self, observation, *, noise=None):
-        self.calls.append((observation, noise))
+    def infer_rgb(self, rgb_u8, layout, token_ids, *, noise=None):
+        self.calls.append((rgb_u8, layout, token_ids, noise))
         offset = len(self.calls) * 1000
-        actions = np.arange(70, dtype=np.float32).reshape(10, 7) + offset
-        return {"actions": actions, "timing": {"model_ms": 1.0}}
+        return (
+            np.arange(np.prod(self.output_shape), dtype=np.float32).reshape(
+                self.output_shape
+            )
+            + offset
+        )
 
     def close(self):
         self.closed = True
+
+
+class _FakeProcessor:
+    def __init__(self):
+        self.preprocess_calls = []
+        self.postprocess_calls = []
+
+    def preprocess_batch(self, env_obs, *, num_views, image_size):
+        self.preprocess_calls.append((env_obs, num_views, image_size))
+        prepared = []
+        for index in range(len(env_obs["task_descriptions"])):
+            prepared.append(
+                {
+                    "rgb_u8": np.full(
+                        (num_views, image_size, image_size, 3),
+                        index,
+                        dtype=np.uint8,
+                    ),
+                    "token_ids": np.array([index, index + 1], dtype=np.uint32),
+                    "state": np.full(32, index, dtype=np.float32),
+                }
+            )
+        return prepared
+
+    def postprocess_batch(self, normalized_actions, prepared):
+        self.postprocess_calls.append((normalized_actions.copy(), prepared))
+        return torch.from_numpy(normalized_actions[:, :5, :7].copy())
 
 
 def _model_cfg(**apxinf_overrides):
@@ -65,92 +101,109 @@ def _model_cfg(**apxinf_overrides):
 
 
 def _env_obs(batch_size=2):
-    main = torch.arange(batch_size * 4 * 5 * 3, dtype=torch.uint8).reshape(
-        batch_size, 4, 5, 3
-    )
-    wrist = main + 1
     return {
-        "main_images": main,
-        "wrist_images": wrist,
+        "main_images": torch.zeros(batch_size, 8, 8, 3, dtype=torch.uint8),
+        "wrist_images": torch.ones(batch_size, 8, 8, 3, dtype=torch.uint8),
         "extra_view_images": None,
-        "states": torch.arange(batch_size * 8, dtype=torch.float32).reshape(
-            batch_size, 8
-        ),
+        "states": torch.zeros(batch_size, 8),
         "task_descriptions": [f"task {index}" for index in range(batch_size)],
     }
 
 
-def test_maps_rlinf_batch_without_repeating_env_transforms_and_slices_time():
-    policy = _FakePolicy()
-    adapter = OpenPIApxInfAdapter(_model_cfg(), "cpu", policy=policy)
+def _adapter(*, model=None, processor=None, **apxinf_overrides):
+    return OpenPIApxInfAdapter(
+        _model_cfg(**apxinf_overrides),
+        "cpu",
+        model=model or _FakeModel(),
+        processor=processor or _FakeProcessor(),
+    )
+
+
+def test_strips_openpi_prompt_padding_before_l1_inference():
+    transformed = {
+        "tokenized_prompt": np.array([2, 42, 108, 0, 0], dtype=np.int32),
+        "tokenized_prompt_mask": np.array([True, True, True, False, False]),
+    }
+
+    tokens = _active_token_ids(transformed)
+
+    np.testing.assert_array_equal(tokens, np.array([2, 42, 108], dtype=np.uint32))
+    assert tokens.flags.c_contiguous
+
+
+def test_calls_l1_infer_rgb_and_delegates_pre_and_postprocessing():
+    model = _FakeModel()
+    processor = _FakeProcessor()
+    adapter = _adapter(model=model, processor=processor)
     env_obs = _env_obs()
 
     actions, result = adapter.predict_action_batch(env_obs, mode="eval")
 
     assert actions.shape == (2, 5, 7)
     assert actions.dtype == torch.float32
-    np.testing.assert_array_equal(
-        policy.calls[0][0]["observation/image"], env_obs["main_images"][0].numpy()
-    )
-    np.testing.assert_array_equal(
-        policy.calls[1][0]["observation/wrist_image"],
-        env_obs["wrist_images"][1].numpy(),
-    )
-    np.testing.assert_array_equal(
-        policy.calls[0][0]["observation/state"], env_obs["states"][0].numpy()
-    )
-    assert policy.calls[1][0]["prompt"] == "task 1"
+    assert processor.preprocess_calls == [(env_obs, 2, 224)]
+    assert len(model.calls) == 2
+    assert model.calls[0][0].shape == (2, 224, 224, 3)
+    assert model.calls[0][0].dtype == np.uint8
+    assert model.calls[0][1] == "nhwc"
+    assert model.calls[0][2].dtype == np.uint32
+    assert model.calls[0][3] is None
+    normalized = processor.postprocess_calls[0][0]
+    assert normalized.shape == (2, 10, 32)
     assert len(result["apxinf_timing"]) == 2
 
 
 def test_explicit_noise_is_split_and_forwarded_exactly():
-    policy = _FakePolicy()
-    adapter = OpenPIApxInfAdapter(
-        _model_cfg(noise_source="observation"), "cpu", policy=policy
-    )
+    model = _FakeModel()
+    adapter = _adapter(model=model, noise_source="observation")
     env_obs = _env_obs()
     env_obs["noise"] = torch.arange(2 * 10 * 32, dtype=torch.float32).reshape(2, 10, 32)
 
     adapter.predict_action_batch(env_obs)
 
-    np.testing.assert_array_equal(policy.calls[0][1], env_obs["noise"][0].numpy())
-    np.testing.assert_array_equal(policy.calls[1][1], env_obs["noise"][1].numpy())
+    np.testing.assert_array_equal(model.calls[0][3], env_obs["noise"][0].numpy())
+    np.testing.assert_array_equal(model.calls[1][3], env_obs["noise"][1].numpy())
+
+
+def test_observation_noise_is_required():
+    adapter = _adapter(noise_source="observation")
+    with pytest.raises(ValueError, match="requires env_obs"):
+        adapter.predict_action_batch(_env_obs())
 
 
 def test_torch_noise_is_reproducible_and_has_model_shape():
-    obs = _env_obs()
-    policy_a = _FakePolicy()
-    policy_b = _FakePolicy()
-    adapter_a = OpenPIApxInfAdapter(
-        _model_cfg(noise_source="torch", seed=7), "cpu", policy=policy_a
-    )
-    adapter_b = OpenPIApxInfAdapter(
-        _model_cfg(noise_source="torch", seed=7), "cpu", policy=policy_b
-    )
+    model_a = _FakeModel()
+    model_b = _FakeModel()
+    adapter_a = _adapter(model=model_a, noise_source="torch", seed=7)
+    adapter_b = _adapter(model=model_b, noise_source="torch", seed=7)
 
-    adapter_a.predict_action_batch(obs)
-    adapter_b.predict_action_batch(obs)
+    adapter_a.predict_action_batch(_env_obs())
+    adapter_b.predict_action_batch(_env_obs())
 
-    assert policy_a.calls[0][1].shape == (10, 32)
-    np.testing.assert_array_equal(policy_a.calls[0][1], policy_b.calls[0][1])
-    np.testing.assert_array_equal(policy_a.calls[1][1], policy_b.calls[1][1])
+    assert model_a.calls[0][3].shape == (10, 32)
+    np.testing.assert_array_equal(model_a.calls[0][3], model_b.calls[0][3])
+    np.testing.assert_array_equal(model_a.calls[1][3], model_b.calls[1][3])
+
+
+def test_rejects_bad_normalized_action_shape():
+    adapter = _adapter(model=_FakeModel(output_shape=(10, 7)))
+    with pytest.raises(ValueError, match="normalized actions have shape"):
+        adapter.predict_action_batch(_env_obs(batch_size=1))
 
 
 def test_rejects_mismatched_openpi_and_apxinf_flow_steps():
     with pytest.raises(ValueError, match="must match OpenPI num_steps"):
-        OpenPIApxInfAdapter(_model_cfg(num_flow_steps=10), "cpu", policy=_FakePolicy())
+        _adapter(num_flow_steps=10)
 
 
-def test_rejects_more_than_two_libero_views():
-    adapter = OpenPIApxInfAdapter(_model_cfg(), "cpu", policy=_FakePolicy())
-    obs = _env_obs()
-    obs["extra_view_images"] = torch.zeros_like(obs["main_images"])
-    with pytest.raises(ValueError, match="exactly two camera views"):
-        adapter.predict_action_batch(obs)
+def test_rejects_training_mode():
+    adapter = _adapter()
+    with pytest.raises(ValueError, match="eval-only"):
+        adapter.predict_action_batch(_env_obs(), mode="train")
 
 
-def test_close_delegates_to_policy():
-    policy = _FakePolicy()
-    adapter = OpenPIApxInfAdapter(_model_cfg(), "cpu", policy=policy)
+def test_close_delegates_to_model():
+    model = _FakeModel()
+    adapter = _adapter(model=model)
     adapter.close()
-    assert policy.closed
+    assert model.closed

--- a/tests/unit_tests/test_apxinf_adapter.py
+++ b/tests/unit_tests/test_apxinf_adapter.py
@@ -171,6 +171,23 @@ def test_observation_noise_is_required():
         adapter.predict_action_batch(_env_obs())
 
 
+def test_observation_noise_does_not_override_other_noise_sources():
+    env_obs = _env_obs()
+    explicit_noise = torch.full((2, 10, 32), 123.0)
+    env_obs["noise"] = explicit_noise
+
+    apxinf_model = _FakeModel()
+    _adapter(model=apxinf_model, noise_source="apxinf").predict_action_batch(env_obs)
+    assert all(call[3] is None for call in apxinf_model.calls)
+
+    torch_model = _FakeModel()
+    torch_adapter = _adapter(model=torch_model, noise_source="torch")
+    torch_adapter.predict_action_batch(env_obs)
+    assert all(call[3] is not None for call in torch_model.calls)
+    for index, call in enumerate(torch_model.calls):
+        assert not np.array_equal(call[3], explicit_noise[index].numpy())
+
+
 def test_torch_noise_is_reproducible_and_has_model_shape():
     model_a = _FakeModel()
     model_b = _FakeModel()


### PR DESCRIPTION
## Summary

This PR adds an eval-only ApxInf rollout backend for OpenPI models in RLinf.

- Add `ApxInfRolloutWorker` for environment scheduling, channel communication, and action rollout.
- Add an OpenPI-specific ApxInf adapter.
- Replace the high-level `AutoPolicy.infer()` path with `apxinf_py.Model.infer_rgb()`.
- Reuse RLinf's native OpenPI transforms for image preprocessing, tokenization, normalization, action unnormalization, and environment-specific action conversion.
- Add a LIBERO-10 PI0.5 evaluation configuration.
- Add English and Chinese documentation.
- Add unit tests for the adapter contract, noise handling, validation, and lifecycle.

## Design

The worker remains responsible only for rollout orchestration:

```text
observation
-> OpenPIApxInfAdapter
-> action
```

The adapter owns the OpenPI-specific inference path:

```text
RLinf OpenPI preprocess
-> rgb_u8 / token_ids / noise
-> apxinf_py.Model.infer_rgb()
-> normalized actions
-> RLinf OpenPI postprocess
-> environment actions
```

Camera inputs are derived from the OpenPI transforms and validated against the checkpoint's `num_views`, rather than being hard-coded to two LIBERO cameras.

Noise sampling follows `rollout.model.apxinf.noise_source`: ApxInf and Torch sampling ignore any observation-provided noise, while `observation` mode requires and forwards the explicit noise tensor.

## Validation

- Ruff formatting and lint checks passed.
- Adapter unit tests: `10 passed`.
- Thor LIBERO-10 default evaluation (`10 environments x 10 rollout epochs`):
  - Completed all 100 trajectories across tasks 0-9, with 10 trials per task.
  - Result: `eval/success_once = 0.94` (94/100).
  - Process exit code: 0; `OOMKilled=false`.
  - Rollout time: 40m22s.
  - Observed container memory stayed around 28.8-29.5 GiB without cumulative growth.

