### PR TITLE
test(data): restore split tests and cover contiguity

### DIFF
--- a/tests/unit_tests/test_nested_dict_process.py
+++ b/tests/unit_tests/test_nested_dict_process.py
@@ -1,0 +1,184 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from rlinf.data.schema.embodied_trajectory_builder import EmbodiedTrajectoryBuilder
+from rlinf.utils.nested_dict_process import split_dict, split_dict_to_chunk
+
+
+def test_split_dict_to_chunk_keeps_mixed_fields_aligned():
+    batch = {
+        "values": torch.arange(10),
+        "sample_ids": list(range(10)),
+        "nested": {"values": torch.arange(10) + 100},
+    }
+
+    chunks = split_dict_to_chunk(batch, 3)
+
+    assert [chunk["values"].tolist() for chunk in chunks] == [
+        [0, 1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+    ]
+    assert [chunk["sample_ids"] for chunk in chunks] == [
+        [0, 1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+    ]
+    assert [chunk["nested"]["values"].tolist() for chunk in chunks] == [
+        [100, 101, 102, 103],
+        [104, 105, 106],
+        [107, 108, 109],
+    ]
+
+
+def test_split_dict_to_chunk_returns_requested_number_of_chunks():
+    batch = {"values": torch.arange(2), "sample_ids": ["a", "b"]}
+
+    chunks = split_dict_to_chunk(batch, 4)
+
+    assert len(chunks) == 4
+    assert [chunk["values"].tolist() for chunk in chunks] == [[0], [1], [], []]
+    assert [chunk["sample_ids"] for chunk in chunks] == [["a"], ["b"], [], []]
+
+
+def _make_trajectory_builder(batch_size: int) -> EmbodiedTrajectoryBuilder:
+    sample_ids = torch.arange(batch_size)
+    builder = EmbodiedTrajectoryBuilder()
+    builder.curr_obs.append({"sample_ids": sample_ids})
+    builder.actions.append(sample_ids[:, None])
+    builder.rewards.append(sample_ids)
+    return builder
+
+
+def test_trajectory_chunks_keep_top_level_fields_aligned():
+    trajectories = _make_trajectory_builder(10).to_splited_trajectories(3)
+
+    expected_ids = [[0, 1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    assert [
+        trajectory.curr_obs["sample_ids"][0].tolist() for trajectory in trajectories
+    ] == expected_ids
+    assert [
+        trajectory.actions[0, :, 0].tolist() for trajectory in trajectories
+    ] == expected_ids
+    assert [
+        trajectory.rewards[0].tolist() for trajectory in trajectories
+    ] == expected_ids
+
+
+def test_trajectory_split_returns_requested_number_of_chunks():
+    trajectories = _make_trajectory_builder(2).to_splited_trajectories(4)
+
+    assert len(trajectories) == 4
+    assert [trajectory.actions.shape[1] for trajectory in trajectories] == [1, 1, 0, 0]
+    assert [
+        trajectory.curr_obs["sample_ids"].shape[1] for trajectory in trajectories
+    ] == [1, 1, 0, 0]
+
+
+def _make_multi_step_builder(
+    num_steps: int, batch_size: int
+) -> EmbodiedTrajectoryBuilder:
+    builder = EmbodiedTrajectoryBuilder()
+    for step in range(num_steps):
+        base = step * batch_size
+        ids = torch.arange(base, base + batch_size)
+        builder.curr_obs.append({"sample_ids": ids[:, None].repeat(1, 2)})
+        builder.next_obs.append({"sample_ids": ids[:, None].repeat(1, 2)})
+        builder.forward_inputs.append({"states": ids[:, None].repeat(1, 3)})
+        builder.actions.append(ids[:, None])
+        builder.rewards.append(ids)
+    return builder
+
+
+def _count_contiguous_tensors(value, path: str) -> int:
+    # Returns how many tensors were checked so callers can pin the expected
+    # coverage: an assertion that never reaches a tensor proves nothing.
+    if value is None or isinstance(value, (int, str)):
+        return 0
+    if isinstance(value, torch.Tensor):
+        assert value.is_contiguous(), f"{path} is not contiguous"
+        return 1
+    if isinstance(value, dict):
+        return sum(
+            _count_contiguous_tensors(item, f"{path}.{key}")
+            for key, item in value.items()
+        )
+    raise AssertionError(f"unexpected value type {type(value)} at {path}")
+
+
+def test_split_dict_to_chunk_returns_contiguous_tensors():
+    # Splitting a contiguous tensor on any dim but the first returns strided
+    # views, which P2P communication rejects. Chunks must be materialized.
+    batch = {
+        "values": torch.arange(24).view(4, 6),
+        "nested": {"values": torch.arange(24).view(4, 6) + 100},
+    }
+
+    chunks = split_dict_to_chunk(batch, 3, dim=1)
+
+    for index, chunk in enumerate(chunks):
+        assert _count_contiguous_tensors(chunk, f"chunk[{index}]") == 2
+    assert [chunk["values"].tolist() for chunk in chunks] == [
+        [[0, 1], [6, 7], [12, 13], [18, 19]],
+        [[2, 3], [8, 9], [14, 15], [20, 21]],
+        [[4, 5], [10, 11], [16, 17], [22, 23]],
+    ]
+
+
+def test_split_dict_returns_contiguous_tensors():
+    batch = {
+        "values": torch.arange(24).view(4, 6),
+        "nested": {"values": torch.arange(24).view(4, 6) + 100},
+    }
+
+    splits = split_dict(batch, [4, 2], dim=1)
+
+    for index, split in enumerate(splits):
+        assert _count_contiguous_tensors(split, f"split[{index}]") == 2
+    assert [split["values"].shape[1] for split in splits] == [4, 2]
+    assert splits[1]["values"].tolist() == [[4, 5], [10, 11], [16, 17], [22, 23]]
+
+
+def test_trajectory_chunks_are_contiguous():
+    trajectories = _make_multi_step_builder(3, 6).to_splited_trajectories(3)
+
+    for index, trajectory in enumerate(trajectories):
+        checked = sum(
+            _count_contiguous_tensors(
+                getattr(trajectory, field_name), f"trajectory[{index}].{field_name}"
+            )
+            for field_name in trajectory.__dataclass_fields__
+        )
+        # actions, rewards, curr_obs, next_obs and forward_inputs all propagate.
+        assert checked == 5
+    assert [trajectory.actions.shape[1] for trajectory in trajectories] == [2, 2, 2]
+
+
+def test_trajectory_splits_by_sizes_are_contiguous():
+    trajectories = _make_multi_step_builder(3, 6).to_splited_trajectories_by_sizes(
+        [4, 2]
+    )
+
+    for index, trajectory in enumerate(trajectories):
+        checked = sum(
+            _count_contiguous_tensors(
+                getattr(trajectory, field_name), f"trajectory[{index}].{field_name}"
+            )
+            for field_name in trajectory.__dataclass_fields__
+        )
+        # actions, rewards, curr_obs, next_obs and forward_inputs all propagate.
+        assert checked == 5
+    assert [trajectory.actions.shape[1] for trajectory in trajectories] == [4, 2]


### PR DESCRIPTION
### Description

Restores `tests/unit_tests/test_nested_dict_process.py` and adds four tests covering a property the file never checked.

- Restores the four existing tests unchanged: they are the only unit coverage for `split_dict_to_chunk`, `split_dict`, and `EmbodiedTrajectoryBuilder.to_splited_trajectories` / `to_splited_trajectories_by_sizes`.
- Adds four tests asserting that the chunks these helpers produce are contiguous, recursing into nested dicts and into every tensor field of a split `Trajectory`.
- No production code changes; this PR is one test file.

### Motivation and Context

#1481 deleted this file, but every module it covers is still on `main` and the PR did not touch any of them, so the four tests were lost with nothing replacing them. `git show 24647d9c --stat -- rlinf/utils/nested_dict_process.py` is empty, while `git ls-tree main --name-only tests/unit_tests/test_nested_dict_process.py` is also empty. This is one of 14 such files; I opened #1562 with the full list, and this PR restores only the one I can also extend usefully rather than bundling all of them.

The added coverage closes a separate gap. `_check_tensor_contiguous` in `collective_group.py` rejects strided tensors, so a view leaking out of a split fails only when the peers are on different devices — same-device transfers go through IPC and never check. That asymmetry is what #832 and #971 reported, and the `.contiguous()` calls added to these helpers to fix them had no test holding them in place: all five could be deleted and the suite stayed green.

### How has this been tested?

`pytest tests/unit_tests/test_nested_dict_process.py` — 8 passed, which is how the `unit-tests` job invokes it.

Mutation check, to confirm the new tests can actually fail: removing all five `.contiguous()` calls from `split_dict_to_chunk`, `split_dict`, `to_splited_trajectories` and `to_splited_trajectories_by_sizes` gives `4 failed, 4 passed` — each new test fails on its own `is_contiguous` assertion, and the four restored tests still pass, which is precisely why they could not have caught this.

`ruff format --check` and `ruff check` pass on the file.

Full local suite is unchanged by this PR: with and without the file, `pytest tests/unit_tests/` reports the same result. Three modules fail to import locally for missing optional dependencies (`gymnasium`, `hydra`, `torchdata`); those are environment-only and identical on a clean `main`.

### Additional information (optional, e.g., figures and logs):

The new tests split on `dim=1` on purpose. A `dim=0` split of a contiguous tensor is itself contiguous, so it cannot distinguish a working helper from a broken one. The pre-existing trajectory fixture has the same blind spot for a different reason: it builds a single step, so the stacked tensor is `(1, N)` and its `dim=1` slices stay contiguous because the leading dimension is 1. The new fixture stacks three steps to avoid both.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
