### PR TITLE
feat(fsdp): support hybrid_shard via a 2-D device mesh

### DIFF
--- a/docs/source-en/rst_source/guides/agentic_config.rst
+++ b/docs/source-en/rst_source/guides/agentic_config.rst
@@ -607,7 +607,15 @@ Used when ``actor.training_backend`` is ``fsdp``.
      - FSDP strategy: ``fsdp`` or ``fsdp2`` (case-insensitive).
    * - ``actor.fsdp_config.sharding_strategy``
      - Sharding strategy: ``full_shard``, ``shard_grad_op``, ``hybrid_shard``, or
-       ``no_shard``.
+       ``no_shard``. ``hybrid_shard`` is rejected for runs that configure an FSDP
+       inference group, whose weight-sync metadata assumes a single shard group.
+   * - ``actor.fsdp_config.hybrid_shard_size``
+     - Ranks per shard group when ``sharding_strategy`` is ``hybrid_shard``:
+       parameters are sharded inside a group of this many ranks and replicated
+       across the remaining ranks, so set it to the accelerators on one node to
+       shard intra-node and replicate inter-node. Required by ``hybrid_shard``;
+       must divide the world size of the component it applies to and leave a
+       shard degree and a replicate degree of at least 2. Ignored otherwise.
    * - ``actor.fsdp_config.cpu_offload``
      - FSDP2: keep parameters on CPU, moving them to GPU only when needed.
    * - ``actor.fsdp_config.offload_pin_memory``

--- a/docs/source-zh/rst_source/guides/agentic_config.rst
+++ b/docs/source-zh/rst_source/guides/agentic_config.rst
@@ -597,6 +597,13 @@ actor
      - FSDP 策略：``fsdp`` 或 ``fsdp2``\ （不区分大小写）。
    * - ``actor.fsdp_config.sharding_strategy``
      - 分片策略：``full_shard``、``shard_grad_op``、``hybrid_shard`` 或 ``no_shard``。
+       配置了 FSDP inference 组的运行不支持 ``hybrid_shard``，因为其权重同步元数据
+       假设只有一个覆盖全部 rank 的分片组。
+   * - ``actor.fsdp_config.hybrid_shard_size``
+     - ``sharding_strategy`` 为 ``hybrid_shard`` 时每个分片组的 rank 数：参数在该数量的
+       rank 内分片，并在其余 rank 上复制。设为单节点的加速卡数即可实现节点内分片、
+       节点间复制。使用 ``hybrid_shard`` 时必须设置；它必须整除所属组件的 world size，
+       且分片度与复制度均不小于 2。其他分片策略会忽略该项。
    * - ``actor.fsdp_config.cpu_offload``
      - FSDP2：参数保留在 CPU，仅在需要时移到 GPU。
    * - ``actor.fsdp_config.offload_pin_memory``

--- a/examples/embodiment/config/hybrid_engines/fsdp.yaml
+++ b/examples/embodiment/config/hybrid_engines/fsdp.yaml
@@ -6,6 +6,13 @@ strategy: "fsdp"            # FSDP strategy: ["fsdp", "fsdp2"]
 # "no_shard" (no sharding)
 sharding_strategy: "full_shard"
 
+# Ranks per shard group when sharding_strategy is "hybrid_shard": parameters are
+# sharded inside a group of this many ranks and replicated across the remaining
+# ranks. -1 means one shard group per node (shard intra-node, replicate
+# inter-node). Must divide the actor world size and leave a replicate degree of
+# at least 2. Ignored by every other sharding strategy.
+hybrid_shard_size: -1
+
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.
 cpu_offload: False            # whether to offload parameters and gradients to CPU when not in use, if True, actor's enable_offload should be True too.
 offload_pin_memory: False     # whether FSDP2's CPU offload policy should pin memory when cpu_offload is True

--- a/examples/embodiment/config/hybrid_engines/fsdp.yaml
+++ b/examples/embodiment/config/hybrid_engines/fsdp.yaml
@@ -11,8 +11,9 @@ sharding_strategy: "full_shard"
 # ranks, so set it to the number of accelerators on one node to shard
 # intra-node and replicate inter-node. Required by "hybrid_shard" (it has to
 # be the same on every rank, so it is not derived from the node-local rank
-# count); must divide the actor world size and leave a shard degree and a
-# replicate degree of at least 2. Ignored by every other sharding strategy.
+# count); must divide the world size of the component this file is applied to and
+# leave a shard degree and a replicate degree of at least 2. Ignored by every
+# other sharding strategy.
 hybrid_shard_size: -1
 
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.

--- a/examples/embodiment/config/hybrid_engines/fsdp.yaml
+++ b/examples/embodiment/config/hybrid_engines/fsdp.yaml
@@ -8,9 +8,11 @@ sharding_strategy: "full_shard"
 
 # Ranks per shard group when sharding_strategy is "hybrid_shard": parameters are
 # sharded inside a group of this many ranks and replicated across the remaining
-# ranks. -1 means one shard group per node (shard intra-node, replicate
-# inter-node). Must divide the actor world size and leave a replicate degree of
-# at least 2. Ignored by every other sharding strategy.
+# ranks, so set it to the number of accelerators on one node to shard
+# intra-node and replicate inter-node. Required by "hybrid_shard" (it has to
+# be the same on every rank, so it is not derived from the node-local rank
+# count); must divide the actor world size and leave a shard degree and a
+# replicate degree of at least 2. Ignored by every other sharding strategy.
 hybrid_shard_size: -1
 
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.

--- a/examples/offline_rl/config/hybrid_engines/fsdp.yaml
+++ b/examples/offline_rl/config/hybrid_engines/fsdp.yaml
@@ -6,6 +6,13 @@ strategy: "fsdp"            # FSDP strategy: ["fsdp", "fsdp2"]
 # "no_shard" (no sharding)
 sharding_strategy: "full_shard" 
 
+# Ranks per shard group when sharding_strategy is "hybrid_shard": parameters are
+# sharded inside a group of this many ranks and replicated across the remaining
+# ranks. -1 means one shard group per node (shard intra-node, replicate
+# inter-node). Must divide the actor world size and leave a replicate degree of
+# at least 2. Ignored by every other sharding strategy.
+hybrid_shard_size: -1
+
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.
 cpu_offload: False            # whether to offload parameters and gradients to CPU when not in use，if True, actor's enable_offload should be True too.
 offload_pin_memory: False     # whether FSDP2's CPU offload policy should pin memory when cpu_offload is True

--- a/examples/offline_rl/config/hybrid_engines/fsdp.yaml
+++ b/examples/offline_rl/config/hybrid_engines/fsdp.yaml
@@ -11,8 +11,9 @@ sharding_strategy: "full_shard"
 # ranks, so set it to the number of accelerators on one node to shard
 # intra-node and replicate inter-node. Required by "hybrid_shard" (it has to
 # be the same on every rank, so it is not derived from the node-local rank
-# count); must divide the actor world size and leave a shard degree and a
-# replicate degree of at least 2. Ignored by every other sharding strategy.
+# count); must divide the world size of the component this file is applied to and
+# leave a shard degree and a replicate degree of at least 2. Ignored by every
+# other sharding strategy.
 hybrid_shard_size: -1
 
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.

--- a/examples/offline_rl/config/hybrid_engines/fsdp.yaml
+++ b/examples/offline_rl/config/hybrid_engines/fsdp.yaml
@@ -8,9 +8,11 @@ sharding_strategy: "full_shard"
 
 # Ranks per shard group when sharding_strategy is "hybrid_shard": parameters are
 # sharded inside a group of this many ranks and replicated across the remaining
-# ranks. -1 means one shard group per node (shard intra-node, replicate
-# inter-node). Must divide the actor world size and leave a replicate degree of
-# at least 2. Ignored by every other sharding strategy.
+# ranks, so set it to the number of accelerators on one node to shard
+# intra-node and replicate inter-node. Required by "hybrid_shard" (it has to
+# be the same on every rank, so it is not derived from the node-local rank
+# count); must divide the actor world size and leave a shard degree and a
+# replicate degree of at least 2. Ignored by every other sharding strategy.
 hybrid_shard_size: -1
 
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.

--- a/examples/reasoning/config/hybrid_engines/fsdp.yaml
+++ b/examples/reasoning/config/hybrid_engines/fsdp.yaml
@@ -6,6 +6,13 @@ strategy: "fsdp"            # FSDP strategy: ["fsdp", "fsdp2"]
 # "no_shard" (no sharding)
 sharding_strategy: "full_shard" 
 
+# Ranks per shard group when sharding_strategy is "hybrid_shard": parameters are
+# sharded inside a group of this many ranks and replicated across the remaining
+# ranks. -1 means one shard group per node (shard intra-node, replicate
+# inter-node). Must divide the actor world size and leave a replicate degree of
+# at least 2. Ignored by every other sharding strategy.
+hybrid_shard_size: -1
+
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.
 cpu_offload: False            # whether to offload parameters and gradients to CPU when not in use，if True, actor's enable_offload should be True too.
 offload_pin_memory: False     # whether FSDP2's CPU offload policy should pin memory when cpu_offload is True

--- a/examples/reasoning/config/hybrid_engines/fsdp.yaml
+++ b/examples/reasoning/config/hybrid_engines/fsdp.yaml
@@ -11,8 +11,9 @@ sharding_strategy: "full_shard"
 # ranks, so set it to the number of accelerators on one node to shard
 # intra-node and replicate inter-node. Required by "hybrid_shard" (it has to
 # be the same on every rank, so it is not derived from the node-local rank
-# count); must divide the actor world size and leave a shard degree and a
-# replicate degree of at least 2. Ignored by every other sharding strategy.
+# count); must divide the world size of the component this file is applied to and
+# leave a shard degree and a replicate degree of at least 2. Ignored by every
+# other sharding strategy.
 hybrid_shard_size: -1
 
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.

--- a/examples/reasoning/config/hybrid_engines/fsdp.yaml
+++ b/examples/reasoning/config/hybrid_engines/fsdp.yaml
@@ -8,9 +8,11 @@ sharding_strategy: "full_shard"
 
 # Ranks per shard group when sharding_strategy is "hybrid_shard": parameters are
 # sharded inside a group of this many ranks and replicated across the remaining
-# ranks. -1 means one shard group per node (shard intra-node, replicate
-# inter-node). Must divide the actor world size and leave a replicate degree of
-# at least 2. Ignored by every other sharding strategy.
+# ranks, so set it to the number of accelerators on one node to shard
+# intra-node and replicate inter-node. Required by "hybrid_shard" (it has to
+# be the same on every rank, so it is not derived from the node-local rank
+# count); must divide the actor world size and leave a shard degree and a
+# replicate degree of at least 2. Ignored by every other sharding strategy.
 hybrid_shard_size: -1
 
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.

--- a/examples/sft/config/hybrid_engines/fsdp.yaml
+++ b/examples/sft/config/hybrid_engines/fsdp.yaml
@@ -6,6 +6,13 @@ strategy: "fsdp"            # FSDP strategy: ["fsdp", "fsdp2"]
 # "no_shard" (no sharding)
 sharding_strategy: "full_shard" 
 
+# Ranks per shard group when sharding_strategy is "hybrid_shard": parameters are
+# sharded inside a group of this many ranks and replicated across the remaining
+# ranks. -1 means one shard group per node (shard intra-node, replicate
+# inter-node). Must divide the actor world size and leave a replicate degree of
+# at least 2. Ignored by every other sharding strategy.
+hybrid_shard_size: -1
+
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.
 cpu_offload: False            # whether to offload parameters and gradients to CPU when not in use，if True, actor's enable_offload should be True too.
 offload_pin_memory: False     # whether FSDP2's CPU offload policy should pin memory when cpu_offload is True

--- a/examples/sft/config/hybrid_engines/fsdp.yaml
+++ b/examples/sft/config/hybrid_engines/fsdp.yaml
@@ -11,8 +11,9 @@ sharding_strategy: "full_shard"
 # ranks, so set it to the number of accelerators on one node to shard
 # intra-node and replicate inter-node. Required by "hybrid_shard" (it has to
 # be the same on every rank, so it is not derived from the node-local rank
-# count); must divide the actor world size and leave a shard degree and a
-# replicate degree of at least 2. Ignored by every other sharding strategy.
+# count); must divide the world size of the component this file is applied to and
+# leave a shard degree and a replicate degree of at least 2. Ignored by every
+# other sharding strategy.
 hybrid_shard_size: -1
 
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.

--- a/examples/sft/config/hybrid_engines/fsdp.yaml
+++ b/examples/sft/config/hybrid_engines/fsdp.yaml
@@ -8,9 +8,11 @@ sharding_strategy: "full_shard"
 
 # Ranks per shard group when sharding_strategy is "hybrid_shard": parameters are
 # sharded inside a group of this many ranks and replicated across the remaining
-# ranks. -1 means one shard group per node (shard intra-node, replicate
-# inter-node). Must divide the actor world size and leave a replicate degree of
-# at least 2. Ignored by every other sharding strategy.
+# ranks, so set it to the number of accelerators on one node to shard
+# intra-node and replicate inter-node. Required by "hybrid_shard" (it has to
+# be the same on every rank, so it is not derived from the node-local rank
+# count); must divide the actor world size and leave a shard degree and a
+# replicate degree of at least 2. Ignored by every other sharding strategy.
 hybrid_shard_size: -1
 
 gradient_checkpointing: False # if True, gradient checkpointing will be used for FSDP/FSDP2 training, which will save memory but increase computation time.

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -517,8 +517,8 @@ def validate_fsdp_cfg(cfg: DictConfig) -> DictConfig:
             "sharding_strategy", "full_shard"
         )
         # Ranks per shard group when sharding_strategy is "hybrid_shard"; <= 0
-        # means one shard group per node. The world size is only known once the
-        # actor group is placed, so the shape itself is validated in
+        # means unset. The world size is only known once the actor group is
+        # placed, so the shape itself is validated in
         # rlinf.hybrid_engines.fsdp.utils.resolve_fsdp_mesh.
         cfg.fsdp_config.hybrid_shard_size = cfg.fsdp_config.get("hybrid_shard_size", -1)
 

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -516,6 +516,11 @@ def validate_fsdp_cfg(cfg: DictConfig) -> DictConfig:
         cfg.fsdp_config.sharding_strategy = cfg.fsdp_config.get(
             "sharding_strategy", "full_shard"
         )
+        # Ranks per shard group when sharding_strategy is "hybrid_shard"; <= 0
+        # means one shard group per node. The world size is only known once the
+        # actor group is placed, so the shape itself is validated in
+        # rlinf.hybrid_engines.fsdp.utils.resolve_fsdp_mesh.
+        cfg.fsdp_config.hybrid_shard_size = cfg.fsdp_config.get("hybrid_shard_size", -1)
 
         cfg.fsdp_config.forward_prefetch = cfg.fsdp_config.get(
             "forward_prefetch", False

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -478,6 +478,14 @@ def validate_fsdp_weight_sync_cfg(cfg: DictConfig) -> None:
     actor and an inference group configured differently would have one side raise
     while the other blocks. Failing here fails both components at startup instead.
 
+    Whether an FSDP inference group is actually launched depends on the entry
+    script (for reasoning it is the placement mode plus
+    ``algorithm.recompute_logprobs``), so this keys off the presence of an
+    ``inference.fsdp_config`` section. That is deliberately conservative: it can
+    reject a run whose inference group would not have been created, but the
+    alternative is restating a launch condition that lives in the entry scripts.
+    Runs without an inference section, such as SFT, are unaffected.
+
     Args:
         cfg (DictConfig): The full run config.
 
@@ -485,7 +493,7 @@ def validate_fsdp_weight_sync_cfg(cfg: DictConfig) -> None:
         ValueError: If a component that syncs weights uses ``hybrid_shard``.
     """
     inference_cfg = cfg.get("inference", None)
-    if inference_cfg is None or not inference_cfg.get("load_from_actor", False):
+    if inference_cfg is None or inference_cfg.get("fsdp_config", None) is None:
         return
 
     for component_name in ("actor", "inference"):
@@ -498,8 +506,8 @@ def validate_fsdp_weight_sync_cfg(cfg: DictConfig) -> None:
         if sharding_strategy == "hybrid_shard":
             raise ValueError(
                 f"{component_name}.fsdp_config.sharding_strategy='hybrid_shard' is "
-                "not supported when inference.load_from_actor is set: the "
-                "actor-to-inference sharding metadata assumes one shard group "
+                "not supported for a run that configures an FSDP inference group: "
+                "the actor-to-inference sharding metadata assumes one shard group "
                 "spanning the whole world. Use 'full_shard' for both components."
             )
 

--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -466,6 +466,44 @@ def validate_model_cfg_by_hf_config(cfg, hf_model_path):
     return cfg
 
 
+def validate_fsdp_weight_sync_cfg(cfg: DictConfig) -> None:
+    """
+    Reject sharding strategies the actor-to-inference weight sync cannot express.
+
+    The handshake in ``FSDPStrategyBase.setup_actor_sync_inference_ranks`` and its
+    inference-side counterpart describes a rank's shard as
+    ``rank * ceil(numel / world_size)``, which only holds while a parameter is
+    sharded once across the whole world. Both sides also refuse ``hybrid_shard``
+    at handshake time, but that check runs inside a cross-group collective, so an
+    actor and an inference group configured differently would have one side raise
+    while the other blocks. Failing here fails both components at startup instead.
+
+    Args:
+        cfg (DictConfig): The full run config.
+
+    Raises:
+        ValueError: If a component that syncs weights uses ``hybrid_shard``.
+    """
+    inference_cfg = cfg.get("inference", None)
+    if inference_cfg is None or not inference_cfg.get("load_from_actor", False):
+        return
+
+    for component_name in ("actor", "inference"):
+        component_cfg = cfg.get(component_name, None)
+        if component_cfg is None:
+            continue
+        sharding_strategy = component_cfg.get("fsdp_config", {}).get(
+            "sharding_strategy", "full_shard"
+        )
+        if sharding_strategy == "hybrid_shard":
+            raise ValueError(
+                f"{component_name}.fsdp_config.sharding_strategy='hybrid_shard' is "
+                "not supported when inference.load_from_actor is set: the "
+                "actor-to-inference sharding metadata assumes one shard group "
+                "spanning the whole world. Use 'full_shard' for both components."
+            )
+
+
 def validate_fsdp_cfg(cfg: DictConfig) -> DictConfig:
     def validate_amp_cfg(config: DictConfig) -> DictConfig:
         """Validate AMP configuration and ensure mutual exclusivity with FSDP mixed_precision."""
@@ -1593,6 +1631,7 @@ def validate_cfg(cfg: DictConfig) -> DictConfig:
             f"actor.global_batch_size ({cfg.actor.global_batch_size}) must be divisible by (actor.micro_batch_size ({cfg.actor.micro_batch_size}) * actor_world_size ({actor_world_size}))"
         )
         cfg.actor = validate_fsdp_cfg(cfg.actor)
+        validate_fsdp_weight_sync_cfg(cfg)
 
     if cfg.get("critic", None) is not None:
         if cfg.critic.use_critic_model and cfg.critic.training_backend == "megatron":

--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -96,10 +96,22 @@ class FSDPModelManager:
         if cfg.get("tokenizer", {}).get("tokenizer_model", None) is not None:
             self.tokenizer = hf_tokenizer(cfg.tokenizer.tokenizer_model)
 
-        self._device_mesh = create_device_mesh(world_size)
+        self._device_mesh = create_device_mesh(
+            world_size,
+            sharding_strategy=self._cfg.fsdp_config.get(
+                "sharding_strategy", "full_shard"
+            ),
+            hybrid_shard_size=self._cfg.fsdp_config.get("hybrid_shard_size", -1),
+        )
+        # Group the sharded gradient norms are reduced over. Under hybrid_shard a
+        # rank holds one shard of the gradient and the shards are replicated along
+        # the "ddp" dim, so the p-norm must be summed over the "fsdp" (shard) group
+        # only -- reducing over "ddp" or over WORLD would over-count it by the
+        # replicate degree. A 1-D mesh shards over the whole world, and `None`
+        # already means WORLD for `torch.distributed.all_reduce`.
         self._dp_group = (
-            self._device_mesh["ddp"].get_group()
-            if "ddp" in self._device_mesh.mesh_dim_names
+            self._device_mesh["fsdp"].get_group()
+            if self._device_mesh.ndim > 1
             else None
         )
 

--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -107,13 +107,11 @@ class FSDPModelManager:
         # rank holds one shard of the gradient and the shards are replicated along
         # the "ddp" dim, so the p-norm must be summed over the "fsdp" (shard) group
         # only -- reducing over "ddp" or over WORLD would over-count it by the
-        # replicate degree. A 1-D mesh shards over the whole world, and `None`
-        # already means WORLD for `torch.distributed.all_reduce`.
-        self._dp_group = (
-            self._device_mesh["fsdp"].get_group()
-            if self._device_mesh.ndim > 1
-            else None
-        )
+        # replicate degree. For a 1-D mesh the "fsdp" group spans the whole world,
+        # so this is the shard group in both cases. It is passed rather than left
+        # as None because FSDP2's `get_grad_norm` skips the reduction entirely
+        # when it has no group, which would clip each rank on its own partial norm.
+        self._dp_group = self._device_mesh["fsdp"].get_group()
 
         self._strategy = FSDPStrategyBase.create(
             self._cfg, world_size, self._dp_group, self._logger

--- a/rlinf/hybrid_engines/fsdp/strategy/base.py
+++ b/rlinf/hybrid_engines/fsdp/strategy/base.py
@@ -34,6 +34,7 @@ from torch.optim.lr_scheduler import LRScheduler
 from rlinf.hybrid_engines.fsdp import FSDP, FSDPModule
 from rlinf.hybrid_engines.fsdp.strategy.checkpoint import Checkpoint
 from rlinf.hybrid_engines.fsdp.utils import (
+    HYBRID_SHARDING_STRATEGY,
     FSDPVersion,
 )
 from rlinf.scheduler import Worker
@@ -426,6 +427,7 @@ class FSDPStrategyBase(ABC):
         Args:
             - inference (FSDPInference): The FSDP inference worker.
         """
+        self._assert_single_shard_group()
         # param name -> (global_start, needed_size)
         local_meta: list[str, tuple[int, int]] = {}
         inference_model_state_dict = inference.get_model_state_dict(
@@ -468,6 +470,30 @@ class FSDPStrategyBase(ABC):
             if resp:
                 inference._actor_dst_map[actor_rank] = resp
 
+    def _assert_single_shard_group(self) -> None:
+        """
+        Reject sharding layouts the actor<->inference handshake cannot describe.
+
+        The metadata exchanged by ``setup_actor_sync_inference_ranks`` and
+        ``setup_inference_sync_actor_ranks`` describes a rank's shard as
+        ``rank * ceil(numel / world_size)``, which only holds when a parameter is
+        sharded once across the whole world. Under ``hybrid_shard`` a rank holds
+        shard ``rank % hybrid_shard_size`` and the shards repeat along the
+        replicate dim, so the advertised offsets would not match the data a rank
+        actually owns and weights would be synchronized from the wrong region.
+
+        Raises:
+            NotImplementedError: If the model is wrapped with ``hybrid_shard``.
+        """
+        sharding_strategy = self.cfg.fsdp_config.get("sharding_strategy", "full_shard")
+        if sharding_strategy == HYBRID_SHARDING_STRATEGY:
+            raise NotImplementedError(
+                "fsdp_config.sharding_strategy='hybrid_shard' is not supported for "
+                "actor-to-inference weight synchronization, whose sharding "
+                "metadata assumes one shard group spanning the whole world. Use "
+                "'full_shard' for runs that sync weights to an inference group."
+            )
+
     def setup_actor_sync_inference_ranks(self, actor: "FSDPActor") -> None:
         """
         Setup the mapping from actor ranks to inference ranks for synchronizing
@@ -481,6 +507,7 @@ class FSDPStrategyBase(ABC):
         Args:
             - actor (FSDPActor): The FSDP actor worker.
         """
+        self._assert_single_shard_group()
         inference_group = actor._inference_group_name
         jobs = [
             actor.recv(

--- a/rlinf/hybrid_engines/fsdp/utils.py
+++ b/rlinf/hybrid_engines/fsdp/utils.py
@@ -28,6 +28,7 @@
 
 import functools
 import math
+import os
 import warnings
 from enum import Enum
 from typing import ContextManager, Iterable, Optional, Union
@@ -62,9 +63,98 @@ class FSDPVersion(str, Enum):
     FSDP2 = "fsdp2"
 
 
-def create_device_mesh(world_size):
+HYBRID_SHARDING_STRATEGY = "hybrid_shard"
+
+
+def resolve_fsdp_mesh(
+    world_size: int,
+    sharding_strategy: str = "full_shard",
+    hybrid_shard_size: int = -1,
+    local_world_size: Optional[int] = None,
+) -> tuple[tuple[int, ...], tuple[str, ...]]:
+    """
+    Resolve the shape and dim names of the FSDP device mesh.
+
+    Every strategy but ``hybrid_shard`` shards over a single group spanning the
+    whole world, which is a 1-D mesh. ``hybrid_shard`` shards inside a group of
+    ``hybrid_shard_size`` ranks and replicates across the remaining ranks, which
+    PyTorch expresses as a 2-D mesh: FSDP1 takes mesh dim 0 as the replicate
+    (inter-node) group and dim 1 as the shard group, and FSDP2's ``fully_shard``
+    reads a 2-D mesh as ``HSDPMeshInfo(shard_mesh_dim=1, replicate_mesh_dim=0)``.
+    The dim order below therefore gives both backends the same HSDP layout.
+
+    Args:
+        world_size (int): Total number of ranks in the FSDP group.
+        sharding_strategy (str): The configured ``fsdp_config.sharding_strategy``.
+        hybrid_shard_size (int): Ranks per shard group for ``hybrid_shard``.
+            Values <= 0 mean "shard within a node", i.e. use ``local_world_size``.
+        local_world_size (Optional[int]): Number of ranks on this node. Only read
+            when ``hybrid_shard_size`` is not set explicitly.
+
+    Returns:
+        tuple[tuple[int, ...], tuple[str, ...]]: The mesh shape and its dim names.
+    """
+    if sharding_strategy != HYBRID_SHARDING_STRATEGY:
+        return (world_size,), ("fsdp",)
+
+    shard_size = hybrid_shard_size
+    if shard_size is None or shard_size <= 0:
+        if not local_world_size or local_world_size <= 0:
+            raise ValueError(
+                "fsdp_config.sharding_strategy='hybrid_shard' needs a shard group "
+                "size, but LOCAL_WORLD_SIZE is not set, so it cannot default to "
+                "one shard group per node. Set fsdp_config.hybrid_shard_size to "
+                "the number of ranks that should shard together."
+            )
+        shard_size = local_world_size
+
+    if world_size % shard_size != 0:
+        raise ValueError(
+            f"fsdp_config.hybrid_shard_size={shard_size} must divide the FSDP "
+            f"world size {world_size}."
+        )
+
+    replicate_size = world_size // shard_size
+    if shard_size < 2 or replicate_size < 2:
+        raise ValueError(
+            f"fsdp_config.sharding_strategy='hybrid_shard' needs to both shard and "
+            f"replicate, but hybrid_shard_size={shard_size} over a world size of "
+            f"{world_size} gives a shard degree of {shard_size} and a replicate "
+            f"degree of {replicate_size}. Use 'full_shard' for a single shard "
+            f"group, or set fsdp_config.hybrid_shard_size so that both degrees "
+            f"are at least 2."
+        )
+
+    return (replicate_size, shard_size), ("ddp", "fsdp")
+
+
+def create_device_mesh(
+    world_size: int,
+    sharding_strategy: str = "full_shard",
+    hybrid_shard_size: int = -1,
+) -> DeviceMesh:
+    """
+    Create the device mesh the FSDP strategies are wrapped on.
+
+    Args:
+        world_size (int): Total number of ranks in the FSDP group.
+        sharding_strategy (str): The configured ``fsdp_config.sharding_strategy``.
+        hybrid_shard_size (int): Ranks per shard group for ``hybrid_shard``.
+
+    Returns:
+        DeviceMesh: A 1-D ``("fsdp",)`` mesh, or a 2-D ``("ddp", "fsdp")`` mesh
+        for ``hybrid_shard``.
+    """
+    mesh_shape, mesh_dim_names = resolve_fsdp_mesh(
+        world_size,
+        sharding_strategy=sharding_strategy,
+        hybrid_shard_size=hybrid_shard_size,
+        local_world_size=int(os.environ.get("LOCAL_WORLD_SIZE", 0) or 0),
+    )
     return init_device_mesh(
-        Worker.torch_device_type, mesh_shape=(world_size,), mesh_dim_names=["fsdp"]
+        Worker.torch_device_type,
+        mesh_shape=mesh_shape,
+        mesh_dim_names=mesh_dim_names,
     )
 
 

--- a/rlinf/hybrid_engines/fsdp/utils.py
+++ b/rlinf/hybrid_engines/fsdp/utils.py
@@ -64,6 +64,13 @@ class FSDPVersion(str, Enum):
 
 HYBRID_SHARDING_STRATEGY = "hybrid_shard"
 
+SHARDING_STRATEGIES = {
+    "full_shard": ShardingStrategy.FULL_SHARD,
+    "shard_grad_op": ShardingStrategy.SHARD_GRAD_OP,
+    HYBRID_SHARDING_STRATEGY: ShardingStrategy.HYBRID_SHARD,
+    "no_shard": ShardingStrategy.NO_SHARD,
+}
+
 
 def resolve_fsdp_mesh(
     world_size: int,
@@ -97,10 +104,20 @@ def resolve_fsdp_mesh(
         tuple[tuple[int, ...], tuple[str, ...]]: The mesh shape and its dim names.
 
     Raises:
-        ValueError: If ``hybrid_shard`` is requested with a shard group size that
-            is unset, does not divide ``world_size``, or leaves a shard or
-            replicate degree below 2.
+        ValueError: If ``sharding_strategy`` is not a known strategy name, or if
+            ``hybrid_shard`` is requested with a shard group size that is unset,
+            does not divide ``world_size``, or leaves a shard or replicate degree
+            below 2.
     """
+    # Every FSDP component resolves its mesh here, while get_sharding_strategy()
+    # is only reached on the FSDP1 path. Validating the name here keeps a typo
+    # from quietly selecting the 1-D branch and training under full_shard.
+    if sharding_strategy not in SHARDING_STRATEGIES:
+        raise ValueError(
+            f"Unknown fsdp_config.sharding_strategy {sharding_strategy!r}; expected "
+            f"one of {', '.join(SHARDING_STRATEGIES)}."
+        )
+
     if sharding_strategy != HYBRID_SHARDING_STRATEGY:
         return (world_size,), ("fsdp",)
 
@@ -892,12 +909,6 @@ def get_sharding_strategy(strategy_str: str) -> ShardingStrategy:
     Returns:
         ShardingStrategy: The corresponding ShardingStrategy enum value.
     """
-    SHARDING_STRATEGIES = {
-        "full_shard": ShardingStrategy.FULL_SHARD,
-        "shard_grad_op": ShardingStrategy.SHARD_GRAD_OP,
-        "hybrid_shard": ShardingStrategy.HYBRID_SHARD,
-        "no_shard": ShardingStrategy.NO_SHARD,
-    }
     assert strategy_str in SHARDING_STRATEGIES, (
         f"Unknown sharding strategy: {strategy_str}"
     )

--- a/rlinf/hybrid_engines/fsdp/utils.py
+++ b/rlinf/hybrid_engines/fsdp/utils.py
@@ -28,7 +28,6 @@
 
 import functools
 import math
-import os
 import warnings
 from enum import Enum
 from typing import ContextManager, Iterable, Optional, Union
@@ -70,7 +69,6 @@ def resolve_fsdp_mesh(
     world_size: int,
     sharding_strategy: str = "full_shard",
     hybrid_shard_size: int = -1,
-    local_world_size: Optional[int] = None,
 ) -> tuple[tuple[int, ...], tuple[str, ...]]:
     """
     Resolve the shape and dim names of the FSDP device mesh.
@@ -83,30 +81,36 @@ def resolve_fsdp_mesh(
     reads a 2-D mesh as ``HSDPMeshInfo(shard_mesh_dim=1, replicate_mesh_dim=0)``.
     The dim order below therefore gives both backends the same HSDP layout.
 
+    ``hybrid_shard_size`` has to be configured rather than derived from the
+    node-local rank count: ``init_device_mesh`` is collective and hangs when the
+    shape disagrees between ranks, and a node-local count is not guaranteed to
+    agree (an uneven placement gives different counts per node, and FSDP worker
+    groups launch with ``isolate_gpu=True``, which pins ``LOCAL_WORLD_SIZE`` to
+    1). A configured value is identical on every rank by construction.
+
     Args:
         world_size (int): Total number of ranks in the FSDP group.
         sharding_strategy (str): The configured ``fsdp_config.sharding_strategy``.
         hybrid_shard_size (int): Ranks per shard group for ``hybrid_shard``.
-            Values <= 0 mean "shard within a node", i.e. use ``local_world_size``.
-        local_world_size (Optional[int]): Number of ranks on this node. Only read
-            when ``hybrid_shard_size`` is not set explicitly.
 
     Returns:
         tuple[tuple[int, ...], tuple[str, ...]]: The mesh shape and its dim names.
+
+    Raises:
+        ValueError: If ``hybrid_shard`` is requested with a shard group size that
+            is unset, does not divide ``world_size``, or leaves a shard or
+            replicate degree below 2.
     """
     if sharding_strategy != HYBRID_SHARDING_STRATEGY:
         return (world_size,), ("fsdp",)
 
     shard_size = hybrid_shard_size
     if shard_size is None or shard_size <= 0:
-        if not local_world_size or local_world_size <= 0:
-            raise ValueError(
-                "fsdp_config.sharding_strategy='hybrid_shard' needs a shard group "
-                "size, but LOCAL_WORLD_SIZE is not set, so it cannot default to "
-                "one shard group per node. Set fsdp_config.hybrid_shard_size to "
-                "the number of ranks that should shard together."
-            )
-        shard_size = local_world_size
+        raise ValueError(
+            "fsdp_config.sharding_strategy='hybrid_shard' requires "
+            "fsdp_config.hybrid_shard_size to be set to the number of ranks that "
+            "shard together, usually the number of accelerators on one node."
+        )
 
     if world_size % shard_size != 0:
         raise ValueError(
@@ -149,7 +153,6 @@ def create_device_mesh(
         world_size,
         sharding_strategy=sharding_strategy,
         hybrid_shard_size=hybrid_shard_size,
-        local_world_size=int(os.environ.get("LOCAL_WORLD_SIZE", 0) or 0),
     )
     return init_device_mesh(
         Worker.torch_device_type,

--- a/tests/unit_tests/test_fsdp_hybrid_shard_mesh.py
+++ b/tests/unit_tests/test_fsdp_hybrid_shard_mesh.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 import pytest
 from omegaconf import OmegaConf
 
+from rlinf.config import validate_fsdp_weight_sync_cfg
 from rlinf.hybrid_engines.fsdp.strategy.base import FSDPStrategyBase
 from rlinf.hybrid_engines.fsdp.utils import resolve_fsdp_mesh
 
@@ -106,3 +107,50 @@ def test_weight_sync_rejects_hybrid_shard():
     # the replicate dim, so it must fail loudly instead of syncing wrong bytes.
     with pytest.raises(NotImplementedError, match="hybrid_shard"):
         FSDPStrategyBase._assert_single_shard_group(_strategy_with("hybrid_shard"))
+
+
+@pytest.mark.parametrize("sharding_strategy", ["hybrid-shard", "HYBRID_SHARD", ""])
+def test_unknown_sharding_strategy_is_rejected(sharding_strategy):
+    # Only FSDP1 routes the name through get_sharding_strategy(), so without this
+    # check a typo would take the 1-D branch and silently train under full_shard.
+    with pytest.raises(ValueError, match="Unknown fsdp_config.sharding_strategy"):
+        resolve_fsdp_mesh(16, sharding_strategy=sharding_strategy)
+
+
+def _run_cfg(actor_strategy, inference_strategy, load_from_actor=True):
+    return OmegaConf.create(
+        {
+            "actor": {"fsdp_config": {"sharding_strategy": actor_strategy}},
+            "inference": {
+                "load_from_actor": load_from_actor,
+                "fsdp_config": {"sharding_strategy": inference_strategy},
+            },
+        }
+    )
+
+
+def test_weight_sync_cfg_accepts_full_shard_on_both_sides():
+    validate_fsdp_weight_sync_cfg(_run_cfg("full_shard", "full_shard"))
+
+
+@pytest.mark.parametrize(
+    ("actor_strategy", "inference_strategy"),
+    [
+        ("hybrid_shard", "full_shard"),  # actor overridden inline
+        ("full_shard", "hybrid_shard"),  # shared fsdp group file edited
+        ("hybrid_shard", "hybrid_shard"),
+    ],
+)
+def test_weight_sync_cfg_rejects_hybrid_shard_on_either_side(
+    actor_strategy, inference_strategy
+):
+    # An asymmetric config is the dangerous one: the handshake guard would raise
+    # on one side while the other blocks in the paired send/recv.
+    with pytest.raises(ValueError, match="hybrid_shard"):
+        validate_fsdp_weight_sync_cfg(_run_cfg(actor_strategy, inference_strategy))
+
+
+def test_weight_sync_cfg_ignores_runs_that_do_not_load_from_the_actor():
+    validate_fsdp_weight_sync_cfg(
+        _run_cfg("hybrid_shard", "full_shard", load_from_actor=False)
+    )

--- a/tests/unit_tests/test_fsdp_hybrid_shard_mesh.py
+++ b/tests/unit_tests/test_fsdp_hybrid_shard_mesh.py
@@ -1,0 +1,82 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from rlinf.hybrid_engines.fsdp.utils import resolve_fsdp_mesh
+
+
+@pytest.mark.parametrize(
+    "sharding_strategy", ["full_shard", "shard_grad_op", "no_shard"]
+)
+def test_non_hybrid_strategies_keep_the_one_dimensional_mesh(sharding_strategy):
+    assert resolve_fsdp_mesh(8, sharding_strategy=sharding_strategy) == (
+        (8,),
+        ("fsdp",),
+    )
+
+
+def test_hybrid_shard_replicates_on_dim0_and_shards_on_dim1():
+    # PyTorch reads mesh dim 0 as the replicate group and dim 1 as the shard
+    # group for both FSDP1 HYBRID_SHARD and FSDP2 fully_shard, so the order and
+    # the pairing of names to sizes are part of the contract, not cosmetic.
+    mesh_shape, mesh_dim_names = resolve_fsdp_mesh(
+        16, sharding_strategy="hybrid_shard", hybrid_shard_size=8
+    )
+
+    assert mesh_dim_names == ("ddp", "fsdp")
+    assert mesh_shape == (2, 8)
+    assert dict(zip(mesh_dim_names, mesh_shape)) == {"ddp": 2, "fsdp": 8}
+
+
+def test_hybrid_shard_defaults_to_one_shard_group_per_node():
+    assert resolve_fsdp_mesh(
+        16, sharding_strategy="hybrid_shard", local_world_size=8
+    ) == ((2, 8), ("ddp", "fsdp"))
+
+
+def test_hybrid_shard_size_overrides_the_node_local_default():
+    assert resolve_fsdp_mesh(
+        16, sharding_strategy="hybrid_shard", hybrid_shard_size=4, local_world_size=8
+    ) == ((4, 4), ("ddp", "fsdp"))
+
+
+def test_hybrid_shard_without_a_size_or_local_world_size_is_rejected():
+    with pytest.raises(ValueError, match="LOCAL_WORLD_SIZE"):
+        resolve_fsdp_mesh(16, sharding_strategy="hybrid_shard", local_world_size=0)
+
+
+def test_hybrid_shard_size_that_does_not_divide_the_world_is_rejected():
+    with pytest.raises(ValueError, match="must divide"):
+        resolve_fsdp_mesh(12, sharding_strategy="hybrid_shard", hybrid_shard_size=8)
+
+
+@pytest.mark.parametrize(
+    ("world_size", "hybrid_shard_size"),
+    [
+        (8, 8),  # replicate degree 1: nothing is replicated
+        (8, 1),  # shard degree 1: nothing is sharded
+    ],
+)
+def test_hybrid_shard_degenerating_to_a_single_group_is_rejected(
+    world_size, hybrid_shard_size
+):
+    # A silent fall back to full_shard here would let a mis-sized multi-node run
+    # train under a different strategy than the config asks for.
+    with pytest.raises(ValueError, match="both shard and replicate"):
+        resolve_fsdp_mesh(
+            world_size,
+            sharding_strategy="hybrid_shard",
+            hybrid_shard_size=hybrid_shard_size,
+        )

--- a/tests/unit_tests/test_fsdp_hybrid_shard_mesh.py
+++ b/tests/unit_tests/test_fsdp_hybrid_shard_mesh.py
@@ -12,9 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+from types import SimpleNamespace
 
+import pytest
+from omegaconf import OmegaConf
+
+from rlinf.hybrid_engines.fsdp.strategy.base import FSDPStrategyBase
 from rlinf.hybrid_engines.fsdp.utils import resolve_fsdp_mesh
+
+
+def _strategy_with(sharding_strategy):
+    return SimpleNamespace(
+        cfg=OmegaConf.create({"fsdp_config": {"sharding_strategy": sharding_strategy}})
+    )
 
 
 @pytest.mark.parametrize(
@@ -40,21 +50,22 @@ def test_hybrid_shard_replicates_on_dim0_and_shards_on_dim1():
     assert dict(zip(mesh_dim_names, mesh_shape)) == {"ddp": 2, "fsdp": 8}
 
 
-def test_hybrid_shard_defaults_to_one_shard_group_per_node():
+def test_hybrid_shard_size_sets_the_shard_degree():
     assert resolve_fsdp_mesh(
-        16, sharding_strategy="hybrid_shard", local_world_size=8
-    ) == ((2, 8), ("ddp", "fsdp"))
-
-
-def test_hybrid_shard_size_overrides_the_node_local_default():
-    assert resolve_fsdp_mesh(
-        16, sharding_strategy="hybrid_shard", hybrid_shard_size=4, local_world_size=8
+        16, sharding_strategy="hybrid_shard", hybrid_shard_size=4
     ) == ((4, 4), ("ddp", "fsdp"))
 
 
-def test_hybrid_shard_without_a_size_or_local_world_size_is_rejected():
-    with pytest.raises(ValueError, match="LOCAL_WORLD_SIZE"):
-        resolve_fsdp_mesh(16, sharding_strategy="hybrid_shard", local_world_size=0)
+@pytest.mark.parametrize("hybrid_shard_size", [-1, 0, None])
+def test_hybrid_shard_without_a_configured_size_is_rejected(hybrid_shard_size):
+    # Deriving the shard degree per rank (e.g. from LOCAL_WORLD_SIZE) would let
+    # ranks disagree on the mesh shape, and init_device_mesh is collective.
+    with pytest.raises(ValueError, match="requires"):
+        resolve_fsdp_mesh(
+            16,
+            sharding_strategy="hybrid_shard",
+            hybrid_shard_size=hybrid_shard_size,
+        )
 
 
 def test_hybrid_shard_size_that_does_not_divide_the_world_is_rejected():
@@ -80,3 +91,18 @@ def test_hybrid_shard_degenerating_to_a_single_group_is_rejected(
             sharding_strategy="hybrid_shard",
             hybrid_shard_size=hybrid_shard_size,
         )
+
+
+@pytest.mark.parametrize(
+    "sharding_strategy", ["full_shard", "shard_grad_op", "no_shard"]
+)
+def test_weight_sync_accepts_single_shard_group_strategies(sharding_strategy):
+    FSDPStrategyBase._assert_single_shard_group(_strategy_with(sharding_strategy))
+
+
+def test_weight_sync_rejects_hybrid_shard():
+    # The actor<->inference handshake advertises each rank's shard as
+    # rank * ceil(numel / world_size), which is wrong once shards repeat along
+    # the replicate dim, so it must fail loudly instead of syncing wrong bytes.
+    with pytest.raises(NotImplementedError, match="hybrid_shard"):
+        FSDPStrategyBase._assert_single_shard_group(_strategy_with("hybrid_shard"))

--- a/tests/unit_tests/test_fsdp_hybrid_shard_mesh.py
+++ b/tests/unit_tests/test_fsdp_hybrid_shard_mesh.py
@@ -117,16 +117,11 @@ def test_unknown_sharding_strategy_is_rejected(sharding_strategy):
         resolve_fsdp_mesh(16, sharding_strategy=sharding_strategy)
 
 
-def _run_cfg(actor_strategy, inference_strategy, load_from_actor=True):
-    return OmegaConf.create(
-        {
-            "actor": {"fsdp_config": {"sharding_strategy": actor_strategy}},
-            "inference": {
-                "load_from_actor": load_from_actor,
-                "fsdp_config": {"sharding_strategy": inference_strategy},
-            },
-        }
-    )
+def _run_cfg(actor_strategy, inference_strategy):
+    cfg = {"actor": {"fsdp_config": {"sharding_strategy": actor_strategy}}}
+    if inference_strategy is not None:
+        cfg["inference"] = {"fsdp_config": {"sharding_strategy": inference_strategy}}
+    return OmegaConf.create(cfg)
 
 
 def test_weight_sync_cfg_accepts_full_shard_on_both_sides():
@@ -150,7 +145,7 @@ def test_weight_sync_cfg_rejects_hybrid_shard_on_either_side(
         validate_fsdp_weight_sync_cfg(_run_cfg(actor_strategy, inference_strategy))
 
 
-def test_weight_sync_cfg_ignores_runs_that_do_not_load_from_the_actor():
-    validate_fsdp_weight_sync_cfg(
-        _run_cfg("hybrid_shard", "full_shard", load_from_actor=False)
-    )
+def test_weight_sync_cfg_ignores_runs_without_an_fsdp_inference_group():
+    # SFT and other single-component runs never do the offset handshake, and are
+    # the case issue #1502 asks hybrid_shard for.
+    validate_fsdp_weight_sync_cfg(_run_cfg("hybrid_shard", None))


### PR DESCRIPTION
### Description

`sharding_strategy: "hybrid_shard"` is documented in every `examples/*/config/hybrid_engines/fsdp.yaml` and accepted by `get_sharding_strategy()`, but it could not be used: `create_device_mesh()` always built a 1-D mesh, and PyTorch requires a 2-D mesh for hybrid strategies.

```python
# before
def create_device_mesh(world_size):
    return init_device_mesh(
        Worker.torch_device_type, mesh_shape=(world_size,), mesh_dim_names=["fsdp"]
    )
```

Reproduced with 4 gloo ranks on CPU, driving `torch.distributed.fsdp._init_utils._init_process_group_state` with the mesh `create_device_mesh` produces:

```
1-D mesh (create_device_mesh today): ValueError: Expected device_mesh to have ndim=2 but got 1
2-D mesh (ddp, fsdp):                OK  shard_pg=2  inter_pg=2
```

The change:

1. **`resolve_fsdp_mesh()`** returns `mesh_shape=(world_size // hybrid_shard_size, hybrid_shard_size)` with `mesh_dim_names=("ddp", "fsdp")` for `hybrid_shard`, and the current 1-D `("fsdp",)` mesh for everything else. `create_device_mesh()` is now a thin wrapper over it.
2. **New `fsdp_config.hybrid_shard_size`**: ranks per shard group. Set it to the accelerators on one node to shard intra-node and replicate inter-node.
3. **`FSDPModelManager._dp_group`** now resolves to the shard (`"fsdp"`) group.
4. **Validation** for unknown strategy names, degenerate shard/replicate degrees, and `hybrid_shard` on runs that configure an FSDP inference group.
5. `hybrid_shard_size` documented in the four `hybrid_engines/fsdp.yaml` files and in the EN + ZH `fsdp_config` tables in `guides/agentic_config.rst`.

### Motivation and Context

Closes #1502 — @CarlDegio asked for hybrid shard for communication efficiency in multi-node training, in the context of PI0.5 SFT.

**Why the dim order is `("ddp", "fsdp")` and not the reverse.** It is part of the contract, not cosmetic. FSDP1's `_init_process_group_state_for_hybrid_shard` takes mesh dim 0 as `_inter_node_pg` and dim 1 as `process_group`; FSDP2's `fully_shard` reads a 2-D named mesh as `HSDPMeshInfo(shard_mesh_dim=1, replicate_mesh_dim=0)`. One mesh therefore gives both backends the same HSDP layout, and reversing it silently swaps shard and replicate.

**Why `hybrid_shard_size` is required rather than defaulted from the node-local rank count.** My first version defaulted to `LOCAL_WORLD_SIZE`. That is wrong twice over: `init_device_mesh` is collective, so ranks that disagree on the shape hang rather than error, and an uneven placement gives different per-node counts (a 4+4+8 layout over world 16 has both `(4,4)` and `(2,8)` validating on different ranks). FSDP worker groups also launch with `isolate_gpu=True`, which pins `LOCAL_WORLD_SIZE` to `1` in `Worker._setup_local_rank_world_size`, so the default would have resolved to `1` on every rank anyway. A configured value is identical on every rank by construction.

**Why `_dp_group` changed from `"ddp"` to `"fsdp"`.** The old lookup was dead code — the mesh was always 1-D `("fsdp",)`, so `"ddp" in mesh_dim_names` was never true and `_dp_group` was always `None`. It is the hook the grad-norm all-reduce in `FSDPStrategy.clip_grad_norm_` and `get_grad_norm` needs, and the shard group is the correct one: under HSDP a rank holds one shard of the gradient and the shards are replicated along `ddp`, so summing the p-norm over `ddp` or over WORLD over-counts it by the replicate degree.

**Why `hybrid_shard` is rejected for runs with an FSDP inference group.** The actor↔inference handshake in `setup_actor_sync_inference_ranks` advertises a rank's shard as `rank * ceil(numel / world_size)`, which only holds while a parameter is sharded once across the whole world; its own docstring notes multi-dim sharding as future work. Under HSDP a rank holds shard `rank % hybrid_shard_size` and the shards repeat along the replicate dim, so the advertised offsets would not match the data and weights would be synced from the wrong region. `sync_model_to_rollout` is unaffected — it goes through `DTensor.full_tensor()`, which is correct over a 2-D mesh.

### How has this been tested?

**Unit tests** — `tests/unit_tests/test_fsdp_hybrid_shard_mesh.py`, 23 tests, CPU-only, no GPU or distributed init needed. They cover the mesh shape and dim-name pairing, the shard/replicate degrees, every rejection path, and the two config guards.

To confirm the tests discriminate rather than decorate, I broke the implementation eight ways, re-ran, and checked each failure landed on the intended assertion before restoring:

| Deliberate break | Result |
| --- | --- |
| dim order reversed to `("fsdp", "ddp")` | 3 tests fail |
| degenerate shard/replicate guard removed | 2 fail |
| 2-D mesh returned for every strategy | 3 fail |
| weight-sync handshake guard removed | 1 fails |
| unset `hybrid_shard_size` accepted | 3 fail |
| strategy-name whitelist removed | 3 fail |
| weight-sync config gate always returns early | 3 fail |

**End-to-end against real torch** (4 gloo ranks on CPU, torch 2.11), feeding `resolve_fsdp_mesh`'s output to both backends:

```
resolve_fsdp_mesh -> shape=(2, 2) names=('ddp', 'fsdp')
FSDP1 shard pg size=2 replicate pg size=2
FSDP2 mesh info: HSDPMeshInfo shard_mesh_dim=1 replicate_mesh_dim=0
_dp_group (mesh['fsdp']) size=2  WORLD size=4
all_reduce over _dp_group summed the shard group only: 1.0 (WORLD would give 6.0)
```

**Regression** — ran the CPU unit-test suite file-by-file as CI does, on this branch and on `main`. Identical results; the only failures are pre-existing local environment noise (`test_auto_placement` and `test_auto_resume_checkpoint` error on a missing `torchdata`, `test_distributed_ray_log_collector` has one failure, three GPU-only files collect nothing) and reproduce unchanged on `main`. `ruff check --preview` and `ruff format --check` are clean.

**Not tested**: I have no multi-node GPU access, so a real HSDP training run is unverified. What is verified is that the mesh both backends receive is the HSDP mesh they expect, and that the grad-norm reduction spans the shard group.

### Notes for review

- **The weight-sync rejection is conservative, not exact.** Whether an FSDP inference group is actually launched depends on the entry script — for reasoning it is the placement mode plus `algorithm.recompute_logprobs` in `main_grpo.py`. `validate_fsdp_weight_sync_cfg` keys off the presence of an `inference.fsdp_config` section instead, because restating that launch condition in `config.py` would duplicate logic that can drift. It can therefore reject a run whose inference group would not have been created. If you would rather have the exact condition, say so and I will thread the placement mode through. SFT-style runs with no `inference` section — the case #1502 asks for — are unaffected.
- **One adjacent bug fixed, deliberately.** Passing `_dp_group` unconditionally also fixes a pre-existing FSDP2 defect: `get_grad_norm` wraps both reductions in `if dp_group is not None`, so `fsdp2` + `full_shard` previously performed no cross-rank reduction at all and every rank clipped on its own shard's partial norm. I folded it in because the alternative was leaving `hybrid_shard` and `full_shard` clipping on different bases in code this PR already rewrites. Happy to split it into its own PR if you would rather review it separately.
- **Adjacent, found but deliberately not fixed**: making the actor↔inference handshake HSDP-aware. It would need the shard layout in the exchanged metadata rather than the `rank * ceil(numel / world_size)` assumption. That is a bigger change with a wire-format implication, and I cannot test it without multi-GPU access. Guarded here instead; happy to open a follow-up issue.
- **`hybrid_shard_size` naming**: I asked in the issue whether you prefer this or verl's `fsdp_size`, which the surrounding code looks derived from, and got no answer. Trivial to rename.
- The runtime guard in `_assert_single_shard_group` is kept as a backstop for callers that bypass config validation, but with the config check in place it should never fire in a Hydra-launched run.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (Document-only update)

### Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
