### PR TITLE
feat(agent): agentic tokenizer refactor + glm search-r1

### DIFF
--- a/rlinf/agents/searchr1/searchr1_agent_loop.py
+++ b/rlinf/agents/searchr1/searchr1_agent_loop.py
@@ -46,12 +46,9 @@ class Searchr1AgentLoopWorker(MultiAgentLoopWorker):
         assert self.toolcall_parser is not None, (
             "toolcall_parser must be set in searchr1"
         )
-
-        # Inserting tool info requires re-encode token_ids, so the recompute_logprobs must be true.
-        if self.cfg.runner.task_type != "reasoning_eval":
-            assert self.cfg.algorithm.recompute_logprobs, (
-                "search r1 must use recompute_logprobs"
-            )
+        # recompute_logprobs is optional (P2). Base class already sets
+        # return_logprobs = not recompute_logprobs, so when recompute=False,
+        # sglang returns logprobs and truncate_after_stop keeps alignment.
 
     async def pre_process_query(
         self, prompt_ids: list[int], answer: str
@@ -70,7 +67,7 @@ class Searchr1AgentLoopWorker(MultiAgentLoopWorker):
         self, generate_context: dict[str, Any], output: MultiAgentLoopOutput
     ) -> MultiAgentLoopOutput:
         # Compute reward from all LLM-generated tokens (excluding tool responses)
-        final_response_text = self.tokenizer.decode(
+        final_response_text = self.agentic_tokenizer.decode(
             generate_context["all_llm_response_ids"]
         )
         reward_score = compute_score(
@@ -83,7 +80,7 @@ class Searchr1AgentLoopWorker(MultiAgentLoopWorker):
         # Store trajectory-level info for eval
         output.extra_fields["llm_reward"] = reward_score
         output.extra_fields["response_text"] = final_response_text
-        output.extra_fields["prompt_text"] = self.tokenizer.decode(
+        output.extra_fields["prompt_text"] = self.agentic_tokenizer.decode(
             generate_context.get("problem_prompt_ids", [])
         )
         # Per-turn details: each turn's input and output text
@@ -91,8 +88,12 @@ class Searchr1AgentLoopWorker(MultiAgentLoopWorker):
         for single_turn_output in output.single_turn_outputs:
             turns.append(
                 {
-                    "input": self.tokenizer.decode(single_turn_output.prompt_ids),
-                    "output": self.tokenizer.decode(single_turn_output.response_ids),
+                    "input": self.agentic_tokenizer.decode(
+                        single_turn_output.prompt_ids
+                    ),
+                    "output": self.agentic_tokenizer.decode(
+                        single_turn_output.response_ids
+                    ),
                 }
             )
         output.extra_fields["turns"] = turns
@@ -120,24 +121,36 @@ class Searchr1AgentLoopWorker(MultiAgentLoopWorker):
             turn_prompt_ids, sampling_params={"max_new_tokens": max_resp_len}
         )
         llm_response_ids: list[int] = generate_result["output_ids"]
+        llm_response_logprobs = (
+            generate_result["logprobs"] if self.return_logprobs else None
+        )
 
         if len(llm_response_ids) > max_resp_len:
             llm_response_ids = llm_response_ids[:max_resp_len]
-        llm_response_text = self.tokenizer.decode(llm_response_ids)
+            if llm_response_logprobs is not None:
+                llm_response_logprobs = llm_response_logprobs[:max_resp_len]
 
-        # split </search> manually
-        if "</search>" in llm_response_text:
-            llm_response_text = llm_response_text.split("</search>")[0] + "</search>"
-            llm_response_ids = self.tokenizer.encode(llm_response_text)
+        # Truncate at </search> in token space (no re-encode, keeps logprobs aligned).
+        # content_start_offset skips the reasoning block
+        content_start = self.agentic_tokenizer.content_start_offset(llm_response_ids)
+        llm_response_ids, matched = self.agentic_tokenizer.truncate_after_stop(
+            response_ids=llm_response_ids,
+            stop_str="</search>",
+            start=content_start,
+        )
+        if llm_response_logprobs is not None:
+            llm_response_logprobs = llm_response_logprobs[: len(llm_response_ids)]
+        llm_response_text = self.agentic_tokenizer.decode(llm_response_ids)
 
         llm_output = AgentLoopOutput(
             prompt_ids=copy.deepcopy(turn_prompt_ids),
             response_ids=llm_response_ids,
+            response_logprobs=llm_response_logprobs,
         )
         generate_context["all_llm_response_ids"] += llm_response_ids
 
         if len(llm_response_ids) == max_resp_len:
-            return False, None, None, llm_output
+            return False, None, llm_response_text, llm_output
 
         return True, llm_response_ids, llm_response_text, llm_output
 
@@ -167,22 +180,24 @@ class Searchr1AgentLoopWorker(MultiAgentLoopWorker):
             message = {"role": "tool", "content": tool_response.text}
             tool_messages.append(message)
 
-        # Tokenize tool responses
-        tool_response_ids: list[int] = self.tokenizer.encode(
-            tool_messages[0]["content"], add_special_tokens=False
+        # Tokenize tool response via agentic tokenizer (text mode = plain
+        # encode, model-agnostic). Returns the full next-turn prompt.
+        prefix_with_llm = turn_prompt_ids + llm_response_ids
+        next_turn_prompt_ids = self.agentic_tokenizer.get_tool_response_ids(
+            prefix_with_llm, tool_messages, mode="text"
         )
+        appended_len = len(next_turn_prompt_ids) - len(prefix_with_llm)
         max_tool_resp_len = self.max_resp_len - (
             len(turn_prompt_ids) + len(llm_response_ids) - len(problem_prompt_ids)
         )
-        if len(tool_response_ids) > max_tool_resp_len:
+        if appended_len > max_tool_resp_len:
             return False, None
 
-        next_turn_prompt_ids = turn_prompt_ids + llm_response_ids + tool_response_ids
         if self.print_outputs:
             # add anything you want to print
             trace_prints.append(
                 {
-                    "prompt": self.tokenizer.decode(turn_prompt_ids),
+                    "prompt": self.agentic_tokenizer.decode(turn_prompt_ids),
                     "generate": llm_response_text,
                     "tool_resp": tool_messages,
                 }

--- a/rlinf/agents/tokenization/__init__.py
+++ b/rlinf/agents/tokenization/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agentic tokenizer package: model-level tokenization for agent loops."""
+
+from rlinf.agents.tokenization.agentic_tokenizer import (
+    AgenticTokenizer,
+    AgenticTokenizerType,
+    GLMAgenticTokenizer,
+    QwenAgenticTokenizer,
+    get_agentic_tokenizer,
+)
+
+__all__ = [
+    "AgenticTokenizer",
+    "AgenticTokenizerType",
+    "GLMAgenticTokenizer",
+    "QwenAgenticTokenizer",
+    "get_agentic_tokenizer",
+]

--- a/rlinf/agents/tokenization/agentic_tokenizer.py
+++ b/rlinf/agents/tokenization/agentic_tokenizer.py
@@ -1,0 +1,250 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agentic tokenizer: model-level tokenization for agent loops."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from rlinf.models.tokenization.hf import hf_tokenizer
+
+
+class AgenticTokenizer:
+    """Base class: model-level tokenization for agent loops.
+
+    Subclasses customize model-specific behavior (reasoning parser name,
+    native tool-call boundary merge, reasoning offset). The base provides the
+    plain-text tool-response path (mode="text") used by search-r1 for both
+    qwen and glm, bit-identical to the pre-refactor behavior.
+    """
+
+    reasoning_parser: str | None = None
+    tool_call_parser: str | None = None
+
+    def __init__(
+        self,
+        model_path: str,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        trust_remote_code: bool = False,
+    ):
+        self.tokenizer = hf_tokenizer(model_path, trust_remote_code=trust_remote_code)
+        self.chat_template_kwargs: dict[str, Any] = chat_template_kwargs or {}
+
+    def require_token_id(self, token_str: str) -> int:
+        """Convert token string to id, raising if not in vocab."""
+        tid = self.tokenizer.convert_tokens_to_ids(token_str)
+        if tid is None or tid == self.tokenizer.unk_token_id:
+            raise ValueError(f"{token_str!r} not in {type(self).__name__} vocab")
+        return tid
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> list[int]:
+        return self.tokenizer.encode(text, add_special_tokens=add_special_tokens)
+
+    def decode(self, ids: list[int], skip_special_tokens: bool = True) -> str:
+        return self.tokenizer.decode(ids, skip_special_tokens=skip_special_tokens)
+
+    def apply_chat_template(self, messages: list[dict], **kwargs: Any):
+        merged = {**self.chat_template_kwargs, **kwargs}
+        return self.tokenizer.apply_chat_template(messages, **merged)
+
+    def get_tool_response_ids(
+        self,
+        prefix_ids: list[int],
+        tool_messages: list[dict],
+        mode: str = "text",
+    ) -> list[int]:
+        """Return the full merged prompt ids for the next turn.
+
+        mode="text" encodes the tool response as plain text (search-r1 style,
+        model-agnostic). mode="native" uses the model-native chat-template
+        boundary merge (subclass-specific).
+        """
+        if mode == "native":
+            return self.build_native_tool_response(prefix_ids, tool_messages)
+        return list(prefix_ids) + self.build_text_tool_response(tool_messages)
+
+    def build_text_tool_response(self, tool_messages: list[dict]) -> list[int]:
+        content = "".join(m["content"] for m in tool_messages)
+        return self.encode(content, add_special_tokens=False)
+
+    def build_native_tool_response(
+        self, prefix_ids: list[int], tool_messages: list[dict]
+    ) -> list[int]:
+        raise NotImplementedError(
+            "Native tool-call boundary merge requires a model-specific subclass"
+        )
+
+    def content_start_offset(self, response_ids: list[int]) -> int:
+        """Index in response_ids where model content begins (after reasoning).
+
+        Base has no reasoning, returns 0.
+        """
+        return 0
+
+    def truncate_after_stop(
+        self, response_ids: list[int], stop_str: str, start: int
+    ) -> tuple[list[int], bool]:
+        """Truncate response_ids at the first token where stop_str appears in
+        the content region (response_ids[start:]).
+
+        Returns (truncated_ids, matched). Decoded text length is monotonic in
+        token count, so binary search finds the smallest k such that
+        decode(response_ids[start:k]) contains stop_str. No re-encode, so
+        response_ids stays a prefix of the original output_ids.
+        """
+        content_text = self.decode(response_ids[start:])
+        pos = content_text.find(stop_str)
+        if pos == -1:
+            return list(response_ids), False
+        target_end = pos + len(stop_str)
+        lo, hi = start + 1, len(response_ids)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if len(self.decode(response_ids[start:mid])) >= target_end:
+                hi = mid
+            else:
+                lo = mid + 1
+        result = response_ids[:lo]
+        assert stop_str in self.decode(result), (
+            f"truncate_after_stop landed before {stop_str!r}"
+        )
+        return result, True
+
+
+class QwenAgenticTokenizer(AgenticTokenizer):
+    """Qwen2.5/3 reference subclass. Inherits base text-mode path."""
+
+    reasoning_parser = "qwen3"
+    tool_call_parser = "qwen25"
+
+
+class GLMAgenticTokenizer(AgenticTokenizer):
+    """GLM-4.7-Flash subclass.
+
+    Text mode (search-r1): plain-text encode, identical to qwen.
+    Native mode: observation-token boundary merge via incremental chat-template
+    render.
+    """
+
+    reasoning_parser = "glm45"
+    tool_call_parser = "glm47"
+    stop_token_ids_extra: tuple[str, ...] = (
+        "<|observation|>",
+        "<|user|>",
+    )
+
+    def __init__(
+        self,
+        model_path: str,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        trust_remote_code: bool = True,
+    ):
+        # clear_thinking=False keeps reasoning blocks in the token stream.
+        merged = {"clear_thinking": False, **(chat_template_kwargs or {})}
+        super().__init__(model_path, merged, trust_remote_code=trust_remote_code)
+        # Resolve special-token ids at load time; fail loudly if missing.
+        self.observation_token_id = self.require_token_id("<|observation|>")
+        self.user_token_id = self.require_token_id("<|user|>")
+        self.ambiguous_token_ids = {self.observation_token_id, self.user_token_id}
+        self.reasoning_end_token_id = self.require_token_id("</think>")
+
+    def render_incremental(self, tool_messages: list[dict]) -> list[int]:
+        """Incremental chat-template render of tool messages + next assistant
+        prompt, returned as token-id diff."""
+        without_tool_ids = self.tokenizer.apply_chat_template(
+            [
+                {"role": "system", "content": "dummy"},
+                {"role": "assistant", "content": " "},
+            ],
+            add_generation_prompt=False,
+            tokenize=True,
+            return_dict=False,
+        )
+        with_tool_ids = self.tokenizer.apply_chat_template(
+            [
+                {"role": "system", "content": "dummy"},
+                {"role": "assistant", "content": " "},
+                *tool_messages,
+            ],
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=False,
+        )
+        return list(with_tool_ids[len(without_tool_ids) :])
+
+    def build_native_tool_response(
+        self, prefix_ids: list[int], tool_messages: list[dict]
+    ) -> list[int]:
+        incremental = self.render_incremental(tool_messages)
+        prefix = list(prefix_ids)
+        # Strip trailing ambiguous stop==start marker to avoid duplication.
+        if prefix and prefix[-1] in self.ambiguous_token_ids:
+            prefix = prefix[:-1]
+        return prefix + incremental
+
+    def content_start_offset(self, response_ids: list[int]) -> int:
+        """Content begins right after the last reasoning-end token; 0 if
+        absent. Uses last occurrence because a thinking model may emit the
+        closing think-token as a literal string inside reasoning."""
+        try:
+            idx = len(response_ids) - response_ids[::-1].index(
+                self.reasoning_end_token_id
+            )
+            return idx
+        except ValueError:
+            return 0
+
+
+class AgenticTokenizerType(str, Enum):
+    """Registry keys for get_agentic_tokenizer."""
+
+    DEFAULT = "default"
+    QWEN = "qwen"
+    GLM47 = "glm47"
+
+
+AGENTIC_TOKENIZER_REGISTRY: dict[AgenticTokenizerType, type[AgenticTokenizer]] = {
+    AgenticTokenizerType.DEFAULT: AgenticTokenizer,
+    AgenticTokenizerType.QWEN: QwenAgenticTokenizer,
+    AgenticTokenizerType.GLM47: GLMAgenticTokenizer,
+}
+
+
+def get_agentic_tokenizer(
+    model_path: str,
+    tokenizer_type: str = "default",
+    chat_template_kwargs: dict[str, Any] | None = None,
+    trust_remote_code: bool = False,
+) -> AgenticTokenizer:
+    """Build an AgenticTokenizer for the given model."""
+    try:
+        key = AgenticTokenizerType(tokenizer_type)
+    except ValueError as e:
+        raise ValueError(
+            f"Unknown agentic_tokenizer type: {tokenizer_type!r}. "
+            f"Valid: {[t.value for t in AgenticTokenizerType]}"
+        ) from e
+    cls = AGENTIC_TOKENIZER_REGISTRY[key]
+    return cls(model_path, chat_template_kwargs, trust_remote_code)
+
+
+__all__ = [
+    "AgenticTokenizer",
+    "QwenAgenticTokenizer",
+    "GLMAgenticTokenizer",
+    "AgenticTokenizerType",
+    "get_agentic_tokenizer",
+]

--- a/rlinf/data/datasets/reasoning/dataset.py
+++ b/rlinf/data/datasets/reasoning/dataset.py
@@ -77,6 +77,9 @@ class ReasoningDataset(Dataset):
         self.prompt_key = config.data.prompt_key
         self.answer_key = config.data.answer_key
         self.is_apply_chat_template = config.data.apply_chat_template
+        self.apply_chat_template_kwargs = config.data.get(
+            "apply_chat_template_kwargs", {}
+        )
         self.filter_prompt_by_length = config.data.get("filter_prompt_by_length", False)
         self.data_size = config.data.get("data_size", None)
         self.process_workers = config.data.get("process_workers", 1)
@@ -195,6 +198,7 @@ class ReasoningDataset(Dataset):
             texts,
             add_generation_prompt=True,
             tokenize=False,
+            **self.apply_chat_template_kwargs,
         )
         return prompts
 

--- a/rlinf/runners/agent_runner.py
+++ b/rlinf/runners/agent_runner.py
@@ -130,6 +130,7 @@ class AgentRunner(ReasoningRunner):
             if (
                 self.cfg.actor.training_backend == "megatron"
                 and self.cfg.actor.megatron.use_hf_ckpt
+                and not getattr(self.cfg.actor.megatron, "mbridge", False)
             ):
                 from rlinf.utils.ckpt_convertor.megatron_convertor.convert_hf_to_mg import (
                     convert_hf_to_mg,

--- a/rlinf/workers/agent/agent_loop.py
+++ b/rlinf/workers/agent/agent_loop.py
@@ -20,8 +20,8 @@ from typing import Any, Optional
 from uuid import uuid4
 
 from omegaconf import DictConfig
-from transformers import AutoTokenizer
 
+from rlinf.agents.tokenization import get_agentic_tokenizer
 from rlinf.agents.tool_call.schema import (
     ToolChannelRequest,
     ToolChannelResponse,
@@ -106,7 +106,13 @@ class AgentLoopWorker(Worker):
                 "agent loop worker must be MultiAgentLoopWorker if is_dynamic_rollout_batch is True"
             )
 
-        self.tokenizer = AutoTokenizer.from_pretrained(cfg.rollout.model.model_path)
+        self.agentic_tokenizer = get_agentic_tokenizer(
+            cfg.rollout.model.model_path,
+            cfg.agentloop.get("agentic_tokenizer", "default"),
+            cfg.agentloop.get("chat_template_kwargs", None),
+            cfg.rollout.model.get("trust_remote_code", False),
+        )
+        self.tokenizer = self.agentic_tokenizer.tokenizer  # back-compat alias
         self.toolcall_parser = None
         if cfg.agentloop.get("toolcall_parser", None) is not None:
             self.toolcall_parser = get_toolcall_parser(cfg.agentloop.toolcall_parser)


### PR DESCRIPTION
### Description

Introduce a pluggable `AgenticTokenizer` abstraction for agent tokenization, with Qwen and GLM-4.7-Flash implementations, enabling search-r1 agent training on GLM models.

- **AgenticTokenizer** base class (`encode`/`decode`/`apply_chat_template`/`get_tool_response_ids`/`content_start_offset`) + `QwenAgenticTokenizer` + `GLMAgenticTokenizer` + `AgenticTokenizerType` enum + `get_agentic_tokenizer` factory.
- **search-r1 agent loop**: use `AgenticTokenizer` for token-level search result truncation + reasoning-content skip via `content_start_offset`.
- **Fix GLM reasoning-end token id**: `convert_tokens_to_ids` without the pipe character (GLM's actual token has no pipe); previously returned `None` → `content_start_offset` always 0 → reasoning skip ineffective.
- **AgenticTokenizer**: `trust_remote_code` passthrough (no longer hardcoded `True`) + edge-case handling.

### Motivation and Context

Search-r1 agent training requires model-specific tokenization (chat template, tool response ids, reasoning-content boundaries). The previous hard-coded Qwen tokenizer broke on GLM-4.7-Flash (different chat template, reasoning-end token, tool call format). This PR abstracts tokenization behind `AgenticTokenizer` with model-specific subclasses, enabling search-r1 on any supported model.

### How has this been tested?

- GLM-4.7-Flash search-r1 agent e2e: tokenizer init + reasoning-content skip (188/216 `content_start>0` after fix) + search truncation + generation + clean exit.
- ruff + ruff-format pass.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project. (`ruff` + `ruff-format` pass on all changed files.)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (Manual e2e passed; CI runs via the `run-ci` label.)
