### PR TITLE
feat(realworld): add Piper and SO101 setup guides and checks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,7 +39,7 @@
 /tests @andylin-hao
 /toolkits/auto_placement @Lin-xs
 /rlinf/utils/ckpt_convertor @qurakchin @guozhen1997
-/toolkits/realworld_check @andylin-hao @zanghz21
+/toolkits/realworld_check @andylin-hao
 
 /.cursor @andylin-hao
 /.pre-commit-config.yaml @andylin-hao

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,8 +25,7 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" || code=$?
-              # A Ray agent may exit during cleanup; retry with a fresh process list.
-              ray stop || ray stop --force
+              ray stop
               [ $code -eq 0 ] || exit $code
           done
 
@@ -64,8 +63,7 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" || code=$?
-              # A Ray agent may exit during cleanup; retry with a fresh process list.
-              ray stop || ray stop --force
+              ray stop
               [ $code -eq 0 ] || exit $code
           done
 
@@ -93,8 +91,7 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" || code=$?
-              # A Ray agent may exit during cleanup; retry with a fresh process list.
-              ray stop || ray stop --force
+              ray stop
               [ $code -eq 0 ] || exit $code
           done
 
@@ -127,8 +124,7 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" || code=$?
-              # A Ray agent may exit during cleanup; retry with a fresh process list.
-              ray stop || ray stop --force
+              ray stop
               [ $code -eq 0 ] || exit $code
           done
 
@@ -168,8 +164,7 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" -m "not placement" || code=$?
-              # A Ray agent may exit during cleanup; retry with a fresh process list.
-              ray stop || ray stop --force
+              ray stop
               [ $code -eq 0 ] || exit $code
           done
           # A placement test hosts parts in real workers. The MUSA image
@@ -185,8 +180,7 @@ jobs:
           for test in $placement_tests; do
               code=0
               pytest "tests/unit_tests/$test" || code=$?
-              # A Ray agent may exit during cleanup; retry with a fresh process list.
-              ray stop || ray stop --force
+              ray stop
               [ $code -eq 0 ] || exit $code
           done
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,8 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" || code=$?
-              ray stop
+              # A Ray agent may exit during cleanup; retry with a fresh process list.
+              ray stop || ray stop --force
               [ $code -eq 0 ] || exit $code
           done
 
@@ -63,7 +64,8 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" || code=$?
-              ray stop
+              # A Ray agent may exit during cleanup; retry with a fresh process list.
+              ray stop || ray stop --force
               [ $code -eq 0 ] || exit $code
           done
 
@@ -91,7 +93,8 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" || code=$?
-              ray stop
+              # A Ray agent may exit during cleanup; retry with a fresh process list.
+              ray stop || ray stop --force
               [ $code -eq 0 ] || exit $code
           done
 
@@ -124,7 +127,8 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" || code=$?
-              ray stop
+              # A Ray agent may exit during cleanup; retry with a fresh process list.
+              ray stop || ray stop --force
               [ $code -eq 0 ] || exit $code
           done
 
@@ -164,7 +168,8 @@ jobs:
           for file in tests/unit_tests/test_*.py; do
               code=0
               pytest "$file" -m "not placement" || code=$?
-              ray stop
+              # A Ray agent may exit during cleanup; retry with a fresh process list.
+              ray stop || ray stop --force
               [ $code -eq 0 ] || exit $code
           done
           # A placement test hosts parts in real workers. The MUSA image
@@ -180,7 +185,8 @@ jobs:
           for test in $placement_tests; do
               code=0
               pytest "tests/unit_tests/$test" || code=$?
-              ray stop
+              # A Ray agent may exit during cleanup; retry with a fresh process list.
+              ray stop || ray stop --force
               [ $code -eq 0 ] || exit $code
           done
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ RLinf is a flexible and scalable open-source RL infrastructure designed for Embo
 
 
 ## What's NEW!
+
+- [2026/09] Add setup guides for [AgileX Piper](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/piper.html) and [SO101](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/so101.html), including calibration, local hardware checks, and a Piper test toolkit.
 - [2026/08] 🔥 RLinf supports SFT and SGLang-based evaluation of NVIDIA's ominimodal world model, Cosmos3. Docs: [Cosmos3 SFT](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/sft_cosmos3.html), [SGLang eval](https://rlinf.readthedocs.io/en/latest/rst_source/evaluations/guides/cosmos3_sglang.html).
 - [2026/08] 🎉 RLinf is officially welcomed into the **PyTorch Ecosystem**! We will continue to bring scalable embodied and agentic RL to PyTorch users, pushing model intelligence into the real world. Blog: [PyTorch Ecosystem Landscape Q3 Update](https://pytorch.org/blog/pytorch-ecosystem-landscape-q3-update/).
 - [2026/08] 🎉 Isaac Lab v3.0.0 officially adopts RLinf as its reinforcement learning (RL) training infrastructure. Doc: [RLinf on Isaac Lab](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/overview/reinforcement-learning/rl_existing_scripts.html#rlinf).
@@ -261,6 +263,8 @@ RLinf supports SFT, simulation RL, and real-world RL for World Action Models (WA
           <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/xsquare_turtle2.html">XSquare Turtle2</a> ✅</li>
           <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/dosw1.html">DOS-W1</a> ✅</li>
           <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/gim_arm.html">GimArm</a> ✅</li>
+          <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/piper.html">AgileX Piper</a> ✅</li>
+          <li><a href="https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/so101.html">SO101</a> ✅</li>
           <li>More...</li>
         </ul>
       </td>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ RLinf is a flexible and scalable open-source RL infrastructure designed for Embo
 
 ## What's NEW!
 
-- [2026/09] Add setup guides for [AgileX Piper](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/piper.html) and [SO101](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/so101.html), including calibration, local hardware checks, and a Piper test toolkit.
 - [2026/08] 🔥 RLinf supports SFT and SGLang-based evaluation of NVIDIA's ominimodal world model, Cosmos3. Docs: [Cosmos3 SFT](https://rlinf.readthedocs.io/en/latest/rst_source/examples/embodied/sft_cosmos3.html), [SGLang eval](https://rlinf.readthedocs.io/en/latest/rst_source/evaluations/guides/cosmos3_sglang.html).
 - [2026/08] 🎉 RLinf is officially welcomed into the **PyTorch Ecosystem**! We will continue to bring scalable embodied and agentic RL to PyTorch users, pushing model intelligence into the real world. Blog: [PyTorch Ecosystem Landscape Q3 Update](https://pytorch.org/blog/pytorch-ecosystem-landscape-q3-update/).
 - [2026/08] 🎉 Isaac Lab v3.0.0 officially adopts RLinf as its reinforcement learning (RL) training infrastructure. Doc: [RLinf on Isaac Lab](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/overview/reinforcement-learning/rl_existing_scripts.html#rlinf).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,8 @@ RLinf 是一个灵活且可扩展的开源框架，专为具身智能和智能�
 </div>
 
 ## 最新动态
+
+- [2026/09] 新增 [AgileX Piper](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/piper.html) 与 [SO101](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/so101.html) 配置指南，覆盖标定、本机硬件检查和 Piper 测试工具。
 - [2026/08] 🔥 RLinf 支持对英伟达全模态世界模型 Cosmos3 做 SFT 及基于 SGLang 的评测。文档：[Cosmos3 SFT](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/sft_cosmos3.html)、[SGLang 评测](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/evaluations/guides/cosmos3_sglang.html)。
 - [2026/08] 🎉 RLinf 正式入选 **PyTorch 生态**！我们将继续把可扩展的具身与智能体强化学习带给 PyTorch 用户，推动模型智能走进真实世界。博客：[PyTorch Ecosystem Landscape Q3 Update](https://pytorch.org/blog/pytorch-ecosystem-landscape-q3-update/)。
 - [2026/08] 🎉 Isaac Lab v3.0.0 正式采用 RLinf 作为其强化学习（RL）训练基础设施。文档：[Isaac Lab 中的 RLinf](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/overview/reinforcement-learning/rl_existing_scripts.html#rlinf)。
@@ -261,6 +263,8 @@ RLinf 支持 World Action Model（WAM）和 Vision-Language-Action Model（VLA�
           <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/xsquare_turtle2.html">XSquare Turtle2</a> ✅</li>
           <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/dosw1.html">DOS-W1</a> ✅</li>
           <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/gim_arm.html">GimArm</a> ✅</li>
+          <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/piper.html">AgileX Piper</a> ✅</li>
+          <li><a href="https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/so101.html">SO101</a> ✅</li>
           <li>More...</li>
         </ul>
       </td>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,6 @@ RLinf 是一个灵活且可扩展的开源框架，专为具身智能和智能�
 
 ## 最新动态
 
-- [2026/09] 新增 [AgileX Piper](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/piper.html) 与 [SO101](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/so101.html) 配置指南，覆盖标定、本机硬件检查和 Piper 测试工具。
 - [2026/08] 🔥 RLinf 支持对英伟达全模态世界模型 Cosmos3 做 SFT 及基于 SGLang 的评测。文档：[Cosmos3 SFT](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/examples/embodied/sft_cosmos3.html)、[SGLang 评测](https://rlinf.readthedocs.io/zh-cn/latest/rst_source/evaluations/guides/cosmos3_sglang.html)。
 - [2026/08] 🎉 RLinf 正式入选 **PyTorch 生态**！我们将继续把可扩展的具身与智能体强化学习带给 PyTorch 用户，推动模型智能走进真实世界。博客：[PyTorch Ecosystem Landscape Q3 Update](https://pytorch.org/blog/pytorch-ecosystem-landscape-q3-update/)。
 - [2026/08] 🎉 Isaac Lab v3.0.0 正式采用 RLinf 作为其强化学习（RL）训练基础设施。文档：[Isaac Lab 中的 RLinf](https://isaac-sim.github.io/IsaacLab/v3.0.0-beta2/source/overview/reinforcement-learning/rl_existing_scripts.html#rlinf)。

--- a/docs/source-en/rst_source/examples/embodied/piper.rst
+++ b/docs/source-en/rst_source/examples/embodied/piper.rst
@@ -1,111 +1,26 @@
 AgileX Piper Setup and Control
 ==============================
 
+This doc walks you through setting up an AgileX Piper arm and running the RLinf
+hardware test script to read feedback and check joint and gripper movement.
+
 .. figure:: https://raw.githubusercontent.com/agilexrobotics/piper_ros/noetic/asserts/pictures/piper_urdf_zero.png
    :align: center
    :width: 70%
 
    Piper arm and gripper model. Image: AgileX Robotics, piper_ros.
 
-Connect an AgileX Piper arm to RLinf, read its joints and gripper, and send a
-command through the robotics interface. Start with a local CAN connection, add
-a camera if your application needs images, then use the task-extension guide to
-build your own real-world task. The supplied reach environment and mock SAC run
-exercise the integration; they are not a validated task or training recipe.
-
 Overview
 --------
 
-Piper support covers the arm and its attached AgxGripper through the
-``pyAgxArm`` SDK. The current test configuration uses an MLP policy to check the
-training path without physical hardware.
-
-.. grid:: 2 4 4 4
-   :gutter: 2
-
-   .. grid-item-card:: Models
-      :text-align: center
-
-      MLP policy (integration test)
-
-   .. grid-item-card:: Algorithms
-      :text-align: center
-
-      SAC (integration test)
-
-   .. grid-item-card:: Tasks
-      :text-align: center
-
-      User-defined; reach scaffold
-
-   .. grid-item-card:: Hardware
-      :text-align: center
-
-      Piper · CAN · AgxGripper
-
-| **You'll do:** install dependencies → configure CAN → read feedback → test joints and gripper → add a task.
-| **Prerequisites:** :doc:`Installation </rst_source/start/installation>` · Piper hardware · Linux controller · CAN adapter.
-
-Tasks
-~~~~~
-
-Use the existing files to inspect the hardware-to-env contract before defining
-the behavior you want the robot to learn.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 40 35
-
-   * - Purpose
-     - Entry Point
-     - Scope
-   * - Local hardware use
-     - ``PiperRobot`` with ``PiperArm``
-     - Read state and command the arm and gripper.
-   * - Environment scaffold
-     - ``PiperReachEnv-v1``; ``env/piper_reach.yaml``
-     - Illustrates joint targets, reset, and reward wiring.
-   * - Integration test
-     - ``piper_mock_sac_mlp_reach``
-     - Runs SAC with mock SDKs; does not establish physical task performance.
-
-Observation and Action
-~~~~~~~~~~~~~~~~~~~~~~
-
-The robot returns nested dictionaries. The reach scaffold converts these into
-the flat state and action arrays used by its test policy.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 23 77
-
-   * - Field
-     - Contract
-   * - Observation
-     - ``arm.arm_joint_position``: six radians; ``arm.tcp_pose``:
-       ``[x, y, z, qx, qy, qz, qw]`` in the base frame, with metres for position;
-       ``arm.end_effector.state``: one gripper opening in ``[0, 1]``.
-       The scaffold's flat state has 14 values with a gripper.
-   * - Action
-     - ``arm.joint_position``: six absolute joint targets in radians;
-       ``arm.end_effector.target``: one opening, ``0`` closed and ``1`` open.
-       The scaffold's flat action has seven values; targets are not deltas.
-   * - Images
-     - Optional cameras. The scaffold centre-crops and resizes each image to
-       ``(128, 128, 3)`` under ``frames.wrist_1``, ``frames.wrist_2``, etc.
-       Without cameras it omits ``frames``; the mock MLP ignores images.
-   * - Reward
-     - The scaffold uses joint distance for dense reward or a per-joint
-       tolerance for sparse reward. Define reward and success for your own task.
-   * - Prompt
-     - The scaffold reports ``reach a joint configuration``.
+The test runs on the Linux machine connected to the arm. It requires no GPU or
+model checkpoint. RLinf does not yet provide a supported real-world task or
+training workflow for AgileX Piper; this guide covers hardware checks only.
 
 Hardware Setup
 --------------
 
-Prepare one controller machine and its attached arm before installing the software.
-The local hardware checks run on the controller; a GPU is needed only for the
-optional mock SAC integration test.
+Prepare the arm and controller machine before installing the software.
 
 .. list-table::
    :header-rows: 1
@@ -117,10 +32,6 @@ optional mock SAC integration test.
      - AgileX Piper with its power supply; AgxGripper if fitted.
    * - Controller machine
      - Linux computer with a USB-to-CAN adapter in SocketCAN mode and a CAN cable to the arm.
-   * - Camera (optional)
-     - Intel RealSense camera connected to the controller for image checks.
-   * - GPU (optional)
-     - One supported GPU for the mock SAC test, separate from the local hardware check.
 
 Mount the arm on a stable surface and leave space for small joint movements.
 Connect the power supply and CAN cable according to the manufacturer's wiring
@@ -152,7 +63,6 @@ Install the robot dependencies from the repository root:
 Run subsequent commands from this checkout with the environment activated.
 The installer includes the pinned ``pyAgxArm`` driver used by ``PiperArm``; see
 :doc:`Installation </rst_source/start/installation>` for platform prerequisites.
-No model checkpoint is needed for the interface examples or the mock MLP test.
 
 Prepare the CAN Connection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -179,30 +89,16 @@ setup and supported hardware.
 Run It
 ------
 
-With CAN configured, use the arm in the calling Python process first. A
-``PiperArm`` declaration records the device settings without opening it, and
-``PiperRobot`` names that arm ``arm``. Its gripper shares the CAN connection and
-appears at ``arm.end_effector``.
-
-Testing the Setup
-~~~~~~~~~~~~~~~~~
-
-First check the toolkit without hardware:
-
-.. code-block:: bash
-
-   python -m toolkits.realworld_check.test_piper_controller --mock --read-only
-
-This prints six measured joint angles, a seven-value tool pose, and one gripper
-opening, then exits. Mock values only verify that the software path works.
-Repeat the check on the connected arm:
+With CAN configured and the arm powered on, read its feedback first:
 
 .. code-block:: bash
 
    python -m toolkits.realworld_check.test_piper_controller \
      --channel can0 --read-only
 
-The command enables the motors and reads feedback without sending a position
+The command prints six joint angles in degrees, a tool pose (position in metres
+and an xyzw quaternion), and the gripper opening in ``[0, 1]``, then exits.
+It enables the motors and reads feedback without sending a position
 target or resetting the arm. The detected firmware profile appears in the log.
 For an AgxGripper with a 0.1 m stroke, add ``--gripper-max-width 0.1``; for an arm
 without a gripper, add ``--no-gripper``.
@@ -230,7 +126,7 @@ script accepts joints 1 through 6 and increments within five degrees; the arm
 driver also clips targets to its travel. ``grip 0.5`` requests half the fitted
 gripper's stroke. ``where`` reads feedback, so repeat it after the gripper has
 settled. ``quit``, EOF, or Ctrl+C closes the CAN session and leaves the motors
-holding position. Add ``--mock`` to rehearse the same commands without hardware.
+holding position.
 
 .. warning::
 
@@ -238,136 +134,13 @@ holding position. Add ``--mock`` to rehearse the same commands without hardware.
    before connecting, and keep hands away during joint and gripper commands.
    Closing the test is not an emergency stop and does not cut motor power.
 
-Use the Robot Interface
-~~~~~~~~~~~~~~~~~~~~~~~
-
-To use the same interface in your own Python program, run the following code.
-The example reads the current joint positions and gripper opening, then sends
-those values back as targets. ``connect()`` opens the connection and enables the
-arm; ``get_observation()`` returns the nested state used to construct the action.
-
-.. code-block:: python
-
-   from rlinf.robotics import PiperRobot
-   from rlinf.robotics.parts.arms.piper import PiperArm
-   from rlinf.utils.logging import get_logger
-
-   logger = get_logger()
-   robot = PiperRobot(arm=PiperArm.declare("can0", speed_percent=10))
-   robot.connect()
-   try:
-       reading = robot.get_observation()["arm"]
-       logger.info("Joint positions: %s", reading["arm_joint_position"])
-       robot.send_action(
-           {
-               "arm": {
-                   "joint_position": reading["arm_joint_position"],
-                   "end_effector": {"target": reading["end_effector"]["state"]},
-               }
-           }
-       )
-   finally:
-       robot.disconnect()
-
-``send_action()`` dispatches the nested targets and returns a dictionary of
-dispatched action values, not a new measurement. Read again to measure the
-result. ``disconnect()`` releases the robot's connections, including the shared
-gripper connection. Omitting ``node_rank`` keeps this example local and does not
-require a Ray cluster.
-
-Set ``gripper_max_width`` to the fitted gripper's full stroke in metres; it
-defaults to ``0.07``. For an arm without a gripper, declare
-``with_gripper=False`` and omit the end-effector action and observation access.
-That variant has six action values and 13 state values in the scaffold.
-
-Add a Camera
-~~~~~~~~~~~~
-
-To read images alongside the arm state, replace the robot declaration above
-with this composition. ``CameraInfo`` describes a physical camera;
-``Camera.declare()`` returns the named, unconnected camera parts to include in
-the robot. The robot installer includes RealSense support on x86 Linux.
-
-Select the RealSense driver with ``Camera.backend("realsense")`` and list
-attached serial numbers with ``discover()``:
-
-.. code-block:: python
-
-   from rlinf.robotics import Camera
-
-   logger.info("RealSense serials: %s", Camera.backend("realsense").discover())
-
-Use one of the reported serial numbers as ``CAMERA_SERIAL`` in the following
-code, then connect and read an image:
-
-.. code-block:: python
-
-   from rlinf.robotics import Camera, CameraInfo
-
-   robot = PiperRobot(
-       arm=PiperArm.declare("can0", speed_percent=10),
-       **Camera.declare(
-           {"wrist_1": CameraInfo(name="wrist_1", serial_number="CAMERA_SERIAL")}
-       ),
-   )
-   robot.connect()
-   try:
-       image = robot.get_observation()["wrist_1"]["frame"]
-       logger.info("Camera image shape: %s", image.shape)
-   finally:
-       robot.disconnect()
-
-The default camera backend is RealSense. The image uses the camera's configured
-resolution; resizing to the policy input belongs to the environment. The robot
-opens and closes the camera along with the arm. See
-:doc:`Robotics Interface </rst_source/concepts/robotics>` for other compositions.
-
-Check the Integration Without Hardware
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Once the interface is clear, the existing mock run can check the scheduler,
-environment, rollout, and actor path on a machine with one supported GPU:
-
-.. code-block:: bash
-
-   bash tests/e2e_tests/embodied/run.sh piper_mock_sac_mlp_reach \
-     runner.logger.log_path="$REPO_PATH/logs/piper_mock"
-
-The launcher enables mock SDKs because the config name contains ``mock``. It
-uses the real env implementation with ``is_dummy: False``, two fake cameras,
-and an MLP with ``action_dim: 7`` and ``obs_dim: 14``. This is a short software
-integration check; it neither moves a physical arm nor validates a task.
+To use the arm in your own program or attach cameras, see
+:doc:`Robotics Interface </rst_source/concepts/robotics>`.
 
 New Real-World Tasks
 --------------------
 
-After verifying your hardware, define the task's observations, reset procedure,
-reward, and success condition using
-:doc:`New Real-World Tasks </rst_source/extending/new_task>`. Piper currently has
-hardware support and a reach scaffold, but no validated real-world task recipe.
-
-Start from ``PiperEnv`` and ``PiperEnvConfig`` in
-``rlinf/envs/real/piper/base.py``. The adjacent ``reach.py`` shows how to build a
-task config from ``override_cfg`` and pass it into the base constructor; do not
-copy the Franka-specific ``CONFIG_CLS`` shortcut from the guide. Register the
-new class in ``rlinf/envs/real/piper/__init__.py`` under ``TASKS``, then copy
-``examples/embodiment/config/env/piper_reach.yaml`` and select your Gymnasium ID
-with ``init_params.id``.
-
-Keep hardware settings in the cluster's ``hardware`` block with ``type: Piper``
-and task settings in ``env.train.override_cfg``. The existing mock config shows
-how to place ``env`` in the node group that carries the robot. For a controller
-on another machine, follow :doc:`Multi-Node Training </rst_source/guides/multi_node>`
-and :doc:`Robotics Architecture </rst_source/concepts/robotics_architecture>`.
-Piper currently has no registered teleoperation device for its joint layout;
-keep ``teleop: none`` unless you add a compatible device.
-
-Visualization and Results
--------------------------
-
-The mock run writes TensorBoard logs under ``logs/piper_mock``. Use them to
-inspect software execution, not to measure physical task success. There are no
-validated task results or pretrained task weights for this example. Once your
-task is implemented, configure logging and video using
-:doc:`Training Metrics </rst_source/reference/metrics>` and
-:doc:`Logging </rst_source/guides/logger>`.
+After the hardware checks pass, follow
+:doc:`New Real-World Tasks </rst_source/extending/new_task>` to define a task's
+reset procedure, observations, actions, reward, and success condition. A working
+real-world task is required before starting training.

--- a/docs/source-en/rst_source/examples/embodied/piper.rst
+++ b/docs/source-en/rst_source/examples/embodied/piper.rst
@@ -1,0 +1,373 @@
+AgileX Piper Setup and Control
+==============================
+
+.. figure:: https://raw.githubusercontent.com/agilexrobotics/piper_ros/noetic/asserts/pictures/piper_urdf_zero.png
+   :align: center
+   :width: 70%
+
+   Piper arm and gripper model. Image: AgileX Robotics, piper_ros.
+
+Connect an AgileX Piper arm to RLinf, read its joints and gripper, and send a
+command through the robotics interface. Start with a local CAN connection, add
+a camera if your application needs images, then use the task-extension guide to
+build your own real-world task. The supplied reach environment and mock SAC run
+exercise the integration; they are not a validated task or training recipe.
+
+Overview
+--------
+
+Piper support covers the arm and its attached AgxGripper through the
+``pyAgxArm`` SDK. The current test configuration uses an MLP policy to check the
+training path without physical hardware.
+
+.. grid:: 2 4 4 4
+   :gutter: 2
+
+   .. grid-item-card:: Models
+      :text-align: center
+
+      MLP policy (integration test)
+
+   .. grid-item-card:: Algorithms
+      :text-align: center
+
+      SAC (integration test)
+
+   .. grid-item-card:: Tasks
+      :text-align: center
+
+      User-defined; reach scaffold
+
+   .. grid-item-card:: Hardware
+      :text-align: center
+
+      Piper · CAN · AgxGripper
+
+| **You'll do:** install dependencies → configure CAN → read feedback → test joints and gripper → add a task.
+| **Prerequisites:** :doc:`Installation </rst_source/start/installation>` · Piper hardware · Linux controller · CAN adapter.
+
+Tasks
+~~~~~
+
+Use the existing files to inspect the hardware-to-env contract before defining
+the behavior you want the robot to learn.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 40 35
+
+   * - Purpose
+     - Entry Point
+     - Scope
+   * - Local hardware use
+     - ``PiperRobot`` with ``PiperArm``
+     - Read state and command the arm and gripper.
+   * - Environment scaffold
+     - ``PiperReachEnv-v1``; ``env/piper_reach.yaml``
+     - Illustrates joint targets, reset, and reward wiring.
+   * - Integration test
+     - ``piper_mock_sac_mlp_reach``
+     - Runs SAC with mock SDKs; does not establish physical task performance.
+
+Observation and Action
+~~~~~~~~~~~~~~~~~~~~~~
+
+The robot returns nested dictionaries. The reach scaffold converts these into
+the flat state and action arrays used by its test policy.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 23 77
+
+   * - Field
+     - Contract
+   * - Observation
+     - ``arm.arm_joint_position``: six radians; ``arm.tcp_pose``:
+       ``[x, y, z, qx, qy, qz, qw]`` in the base frame, with metres for position;
+       ``arm.end_effector.state``: one gripper opening in ``[0, 1]``.
+       The scaffold's flat state has 14 values with a gripper.
+   * - Action
+     - ``arm.joint_position``: six absolute joint targets in radians;
+       ``arm.end_effector.target``: one opening, ``0`` closed and ``1`` open.
+       The scaffold's flat action has seven values; targets are not deltas.
+   * - Images
+     - Optional cameras. The scaffold centre-crops and resizes each image to
+       ``(128, 128, 3)`` under ``frames.wrist_1``, ``frames.wrist_2``, etc.
+       Without cameras it omits ``frames``; the mock MLP ignores images.
+   * - Reward
+     - The scaffold uses joint distance for dense reward or a per-joint
+       tolerance for sparse reward. Define reward and success for your own task.
+   * - Prompt
+     - The scaffold reports ``reach a joint configuration``.
+
+Hardware Setup
+--------------
+
+Prepare one controller machine and its attached arm before installing the software.
+The local hardware checks run on the controller; a GPU is needed only for the
+optional mock SAC integration test.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Component
+     - Requirement
+   * - Arm and gripper
+     - AgileX Piper with its power supply; AgxGripper if fitted.
+   * - Controller machine
+     - Linux computer with a USB-to-CAN adapter in SocketCAN mode and a CAN cable to the arm.
+   * - Camera (optional)
+     - Intel RealSense camera connected to the controller for image checks.
+   * - GPU (optional)
+     - One supported GPU for the mock SAC test, separate from the local hardware check.
+
+Mount the arm on a stable surface and leave space for small joint movements.
+Connect the power supply and CAN cable according to the manufacturer's wiring
+instructions before powering it on.
+
+Installation
+------------
+
+Install the robot dependencies on the controller machine using the custom-environment
+workflow below. Run the checks from the same checkout and activated environment.
+
+Robot Controller Node
+~~~~~~~~~~~~~~~~~~~~~
+
+Clone RLinf on the machine connected to the robot, then install its environment.
+
+.. include:: _setup_common.rst
+   :end-before: Then set up the dependencies
+
+Install the robot dependencies from the repository root:
+
+.. code-block:: bash
+
+   # Mainland China users can add --use-mirror for faster downloads.
+   bash requirements/install.sh embodied --env piper
+   source .venv/bin/activate
+   export REPO_PATH="$PWD"
+
+Run subsequent commands from this checkout with the environment activated.
+The installer includes the pinned ``pyAgxArm`` driver used by ``PiperArm``; see
+:doc:`Installation </rst_source/start/installation>` for platform prerequisites.
+No model checkpoint is needed for the interface examples or the mock MLP test.
+
+Prepare the CAN Connection
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Find the SocketCAN interface with ``ip -brief link``. A USB-to-CAN adapter in
+SocketCAN mode normally appears as ``can0``; replace that name below if yours
+differs. Bring this interface up at 1 Mbit/s before opening the robot:
+
+.. code-block:: bash
+
+   sudo ip link set can0 down
+   sudo ip link set can0 type can bitrate 1000000
+   sudo ip link set can0 up
+   ip -details link show can0
+
+The output should show an enabled interface and ``bitrate 1000000``. With the
+arm powered on, run ``candump -n 5 can0`` to inspect five feedback frames. If it
+waits without receiving frames, press Ctrl+C and check the arm's power, CAN
+wiring, selected adapter, and bitrate before continuing. The SDK does not
+configure the CAN interface. Consult the
+`pyAgxArm documentation <https://github.com/agilexrobotics/pyAgxArm>`_ for adapter
+setup and supported hardware.
+
+Run It
+------
+
+With CAN configured, use the arm in the calling Python process first. A
+``PiperArm`` declaration records the device settings without opening it, and
+``PiperRobot`` names that arm ``arm``. Its gripper shares the CAN connection and
+appears at ``arm.end_effector``.
+
+Testing the Setup
+~~~~~~~~~~~~~~~~~
+
+First check the toolkit without hardware:
+
+.. code-block:: bash
+
+   python -m toolkits.realworld_check.test_piper_controller --mock --read-only
+
+This prints six measured joint angles, a seven-value tool pose, and one gripper
+opening, then exits. Mock values only verify that the software path works.
+Repeat the check on the connected arm:
+
+.. code-block:: bash
+
+   python -m toolkits.realworld_check.test_piper_controller \
+     --channel can0 --read-only
+
+The command enables the motors and reads feedback without sending a position
+target or resetting the arm. The detected firmware profile appears in the log.
+For an AgxGripper with a 0.1 m stroke, add ``--gripper-max-width 0.1``; for an arm
+without a gripper, add ``--no-gripper``.
+
+To test a small movement, omit ``--read-only`` and enter the commands below one
+at a time, waiting for the arm after each movement:
+
+.. code-block:: bash
+
+   python -m toolkits.realworld_check.test_piper_controller \
+     --channel can0 --speed-percent 10
+
+.. code-block:: text
+
+   where
+   joint 1 2
+   where
+   joint 1 -2
+   grip 0.5
+   where
+   quit
+
+``joint 1 2`` moves joint 1 by two degrees from its measured position. The
+script accepts joints 1 through 6 and increments within five degrees; the arm
+driver also clips targets to its travel. ``grip 0.5`` requests half the fitted
+gripper's stroke. ``where`` reads feedback, so repeat it after the gripper has
+settled. ``quit``, EOF, or Ctrl+C closes the CAN session and leaves the motors
+holding position. Add ``--mock`` to rehearse the same commands without hardware.
+
+.. warning::
+
+   Connection enables the motors even with ``--read-only``. Clear the workspace
+   before connecting, and keep hands away during joint and gripper commands.
+   Closing the test is not an emergency stop and does not cut motor power.
+
+Use the Robot Interface
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To use the same interface in your own Python program, run the following code.
+The example reads the current joint positions and gripper opening, then sends
+those values back as targets. ``connect()`` opens the connection and enables the
+arm; ``get_observation()`` returns the nested state used to construct the action.
+
+.. code-block:: python
+
+   from rlinf.robotics import PiperRobot
+   from rlinf.robotics.parts.arms.piper import PiperArm
+   from rlinf.utils.logging import get_logger
+
+   logger = get_logger()
+   robot = PiperRobot(arm=PiperArm.declare("can0", speed_percent=10))
+   robot.connect()
+   try:
+       reading = robot.get_observation()["arm"]
+       logger.info("Joint positions: %s", reading["arm_joint_position"])
+       robot.send_action(
+           {
+               "arm": {
+                   "joint_position": reading["arm_joint_position"],
+                   "end_effector": {"target": reading["end_effector"]["state"]},
+               }
+           }
+       )
+   finally:
+       robot.disconnect()
+
+``send_action()`` dispatches the nested targets and returns a dictionary of
+dispatched action values, not a new measurement. Read again to measure the
+result. ``disconnect()`` releases the robot's connections, including the shared
+gripper connection. Omitting ``node_rank`` keeps this example local and does not
+require a Ray cluster.
+
+Set ``gripper_max_width`` to the fitted gripper's full stroke in metres; it
+defaults to ``0.07``. For an arm without a gripper, declare
+``with_gripper=False`` and omit the end-effector action and observation access.
+That variant has six action values and 13 state values in the scaffold.
+
+Add a Camera
+~~~~~~~~~~~~
+
+To read images alongside the arm state, replace the robot declaration above
+with this composition. ``CameraInfo`` describes a physical camera;
+``Camera.declare()`` returns the named, unconnected camera parts to include in
+the robot. The robot installer includes RealSense support on x86 Linux.
+
+Select the RealSense driver with ``Camera.backend("realsense")`` and list
+attached serial numbers with ``discover()``:
+
+.. code-block:: python
+
+   from rlinf.robotics import Camera
+
+   logger.info("RealSense serials: %s", Camera.backend("realsense").discover())
+
+Use one of the reported serial numbers as ``CAMERA_SERIAL`` in the following
+code, then connect and read an image:
+
+.. code-block:: python
+
+   from rlinf.robotics import Camera, CameraInfo
+
+   robot = PiperRobot(
+       arm=PiperArm.declare("can0", speed_percent=10),
+       **Camera.declare(
+           {"wrist_1": CameraInfo(name="wrist_1", serial_number="CAMERA_SERIAL")}
+       ),
+   )
+   robot.connect()
+   try:
+       image = robot.get_observation()["wrist_1"]["frame"]
+       logger.info("Camera image shape: %s", image.shape)
+   finally:
+       robot.disconnect()
+
+The default camera backend is RealSense. The image uses the camera's configured
+resolution; resizing to the policy input belongs to the environment. The robot
+opens and closes the camera along with the arm. See
+:doc:`Robotics Interface </rst_source/concepts/robotics>` for other compositions.
+
+Check the Integration Without Hardware
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the interface is clear, the existing mock run can check the scheduler,
+environment, rollout, and actor path on a machine with one supported GPU:
+
+.. code-block:: bash
+
+   bash tests/e2e_tests/embodied/run.sh piper_mock_sac_mlp_reach \
+     runner.logger.log_path="$REPO_PATH/logs/piper_mock"
+
+The launcher enables mock SDKs because the config name contains ``mock``. It
+uses the real env implementation with ``is_dummy: False``, two fake cameras,
+and an MLP with ``action_dim: 7`` and ``obs_dim: 14``. This is a short software
+integration check; it neither moves a physical arm nor validates a task.
+
+New Real-World Tasks
+--------------------
+
+After verifying your hardware, define the task's observations, reset procedure,
+reward, and success condition using
+:doc:`New Real-World Tasks </rst_source/extending/new_task>`. Piper currently has
+hardware support and a reach scaffold, but no validated real-world task recipe.
+
+Start from ``PiperEnv`` and ``PiperEnvConfig`` in
+``rlinf/envs/real/piper/base.py``. The adjacent ``reach.py`` shows how to build a
+task config from ``override_cfg`` and pass it into the base constructor; do not
+copy the Franka-specific ``CONFIG_CLS`` shortcut from the guide. Register the
+new class in ``rlinf/envs/real/piper/__init__.py`` under ``TASKS``, then copy
+``examples/embodiment/config/env/piper_reach.yaml`` and select your Gymnasium ID
+with ``init_params.id``.
+
+Keep hardware settings in the cluster's ``hardware`` block with ``type: Piper``
+and task settings in ``env.train.override_cfg``. The existing mock config shows
+how to place ``env`` in the node group that carries the robot. For a controller
+on another machine, follow :doc:`Multi-Node Training </rst_source/guides/multi_node>`
+and :doc:`Robotics Architecture </rst_source/concepts/robotics_architecture>`.
+Piper currently has no registered teleoperation device for its joint layout;
+keep ``teleop: none`` unless you add a compatible device.
+
+Visualization and Results
+-------------------------
+
+The mock run writes TensorBoard logs under ``logs/piper_mock``. Use them to
+inspect software execution, not to measure physical task success. There are no
+validated task results or pretrained task weights for this example. Once your
+task is implemented, configure logging and video using
+:doc:`Training Metrics </rst_source/reference/metrics>` and
+:doc:`Logging </rst_source/guides/logger>`.

--- a/docs/source-en/rst_source/examples/embodied/so101.rst
+++ b/docs/source-en/rst_source/examples/embodied/so101.rst
@@ -1,113 +1,26 @@
 SO101 Setup and Control
 =======================
 
+This doc walks you through setting up an SO101 arm and running the RLinf
+hardware test script to read feedback and check joint and gripper movement.
+
 .. figure:: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lerobot/SO101_Follower.webp
    :align: center
    :width: 70%
 
    SO-101 follower with its gripper. Image: Hugging Face LeRobot.
 
-Connect an SO-101 follower to RLinf, read its joints and gripper, and send a
-command through the robotics interface. Install and calibrate the arm first,
-check it locally, then add cameras or a leader as your application requires.
-Use the task-extension guide to define a real-world task: the supplied reach
-environment and mock SAC run are integration scaffolding, not a validated task
-or training recipe.
-
 Overview
 --------
 
-SO101 support uses LeRobot to control five arm joints and a gripper on one
-serial bus. The current MLP and SAC configuration tests that hardware interface
-through mock SDKs.
-
-.. grid:: 2 4 4 4
-   :gutter: 2
-
-   .. grid-item-card:: Models
-      :text-align: center
-
-      MLP policy (integration test)
-
-   .. grid-item-card:: Algorithms
-      :text-align: center
-
-      SAC (integration test)
-
-   .. grid-item-card:: Tasks
-      :text-align: center
-
-      User-defined; reach scaffold
-
-   .. grid-item-card:: Hardware
-      :text-align: center
-
-      SO-101 follower · USB serial
-
-| **You'll do:** install dependencies → configure motors → calibrate → test follower and leader → add a task.
-| **Prerequisites:** :doc:`Installation </rst_source/start/installation>` · SO-101 hardware · Linux controller · USB serial connection.
-
-Tasks
-~~~~~
-
-The existing examples establish how to use the hardware and connect it to an
-environment. Define and validate the physical task separately.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 40 35
-
-   * - Purpose
-     - Entry Point
-     - Scope
-   * - Local hardware use
-     - ``SO101Robot`` with ``SO101Arm``
-     - Read state and command the follower's arm and gripper.
-   * - Environment scaffold
-     - ``SO101ReachEnv-v1``; ``env/so101_reach.yaml``
-     - Illustrates joint targets, reset, and reward wiring.
-   * - Integration test
-     - ``so101_mock_sac_mlp_reach``
-     - Runs SAC with mock SDKs; does not establish physical task performance.
-
-Observation and Action
-~~~~~~~~~~~~~~~~~~~~~~
-
-Use radians at the RLinf interface. The driver converts between these values
-and LeRobot's degrees, and between a fractional gripper opening and LeRobot's
-``0..100`` gripper scale.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 23 77
-
-   * - Field
-     - Contract
-   * - Observation
-     - ``arm.arm_joint_position``: five radians, ordered as ``shoulder_pan``,
-       ``shoulder_lift``, ``elbow_flex``, ``wrist_flex``, ``wrist_roll``;
-       ``arm.end_effector.state``: one gripper opening in ``[0, 1]``.
-       The scaffold's flat state has six values. No TCP pose, force, or torque
-       observation is supplied.
-   * - Action
-     - ``arm.joint_position``: five absolute joint targets in radians;
-       ``arm.end_effector.target``: one opening, ``0`` closed and ``1`` open.
-       The scaffold's flat action has six values; targets are not deltas.
-   * - Images
-     - Optional cameras. The scaffold centre-crops and resizes each image to
-       ``(128, 128, 3)`` under ``frames.wrist_1``, ``frames.wrist_2``, etc.
-       Without cameras it omits ``frames``; the mock MLP ignores images.
-   * - Reward
-     - The scaffold uses joint distance for dense reward or a per-joint
-       tolerance for sparse reward. Define reward and success for your own task.
-   * - Prompt
-     - The scaffold reports ``reach a joint configuration``.
+The test runs on the Linux machine connected to the arm. It requires no GPU or
+model checkpoint. RLinf does not yet provide a supported real-world task or
+training workflow for SO101; this guide covers hardware checks only.
 
 Hardware Setup
 --------------
 
-Prepare the follower and its controller machine first. A leader and camera are
-optional additions; neither is required for the initial joint and gripper check.
+Prepare the arm and controller machine before installing the software.
 
 .. list-table::
    :header-rows: 1
@@ -119,12 +32,6 @@ optional additions; neither is required for the initial joint and gripper check.
      - SO-101 arm with its gripper, servo controller, and the power supply specified for the kit.
    * - Controller machine
      - Linux computer with a USB connection to the follower's servo controller.
-   * - Leader (optional)
-     - A separate SO-101 leader, its power supply, and a second USB serial connection.
-   * - Camera (optional)
-     - Intel RealSense camera connected to the controller for image checks.
-   * - GPU (optional)
-     - One supported GPU for the mock SAC test, separate from the local hardware check.
 
 For an unassembled arm, follow the parts and assembly instructions in the
 `LeRobot SO-101 guide <https://huggingface.co/docs/lerobot/so101>`_. Configure new
@@ -156,8 +63,7 @@ Install the robot dependencies from the repository root:
 
 The installer includes LeRobot with Feetech support. Run subsequent commands
 from this checkout with the environment activated. See
-:doc:`Installation </rst_source/start/installation>` for platform prerequisites;
-no model checkpoint is needed for the interface examples or the mock MLP test.
+:doc:`Installation </rst_source/start/installation>` for platform prerequisites.
 
 Find the Port and Configure the Motors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -214,7 +120,7 @@ Replace the port with your device. Move the joints to the middle positions
 shown in the guide, confirm the prompt, then move each joint through its travel
 as instructed. The tool reports the saved calibration file. Keep it under the
 account used for RLinf and reuse the ID as
-``calibration_id="rlinf_follower"``; do not substitute the leader's calibration.
+``--id rlinf_follower``; do not substitute the leader's calibration.
 
 .. warning::
 
@@ -225,32 +131,15 @@ account used for RLinf and reuse the ID as
 Run It
 ------
 
-With the follower calibrated, check its joints and gripper through RLinf. An
-``SO101Arm`` declaration records the port and calibration settings without
-opening hardware. ``SO101Robot`` names the arm ``arm`` and exposes its gripper
-at ``arm.end_effector`` on the same connection.
-
-Testing the Setup
-~~~~~~~~~~~~~~~~~
-
-Rehearse the existing interactive check without hardware first:
-
-.. code-block:: bash
-
-   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env --mock
-
-At the prompt, enter ``where``, ``up``, ``where``, and ``quit``. The mock
-exercises the actual environment and driver with a fake servo bus. The toolkit
-uses a scheduler worker, so it may start a local Ray instance; no GPU is needed
-for this check. ``CAMERA_SERIALS=''`` explicitly disables camera discovery.
+With the follower calibrated, use the interactive test to check its joints and
+gripper. The script may start a local Ray instance to communicate with the arm.
 
 .. warning::
 
    On hardware, the environment constructor moves the arm to the folded rest
    pose ``[0, -99, 95, 65, 0]`` degrees. Clear that motion path before launching
    the toolkit. Its ``--no-reset`` flag skips a later reset but does not bypass
-   this initial movement. Use the Python interface example below to connect
-   without commanding a rest pose.
+   this initial movement.
 
 With the follower calibrated and room for the initial fold, run:
 
@@ -259,6 +148,8 @@ With the follower calibrated and room for the initial fold, run:
    CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env \
      --port /dev/ttyACM0 --id rlinf_follower --step 2
 
+Replace the port with your device and use the ID from calibration.
+``CAMERA_SERIALS=''`` disables camera discovery so the check uses only the arm.
 Enter these commands one at a time, allowing each move to finish:
 
 .. code-block:: text
@@ -275,185 +166,13 @@ the tool vertically. Joint feedback is printed after each move; ``open`` and
 ``close`` test the gripper. ``quit`` closes the environment and its arm worker.
 Use ``help`` for the other joint directions.
 
-Use the Robot Interface
-~~~~~~~~~~~~~~~~~~~~~~~
-
-For a local connection without a reset or scheduler worker, run this Python
-example from the same environment.
-The example reads the current joint positions and gripper opening, then sends
-those values back as targets. ``connect()`` opens the calibrated arm;
-``get_observation()`` returns the nested state used to construct the action.
-
-.. code-block:: python
-
-   from rlinf.robotics import SO101Robot
-   from rlinf.robotics.parts.arms.so101 import SO101Arm
-   from rlinf.utils.logging import get_logger
-
-   logger = get_logger()
-   robot = SO101Robot(
-       arm=SO101Arm.declare(
-           "/dev/ttyACM0", calibration_id="rlinf_follower", max_relative_target=5
-       )
-   )
-   robot.connect()
-   try:
-       reading = robot.get_observation()["arm"]
-       logger.info("Joint positions: %s", reading["arm_joint_position"])
-       robot.send_action(
-           {
-               "arm": {
-                   "joint_position": reading["arm_joint_position"],
-                   "end_effector": {"target": reading["end_effector"]["state"]},
-               }
-           }
-       )
-   finally:
-       robot.disconnect()
-
-``send_action()`` dispatches the nested targets and returns a dictionary of
-dispatched action values, not a new measurement. Read again to measure the
-result. ``disconnect()`` releases the arm and its shared gripper connection.
-Omitting ``node_rank`` keeps the example local and does not require a Ray cluster.
-
-The optional ``max_relative_target`` limit is passed to LeRobot in degrees:
-``5`` limits each joint target relative to the current joint position. It does
-not change RLinf's radian action units. Its default, ``None``, disables this
-clamping.
-
-Add a Camera
-~~~~~~~~~~~~
-
-To read images alongside the arm state, replace the robot declaration above
-with this composition. ``CameraInfo`` describes a physical camera;
-``Camera.declare()`` returns named, unconnected camera parts. The robot installer includes RealSense support on x86 Linux.
-
-Select the RealSense driver with ``Camera.backend("realsense")`` and list
-attached serial numbers with ``discover()``:
-
-.. code-block:: python
-
-   from rlinf.robotics import Camera
-
-   logger.info("RealSense serials: %s", Camera.backend("realsense").discover())
-
-Use one of the reported serial numbers as ``CAMERA_SERIAL`` in the following
-code, then connect and read an image:
-
-.. code-block:: python
-
-   from rlinf.robotics import Camera, CameraInfo
-
-   robot = SO101Robot(
-       arm=SO101Arm.declare(
-           "/dev/ttyACM0", calibration_id="rlinf_follower", max_relative_target=5
-       ),
-       **Camera.declare(
-           {"wrist_1": CameraInfo(name="wrist_1", serial_number="CAMERA_SERIAL")}
-       ),
-   )
-   robot.connect()
-   try:
-       image = robot.get_observation()["wrist_1"]["frame"]
-       logger.info("Camera image shape: %s", image.shape)
-   finally:
-       robot.disconnect()
-
-The default camera backend is RealSense. The image uses the camera's configured
-resolution; the environment prepares it for a policy. The robot opens and
-closes both connections. See
-:doc:`Robotics Interface </rst_source/concepts/robotics>` for other compositions.
-
-Use a Leader Arm
-~~~~~~~~~~~~~~~~
-
-For operator input, set up a separate SO-101 leader on its own serial port.
-Find the port as you did for the follower; the example uses ``/dev/ttyACM1``.
-For new motors, configure them individually using the same prompt-driven wiring
-sequence:
-
-.. code-block:: bash
-
-   lerobot-setup-motors \
-     --teleop.type=so101_leader \
-     --teleop.port=/dev/ttyACM1
-
-After assembling the leader, calibrate it and inspect its input with this
-terminal command. It reads the leader without driving a follower:
-
-.. code-block:: bash
-
-   python -m rlinf.robotics.parts.teleop.so101_leader \
-     --port /dev/ttyACM1 --id rlinf_leader --calibrate
-
-Follow the calibration prompts, inspect the reported joints and grip, then
-press Ctrl+C to close the connection. The environment's ``teleop`` setting can
-select ``so101_leader`` with ``port`` and ``calibration_id`` options. The leader
-produces the same five joint targets and continuous gripper opening as the
-follower. Keep ``teleop: none`` until you configure that device; see the
-teleoperation workflow in :doc:`New Real-World Tasks </rst_source/extending/new_task>`.
-
-After closing the leader check, launch the follower toolkit with both ports
-and calibration IDs:
-
-.. code-block:: bash
-
-   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env \
-     --port /dev/ttyACM0 --id rlinf_follower \
-     --leader /dev/ttyACM1 --leader-id rlinf_leader
-
-The follower initially folds as described above. Place the leader close to
-that pose, enter ``teleop``, then move it a little and verify the follower
-tracks it. These are absolute joint targets. Press Ctrl+C to stop following
-and return to the prompt, then enter ``quit`` to release the follower.
-
-Check the Integration Without Hardware
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The existing mock run checks the scheduler, environment, rollout, and actor
-path on a machine with one supported GPU:
-
-.. code-block:: bash
-
-   bash tests/e2e_tests/embodied/run.sh so101_mock_sac_mlp_reach \
-     runner.logger.log_path="$REPO_PATH/logs/so101_mock"
-
-The launcher enables mock SDKs because the config name contains ``mock``. It
-uses the real env implementation with ``is_dummy: False``, two fake cameras,
-and an MLP with ``action_dim: 6`` and ``obs_dim: 6``. This is a short software
-integration check; it does not need physical calibration or validate a task.
+To use the arm in your own program or attach cameras, see
+:doc:`Robotics Interface </rst_source/concepts/robotics>`.
 
 New Real-World Tasks
 --------------------
 
-After verifying your hardware, define the task's observations, reset procedure,
-reward, and success condition using
-:doc:`New Real-World Tasks </rst_source/extending/new_task>`. SO101 currently has
-hardware support and a reach scaffold, but no validated real-world task recipe.
-
-Start from ``SO101Env`` and ``SO101EnvConfig`` in
-``rlinf/envs/real/so101/base.py``. The adjacent ``reach.py`` shows how to build a
-task config from ``override_cfg`` and pass it into the base constructor; do not
-copy the Franka-specific ``CONFIG_CLS`` shortcut from the guide. Register the
-new class in ``rlinf/envs/real/so101/__init__.py`` under ``TASKS``, then copy
-``examples/embodiment/config/env/so101_reach.yaml`` and select your Gymnasium ID
-with ``init_params.id``. A task that needs Cartesian state must also supply
-forward kinematics or another source of pose observations.
-
-Keep hardware settings in the cluster's ``hardware`` block with ``type: SO101``:
-``serial_port`` selects the follower, ``calibration_id`` selects its calibration,
-and ``camera_serials: []`` selects no cameras. Task settings belong in
-``env.train.override_cfg``. The existing mock config shows how to place ``env``
-in the node group that carries the robot. For a controller on another machine,
-follow :doc:`Multi-Node Training </rst_source/guides/multi_node>` and
-:doc:`Robotics Architecture </rst_source/concepts/robotics_architecture>`.
-
-Visualization and Results
--------------------------
-
-The mock run writes TensorBoard logs under ``logs/so101_mock``. Use them to
-inspect software execution, not to measure physical task success. There are no
-validated task results or pretrained task weights for this example. Once your
-task is implemented, configure logging and video using
-:doc:`Training Metrics </rst_source/reference/metrics>` and
-:doc:`Logging </rst_source/guides/logger>`.
+After the hardware checks pass, follow
+:doc:`New Real-World Tasks </rst_source/extending/new_task>` to define a task's
+reset procedure, observations, actions, reward, and success condition. A working
+real-world task is required before starting training.

--- a/docs/source-en/rst_source/examples/embodied/so101.rst
+++ b/docs/source-en/rst_source/examples/embodied/so101.rst
@@ -1,0 +1,459 @@
+SO101 Setup and Control
+=======================
+
+.. figure:: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lerobot/SO101_Follower.webp
+   :align: center
+   :width: 70%
+
+   SO-101 follower with its gripper. Image: Hugging Face LeRobot.
+
+Connect an SO-101 follower to RLinf, read its joints and gripper, and send a
+command through the robotics interface. Install and calibrate the arm first,
+check it locally, then add cameras or a leader as your application requires.
+Use the task-extension guide to define a real-world task: the supplied reach
+environment and mock SAC run are integration scaffolding, not a validated task
+or training recipe.
+
+Overview
+--------
+
+SO101 support uses LeRobot to control five arm joints and a gripper on one
+serial bus. The current MLP and SAC configuration tests that hardware interface
+through mock SDKs.
+
+.. grid:: 2 4 4 4
+   :gutter: 2
+
+   .. grid-item-card:: Models
+      :text-align: center
+
+      MLP policy (integration test)
+
+   .. grid-item-card:: Algorithms
+      :text-align: center
+
+      SAC (integration test)
+
+   .. grid-item-card:: Tasks
+      :text-align: center
+
+      User-defined; reach scaffold
+
+   .. grid-item-card:: Hardware
+      :text-align: center
+
+      SO-101 follower · USB serial
+
+| **You'll do:** install dependencies → configure motors → calibrate → test follower and leader → add a task.
+| **Prerequisites:** :doc:`Installation </rst_source/start/installation>` · SO-101 hardware · Linux controller · USB serial connection.
+
+Tasks
+~~~~~
+
+The existing examples establish how to use the hardware and connect it to an
+environment. Define and validate the physical task separately.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 40 35
+
+   * - Purpose
+     - Entry Point
+     - Scope
+   * - Local hardware use
+     - ``SO101Robot`` with ``SO101Arm``
+     - Read state and command the follower's arm and gripper.
+   * - Environment scaffold
+     - ``SO101ReachEnv-v1``; ``env/so101_reach.yaml``
+     - Illustrates joint targets, reset, and reward wiring.
+   * - Integration test
+     - ``so101_mock_sac_mlp_reach``
+     - Runs SAC with mock SDKs; does not establish physical task performance.
+
+Observation and Action
+~~~~~~~~~~~~~~~~~~~~~~
+
+Use radians at the RLinf interface. The driver converts between these values
+and LeRobot's degrees, and between a fractional gripper opening and LeRobot's
+``0..100`` gripper scale.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 23 77
+
+   * - Field
+     - Contract
+   * - Observation
+     - ``arm.arm_joint_position``: five radians, ordered as ``shoulder_pan``,
+       ``shoulder_lift``, ``elbow_flex``, ``wrist_flex``, ``wrist_roll``;
+       ``arm.end_effector.state``: one gripper opening in ``[0, 1]``.
+       The scaffold's flat state has six values. No TCP pose, force, or torque
+       observation is supplied.
+   * - Action
+     - ``arm.joint_position``: five absolute joint targets in radians;
+       ``arm.end_effector.target``: one opening, ``0`` closed and ``1`` open.
+       The scaffold's flat action has six values; targets are not deltas.
+   * - Images
+     - Optional cameras. The scaffold centre-crops and resizes each image to
+       ``(128, 128, 3)`` under ``frames.wrist_1``, ``frames.wrist_2``, etc.
+       Without cameras it omits ``frames``; the mock MLP ignores images.
+   * - Reward
+     - The scaffold uses joint distance for dense reward or a per-joint
+       tolerance for sparse reward. Define reward and success for your own task.
+   * - Prompt
+     - The scaffold reports ``reach a joint configuration``.
+
+Hardware Setup
+--------------
+
+Prepare the follower and its controller machine first. A leader and camera are
+optional additions; neither is required for the initial joint and gripper check.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Component
+     - Requirement
+   * - Follower
+     - SO-101 arm with its gripper, servo controller, and the power supply specified for the kit.
+   * - Controller machine
+     - Linux computer with a USB connection to the follower's servo controller.
+   * - Leader (optional)
+     - A separate SO-101 leader, its power supply, and a second USB serial connection.
+   * - Camera (optional)
+     - Intel RealSense camera connected to the controller for image checks.
+   * - GPU (optional)
+     - One supported GPU for the mock SAC test, separate from the local hardware check.
+
+For an unassembled arm, follow the parts and assembly instructions in the
+`LeRobot SO-101 guide <https://huggingface.co/docs/lerobot/so101>`_. Configure new
+motors individually before completing the wiring; the installation steps below
+include the required commands.
+
+Installation
+------------
+
+Install the robot dependencies on the controller machine using the custom-environment
+workflow below. Run the checks from the same checkout and activated environment.
+
+Robot Controller Node
+~~~~~~~~~~~~~~~~~~~~~
+
+Clone RLinf on the machine connected to the robot, then install its environment.
+
+.. include:: _setup_common.rst
+   :end-before: Then set up the dependencies
+
+Install the robot dependencies from the repository root:
+
+.. code-block:: bash
+
+   # Mainland China users can add --use-mirror for faster downloads.
+   bash requirements/install.sh embodied --env so101
+   source .venv/bin/activate
+   export REPO_PATH="$PWD"
+
+The installer includes LeRobot with Feetech support. Run subsequent commands
+from this checkout with the environment activated. See
+:doc:`Installation </rst_source/start/installation>` for platform prerequisites;
+no model checkpoint is needed for the interface examples or the mock MLP test.
+
+Find the Port and Configure the Motors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Connect the servo controller's USB cable and the power supply specified for
+your kit. Find which serial device belongs to the follower:
+
+.. code-block:: bash
+
+   lerobot-find-port
+
+Unplug the USB cable when prompted, then reconnect it. The reported device path
+is the port to use below; these examples assume ``/dev/ttyACM0``. Check access:
+
+.. code-block:: bash
+
+   ls -l /dev/ttyACM0
+   id -nG
+
+On Ubuntu, a port owned by the ``dialout`` group requires your account to belong
+to that group. If it does not, run ``sudo usermod -aG dialout "$USER"``, log out
+and back in, then return to the checkout and reactivate ``.venv``. Recheck the
+port path after reconnecting USB.
+
+For new or replaced motors, assign IDs and baud rates once, following the
+upstream guide's wiring sequence:
+
+.. code-block:: bash
+
+   lerobot-setup-motors \
+     --robot.type=so101_follower \
+     --robot.port=/dev/ttyACM0
+
+Connect only the motor named by each prompt to the controller. The tool assigns
+its ID and baud rate before requesting the next motor. After all six motors
+are configured, complete the assembly and reconnect the daisy chain as shown
+in the guide. Skip motor setup for an already configured arm; calibration is
+still needed under the ID you will use with RLinf.
+
+Calibrate the Follower
+^^^^^^^^^^^^^^^^^^^^^^
+
+With the motors configured and the arm assembled, calibrate the follower from
+a terminal before RLinf opens the serial bus:
+
+.. code-block:: bash
+
+   lerobot-calibrate \
+     --robot.type=so101_follower \
+     --robot.port=/dev/ttyACM0 \
+     --robot.id=rlinf_follower
+
+Replace the port with your device. Move the joints to the middle positions
+shown in the guide, confirm the prompt, then move each joint through its travel
+as instructed. The tool reports the saved calibration file. Keep it under the
+account used for RLinf and reuse the ID as
+``calibration_id="rlinf_follower"``; do not substitute the leader's calibration.
+
+.. warning::
+
+   RLinf workers do not run interactive follower calibration. Missing or
+   inconsistent calibration causes connection to fail. Calibrate under the
+   account that will run the arm before starting workers.
+
+Run It
+------
+
+With the follower calibrated, check its joints and gripper through RLinf. An
+``SO101Arm`` declaration records the port and calibration settings without
+opening hardware. ``SO101Robot`` names the arm ``arm`` and exposes its gripper
+at ``arm.end_effector`` on the same connection.
+
+Testing the Setup
+~~~~~~~~~~~~~~~~~
+
+Rehearse the existing interactive check without hardware first:
+
+.. code-block:: bash
+
+   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env --mock
+
+At the prompt, enter ``where``, ``up``, ``where``, and ``quit``. The mock
+exercises the actual environment and driver with a fake servo bus. The toolkit
+uses a scheduler worker, so it may start a local Ray instance; no GPU is needed
+for this check. ``CAMERA_SERIALS=''`` explicitly disables camera discovery.
+
+.. warning::
+
+   On hardware, the environment constructor moves the arm to the folded rest
+   pose ``[0, -99, 95, 65, 0]`` degrees. Clear that motion path before launching
+   the toolkit. Its ``--no-reset`` flag skips a later reset but does not bypass
+   this initial movement. Use the Python interface example below to connect
+   without commanding a rest pose.
+
+With the follower calibrated and room for the initial fold, run:
+
+.. code-block:: bash
+
+   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env \
+     --port /dev/ttyACM0 --id rlinf_follower --step 2
+
+Enter these commands one at a time, allowing each move to finish:
+
+.. code-block:: text
+
+   where
+   up
+   down
+   open
+   close
+   quit
+
+``up`` and ``down`` change the shoulder angle by two degrees, rather than moving
+the tool vertically. Joint feedback is printed after each move; ``open`` and
+``close`` test the gripper. ``quit`` closes the environment and its arm worker.
+Use ``help`` for the other joint directions.
+
+Use the Robot Interface
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For a local connection without a reset or scheduler worker, run this Python
+example from the same environment.
+The example reads the current joint positions and gripper opening, then sends
+those values back as targets. ``connect()`` opens the calibrated arm;
+``get_observation()`` returns the nested state used to construct the action.
+
+.. code-block:: python
+
+   from rlinf.robotics import SO101Robot
+   from rlinf.robotics.parts.arms.so101 import SO101Arm
+   from rlinf.utils.logging import get_logger
+
+   logger = get_logger()
+   robot = SO101Robot(
+       arm=SO101Arm.declare(
+           "/dev/ttyACM0", calibration_id="rlinf_follower", max_relative_target=5
+       )
+   )
+   robot.connect()
+   try:
+       reading = robot.get_observation()["arm"]
+       logger.info("Joint positions: %s", reading["arm_joint_position"])
+       robot.send_action(
+           {
+               "arm": {
+                   "joint_position": reading["arm_joint_position"],
+                   "end_effector": {"target": reading["end_effector"]["state"]},
+               }
+           }
+       )
+   finally:
+       robot.disconnect()
+
+``send_action()`` dispatches the nested targets and returns a dictionary of
+dispatched action values, not a new measurement. Read again to measure the
+result. ``disconnect()`` releases the arm and its shared gripper connection.
+Omitting ``node_rank`` keeps the example local and does not require a Ray cluster.
+
+The optional ``max_relative_target`` limit is passed to LeRobot in degrees:
+``5`` limits each joint target relative to the current joint position. It does
+not change RLinf's radian action units. Its default, ``None``, disables this
+clamping.
+
+Add a Camera
+~~~~~~~~~~~~
+
+To read images alongside the arm state, replace the robot declaration above
+with this composition. ``CameraInfo`` describes a physical camera;
+``Camera.declare()`` returns named, unconnected camera parts. The robot installer includes RealSense support on x86 Linux.
+
+Select the RealSense driver with ``Camera.backend("realsense")`` and list
+attached serial numbers with ``discover()``:
+
+.. code-block:: python
+
+   from rlinf.robotics import Camera
+
+   logger.info("RealSense serials: %s", Camera.backend("realsense").discover())
+
+Use one of the reported serial numbers as ``CAMERA_SERIAL`` in the following
+code, then connect and read an image:
+
+.. code-block:: python
+
+   from rlinf.robotics import Camera, CameraInfo
+
+   robot = SO101Robot(
+       arm=SO101Arm.declare(
+           "/dev/ttyACM0", calibration_id="rlinf_follower", max_relative_target=5
+       ),
+       **Camera.declare(
+           {"wrist_1": CameraInfo(name="wrist_1", serial_number="CAMERA_SERIAL")}
+       ),
+   )
+   robot.connect()
+   try:
+       image = robot.get_observation()["wrist_1"]["frame"]
+       logger.info("Camera image shape: %s", image.shape)
+   finally:
+       robot.disconnect()
+
+The default camera backend is RealSense. The image uses the camera's configured
+resolution; the environment prepares it for a policy. The robot opens and
+closes both connections. See
+:doc:`Robotics Interface </rst_source/concepts/robotics>` for other compositions.
+
+Use a Leader Arm
+~~~~~~~~~~~~~~~~
+
+For operator input, set up a separate SO-101 leader on its own serial port.
+Find the port as you did for the follower; the example uses ``/dev/ttyACM1``.
+For new motors, configure them individually using the same prompt-driven wiring
+sequence:
+
+.. code-block:: bash
+
+   lerobot-setup-motors \
+     --teleop.type=so101_leader \
+     --teleop.port=/dev/ttyACM1
+
+After assembling the leader, calibrate it and inspect its input with this
+terminal command. It reads the leader without driving a follower:
+
+.. code-block:: bash
+
+   python -m rlinf.robotics.parts.teleop.so101_leader \
+     --port /dev/ttyACM1 --id rlinf_leader --calibrate
+
+Follow the calibration prompts, inspect the reported joints and grip, then
+press Ctrl+C to close the connection. The environment's ``teleop`` setting can
+select ``so101_leader`` with ``port`` and ``calibration_id`` options. The leader
+produces the same five joint targets and continuous gripper opening as the
+follower. Keep ``teleop: none`` until you configure that device; see the
+teleoperation workflow in :doc:`New Real-World Tasks </rst_source/extending/new_task>`.
+
+After closing the leader check, launch the follower toolkit with both ports
+and calibration IDs:
+
+.. code-block:: bash
+
+   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env \
+     --port /dev/ttyACM0 --id rlinf_follower \
+     --leader /dev/ttyACM1 --leader-id rlinf_leader
+
+The follower initially folds as described above. Place the leader close to
+that pose, enter ``teleop``, then move it a little and verify the follower
+tracks it. These are absolute joint targets. Press Ctrl+C to stop following
+and return to the prompt, then enter ``quit`` to release the follower.
+
+Check the Integration Without Hardware
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The existing mock run checks the scheduler, environment, rollout, and actor
+path on a machine with one supported GPU:
+
+.. code-block:: bash
+
+   bash tests/e2e_tests/embodied/run.sh so101_mock_sac_mlp_reach \
+     runner.logger.log_path="$REPO_PATH/logs/so101_mock"
+
+The launcher enables mock SDKs because the config name contains ``mock``. It
+uses the real env implementation with ``is_dummy: False``, two fake cameras,
+and an MLP with ``action_dim: 6`` and ``obs_dim: 6``. This is a short software
+integration check; it does not need physical calibration or validate a task.
+
+New Real-World Tasks
+--------------------
+
+After verifying your hardware, define the task's observations, reset procedure,
+reward, and success condition using
+:doc:`New Real-World Tasks </rst_source/extending/new_task>`. SO101 currently has
+hardware support and a reach scaffold, but no validated real-world task recipe.
+
+Start from ``SO101Env`` and ``SO101EnvConfig`` in
+``rlinf/envs/real/so101/base.py``. The adjacent ``reach.py`` shows how to build a
+task config from ``override_cfg`` and pass it into the base constructor; do not
+copy the Franka-specific ``CONFIG_CLS`` shortcut from the guide. Register the
+new class in ``rlinf/envs/real/so101/__init__.py`` under ``TASKS``, then copy
+``examples/embodiment/config/env/so101_reach.yaml`` and select your Gymnasium ID
+with ``init_params.id``. A task that needs Cartesian state must also supply
+forward kinematics or another source of pose observations.
+
+Keep hardware settings in the cluster's ``hardware`` block with ``type: SO101``:
+``serial_port`` selects the follower, ``calibration_id`` selects its calibration,
+and ``camera_serials: []`` selects no cameras. Task settings belong in
+``env.train.override_cfg``. The existing mock config shows how to place ``env``
+in the node group that carries the robot. For a controller on another machine,
+follow :doc:`Multi-Node Training </rst_source/guides/multi_node>` and
+:doc:`Robotics Architecture </rst_source/concepts/robotics_architecture>`.
+
+Visualization and Results
+-------------------------
+
+The mock run writes TensorBoard logs under ``logs/so101_mock``. Use them to
+inspect software execution, not to measure physical task success. There are no
+validated task results or pretrained task weights for this example. Once your
+task is implemented, configure logging and video using
+:doc:`Training Metrics </rst_source/reference/metrics>` and
+:doc:`Logging </rst_source/guides/logger>`.

--- a/docs/source-en/rst_source/examples/real_world_index.rst
+++ b/docs/source-en/rst_source/examples/real_world_index.rst
@@ -1,7 +1,7 @@
 RL with Real-World Robots
 =========================
 
-Use this section when your starting point is physical robot hardware. Start with Franka if you use a Franka arm or a Franka-based rig; use the other robot pages for GimArm, XSquare Turtle2, and Dexmal DOS-W1.
+Use this section when your starting point is physical robot hardware. Start with Franka if you use a Franka arm or a Franka-based rig; use the other robot pages for GimArm, XSquare Turtle2, Dexmal DOS-W1, AgileX Piper, and SO101.
 
 Each section gives the setup path for teleoperation, data collection, sim-to-real transfer, deployment, or online RL.
 
@@ -62,6 +62,26 @@ Each section gives the setup path for teleoperation, data collection, sim-to-rea
 
    </div>
 
+Piper and SO101 Setup
+---------------------
+
+Use these guides to connect and test an arm, then define your own task.
+
+.. grid:: 1 2 2 2
+   :gutter: 2
+
+   .. grid-item-card:: AgileX Piper
+      :link: embodied/piper
+      :link-type: doc
+
+      Configure CAN and check Piper joints, gripper, and camera composition.
+
+   .. grid-item-card:: SO101
+      :link: embodied/so101
+      :link-type: doc
+
+      Set up motors, calibrate an SO-101, and check follower and leader control.
+
 .. toctree::
    :hidden:
    :maxdepth: 3
@@ -71,3 +91,5 @@ Each section gives the setup path for teleoperation, data collection, sim-to-rea
    GimArm <embodied/gim_arm>
    XSquare Turtle2 <embodied/xsquare_turtle2>
    DOS-W1 <embodied/dosw1>
+   Piper <embodied/piper>
+   SO101 <embodied/so101>

--- a/docs/source-en/rst_source/examples/real_world_index.rst
+++ b/docs/source-en/rst_source/examples/real_world_index.rst
@@ -3,7 +3,7 @@ RL with Real-World Robots
 
 Use this section when your starting point is physical robot hardware. Start with Franka if you use a Franka arm or a Franka-based rig; use the other robot pages for GimArm, XSquare Turtle2, Dexmal DOS-W1, AgileX Piper, and SO101.
 
-Each section gives the setup path for teleoperation, data collection, sim-to-real transfer, deployment, or online RL.
+Choose a guide for hardware checks, teleoperation, data collection, sim-to-real transfer, deployment, or online RL.
 
 .. raw:: html
 
@@ -65,7 +65,7 @@ Each section gives the setup path for teleoperation, data collection, sim-to-rea
 Piper and SO101 Setup
 ---------------------
 
-Use these guides to connect and test an arm, then define your own task.
+Use these guides to connect an arm and run its hardware test script. Piper and SO101 do not yet have supported real-world tasks or training workflows.
 
 .. grid:: 1 2 2 2
    :gutter: 2
@@ -74,13 +74,13 @@ Use these guides to connect and test an arm, then define your own task.
       :link: embodied/piper
       :link-type: doc
 
-      Configure CAN and check Piper joints, gripper, and camera composition.
+      Configure CAN and run the Piper joint and gripper test script.
 
    .. grid-item-card:: SO101
       :link: embodied/so101
       :link-type: doc
 
-      Set up motors, calibrate an SO-101, and check follower and leader control.
+      Set up motors, calibrate an SO-101, and run the joint and gripper test script.
 
 .. toctree::
    :hidden:

--- a/docs/source-zh/rst_source/examples/embodied/piper.rst
+++ b/docs/source-zh/rst_source/examples/embodied/piper.rst
@@ -1,93 +1,23 @@
 AgileX Piper 配置与控制
 =======================
 
+本文介绍如何配置 AgileX Piper 机械臂，并运行 RLinf 硬件测试脚本，读取反馈、检查关节运动与夹爪开合。
+
 .. figure:: https://raw.githubusercontent.com/agilexrobotics/piper_ros/noetic/asserts/pictures/piper_urdf_zero.png
    :align: center
    :width: 70%
 
    Piper 机械臂与夹爪模型。图片来源：AgileX Robotics，piper_ros。
 
-将 AgileX Piper 机械臂接入 RLinf，读取关节与夹爪状态，并通过机器人接口发送控制指令。先在本机连接 CAN 总线，按需加入相机，再参考任务扩展指南定义自己的真机任务。现有 reach 环境和 mock SAC 配置用于检查集成流程，尚无经过验证的任务或训练方案。
-
 概览
 ----
 
-RLinf 通过 ``pyAgxArm`` SDK 控制 Piper 机械臂及其 AgxGripper 夹爪。当前测试配置采用 MLP policy，通过 mock SDK 检查训练流程，无需物理硬件。
-
-.. grid:: 2 4 4 4
-   :gutter: 2
-
-   .. grid-item-card:: 模型
-      :text-align: center
-
-      MLP policy（集成测试）
-
-   .. grid-item-card:: 算法
-      :text-align: center
-
-      SAC（集成测试）
-
-   .. grid-item-card:: 任务
-      :text-align: center
-
-      自定义任务；reach 示例框架
-
-   .. grid-item-card:: 硬件
-      :text-align: center
-
-      Piper · CAN · AgxGripper
-
-| **操作流程：** 安装依赖 → 配置 CAN → 读取反馈 → 测试关节与夹爪 → 新增任务。
-| **前置条件：** :doc:`安装 </rst_source/start/installation>` · Piper 硬件 · Linux 控制主机 · CAN 适配器。
-
-任务
-~~~~
-
-先通过现有文件了解硬件与环境之间的 contract，再定义需要机器人学习的行为。
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 40 35
-
-   * - 用途
-     - 入口
-     - 范围
-   * - 本机硬件操作
-     - ``PiperRobot`` 与 ``PiperArm``
-     - 读取状态，控制机械臂与夹爪。
-   * - 环境示例框架
-     - ``PiperReachEnv-v1``；``env/piper_reach.yaml``
-     - 展示关节目标、复位和奖励的接入方式。
-   * - 集成测试
-     - ``piper_mock_sac_mlp_reach``
-     - 使用 mock SDK 运行 SAC，不代表物理任务性能。
-
-观测与动作
-~~~~~~~~~~
-
-机器人返回嵌套字典。reach 示例框架将这些数据转换为测试 policy 使用的一维状态和动作数组。
-
-.. list-table::
-   :header-rows: 1
-   :widths: 23 77
-
-   * - 字段
-     - Contract
-   * - Observation
-     - ``arm.arm_joint_position``：6 个关节角，单位为弧度；``arm.tcp_pose``：基座坐标系中的 ``[x, y, z, qx, qy, qz, qw]``，位置单位为米；``arm.end_effector.state``：1 个夹爪开度，范围为 ``[0, 1]``。带夹爪时，示例框架的一维状态包含 14 个数值。
-   * - Action
-     - ``arm.joint_position``：6 个绝对关节目标，单位为弧度；``arm.end_effector.target``：1 个夹爪开度，``0`` 为闭合，``1`` 为全开。示例框架的一维动作包含 7 个数值，关节目标不是增量。
-   * - Images
-     - 相机可选。示例框架对每张图像居中裁剪并缩放为 ``(128, 128, 3)``，存入 ``frames.wrist_1``、``frames.wrist_2`` 等 key。没有相机时不包含 ``frames``；mock MLP 不使用图像。
-   * - Reward
-     - 示例框架按关节距离计算稠密奖励，或按逐关节容差计算稀疏奖励。实际任务需要自行定义奖励与成功条件。
-   * - Prompt
-     - 示例框架返回 ``reach a joint configuration``。
+测试在连接机械臂的 Linux 主机上运行，无需 GPU 或模型 checkpoint。RLinf 目前尚未提供适用于 AgileX Piper 的真机任务或训练流程；本指南仅介绍硬件检查。
 
 硬件配置
 --------
 
-先准备控制主机及其连接的机械臂，再安装软件。本机硬件检查在控制主机上运行；只有可选的 mock SAC 集成测试需要 GPU。
+安装软件前，先准备机械臂及其控制主机。
 
 .. list-table::
    :header-rows: 1
@@ -99,10 +29,6 @@ RLinf 通过 ``pyAgxArm`` SDK 控制 Piper 机械臂及其 AgxGripper 夹爪。�
      - AgileX Piper 及其电源；若安装夹爪，则使用 AgxGripper。
    * - 控制主机
      - Linux 计算机、处于 SocketCAN 模式的 USB-to-CAN 适配器，以及连接机械臂的 CAN 线缆。
-   * - 相机（可选）
-     - 连接到控制主机的 Intel RealSense 相机，用于图像检查。
-   * - GPU（可选）
-     - mock SAC 测试需要一张受支持的 GPU，本机硬件检查无需 GPU。
 
 将机械臂固定在稳定的台面上，并为小幅关节运动留出空间。上电前，按厂商说明连接电源与 CAN 线缆。
 
@@ -128,7 +54,7 @@ RLinf 通过 ``pyAgxArm`` SDK 控制 Piper 机械臂及其 AgxGripper 夹爪。�
    source .venv/bin/activate
    export REPO_PATH="$PWD"
 
-后续命令均在此仓库目录中运行，并保持环境已激活。安装脚本会安装 ``PiperArm`` 使用的固定版本 ``pyAgxArm`` 驱动；平台要求见 :doc:`安装 </rst_source/start/installation>`。接口示例和 mock MLP 测试均无需下载模型 checkpoint。
+后续命令均在此仓库目录中运行，并保持环境已激活。安装脚本会安装 ``PiperArm`` 使用的固定版本 ``pyAgxArm`` 驱动；平台要求见 :doc:`安装 </rst_source/start/installation>`。
 
 准备 CAN 连接
 ^^^^^^^^^^^^^
@@ -147,25 +73,14 @@ RLinf 通过 ``pyAgxArm`` SDK 控制 Piper 机械臂及其 AgxGripper 夹爪。�
 运行
 ----
 
-CAN 配置完成后，先在当前 Python 进程中使用机械臂。``PiperArm`` 声明记录设备参数，但不打开硬件；``PiperRobot`` 将这条机械臂命名为 ``arm``。夹爪与机械臂共用 CAN 连接，访问路径为 ``arm.end_effector``。
-
-测试配置
-~~~~~~~~
-
-先在无硬件模式下检查测试工具：
-
-.. code-block:: bash
-
-   python -m toolkits.realworld_check.test_piper_controller --mock --read-only
-
-命令打印 6 个实测关节角、包含 7 个数值的工具位姿以及 1 个夹爪开度，然后退出。mock 数值仅用于验证软件流程。随后对已连接的机械臂执行相同检查：
+CAN 配置完成且机械臂上电后，先读取反馈：
 
 .. code-block:: bash
 
    python -m toolkits.realworld_check.test_piper_controller \
      --channel can0 --read-only
 
-此命令使能电机并读取反馈，不发送位置目标，也不复位机械臂。日志中会显示检测到的固件 profile。若 AgxGripper 行程为 0.1 m，添加 ``--gripper-max-width 0.1``；未安装夹爪时，添加 ``--no-gripper``。
+命令打印 6 个关节角（单位为度）、工具位姿（位置单位为米，旋转为 xyzw 四元数）和范围为 ``[0, 1]`` 的夹爪开度，然后退出。此命令使能电机并读取反馈，不发送位置目标，也不复位机械臂。日志中会显示检测到的固件 profile。若 AgxGripper 行程为 0.1 m，添加 ``--gripper-max-width 0.1``；未安装夹爪时，添加 ``--no-gripper``。
 
 去掉 ``--read-only`` 即可测试小幅运动。逐条输入下列指令，每次运动结束后再继续：
 
@@ -184,100 +99,15 @@ CAN 配置完成后，先在当前 Python 进程中使用机械臂。``PiperArm`
    where
    quit
 
-``joint 1 2`` 以关节 1 的实测位置为起点，增加 2 度。脚本接受关节编号 1 至 6，单次增量不超过 5 度；机械臂驱动还会按关节行程裁剪目标。``grip 0.5`` 将夹爪目标设为完整行程的一半。``where`` 读取反馈，夹爪停止后可再次执行。``quit``、EOF 或 Ctrl+C 关闭 CAN 会话，电机继续保持位置。添加 ``--mock`` 可在无硬件模式下演练同一组指令。
+``joint 1 2`` 以关节 1 的实测位置为起点，增加 2 度。脚本接受关节编号 1 至 6，单次增量不超过 5 度；机械臂驱动还会按关节行程裁剪目标。``grip 0.5`` 将夹爪目标设为完整行程的一半。``where`` 读取反馈，夹爪停止后可再次执行。``quit``、EOF 或 Ctrl+C 关闭 CAN 会话，电机继续保持位置。
 
 .. warning::
 
    即使指定 ``--read-only``，连接时也会使能电机。连接前清空运动区域，执行关节与夹爪指令时保持手部远离机器人。退出测试不等同于急停，也不会切断电机电源。
 
-使用机器人接口
-~~~~~~~~~~~~~~
-
-在自己的 Python 程序中可使用以下接口示例。``connect()`` 打开连接并使能机械臂，``get_observation()`` 返回嵌套状态。示例读取当前关节位置和夹爪开度，再将这些数值作为目标发送回机器人。
-
-.. code-block:: python
-
-   from rlinf.robotics import PiperRobot
-   from rlinf.robotics.parts.arms.piper import PiperArm
-   from rlinf.utils.logging import get_logger
-
-   logger = get_logger()
-   robot = PiperRobot(arm=PiperArm.declare("can0", speed_percent=10))
-   robot.connect()
-   try:
-       reading = robot.get_observation()["arm"]
-       logger.info("Joint positions: %s", reading["arm_joint_position"])
-       robot.send_action(
-           {
-               "arm": {
-                   "joint_position": reading["arm_joint_position"],
-                   "end_effector": {"target": reading["end_effector"]["state"]},
-               }
-           }
-       )
-   finally:
-       robot.disconnect()
-
-``send_action()`` 分发嵌套目标，返回已分发动作值的字典；如需测量执行结果，应再次读取观测。``disconnect()`` 释放机器人连接，包括机械臂与夹爪共用的连接。不指定 ``node_rank`` 时，上述示例在本机进程中运行，无需 Ray 集群。
-
-``gripper_max_width`` 表示所装夹爪的完整行程，单位为米，默认值为 ``0.07``。没有夹爪时，声明 ``with_gripper=False``，并移除夹爪动作与观测访问。此时示例框架包含 6 个动作值和 13 个状态值。
-
-加入相机
-~~~~~~~~
-
-如果需要同时读取图像和机械臂状态，可将上例的机器人声明替换为以下组合。``CameraInfo`` 描述物理相机，``Camera.declare()`` 返回按名称组织、尚未连接的相机零部件。机器人安装脚本在 x86 Linux 上包含 RealSense 支持。
-
-通过 ``Camera.backend("realsense")`` 选择相机驱动，再调用 ``discover()`` 列出已连接相机的序列号：
-
-.. code-block:: python
-
-   from rlinf.robotics import Camera
-
-   logger.info("RealSense serials: %s", Camera.backend("realsense").discover())
-
-将下例中的 ``CAMERA_SERIAL`` 替换为列出的一个序列号，再连接并读取图像：
-
-.. code-block:: python
-
-   from rlinf.robotics import Camera, CameraInfo
-
-   robot = PiperRobot(
-       arm=PiperArm.declare("can0", speed_percent=10),
-       **Camera.declare(
-           {"wrist_1": CameraInfo(name="wrist_1", serial_number="CAMERA_SERIAL")}
-       ),
-   )
-   robot.connect()
-   try:
-       image = robot.get_observation()["wrist_1"]["frame"]
-       logger.info("Camera image shape: %s", image.shape)
-   finally:
-       robot.disconnect()
-
-默认相机 backend 为 RealSense。接口返回相机配置分辨率下的图像，由环境负责缩放到 policy 输入所需的尺寸。机器人统一打开和关闭相机与机械臂；其他组合方式见 :doc:`机器人接口 </rst_source/concepts/robotics>`。
-
-无硬件集成检查
-~~~~~~~~~~~~~~
-
-理解接口后，可在配有一张受支持 GPU 的主机上运行现有 mock 配置，检查 scheduler、环境、rollout 与 actor 的完整调用流程：
-
-.. code-block:: bash
-
-   bash tests/e2e_tests/embodied/run.sh piper_mock_sac_mlp_reach \
-     runner.logger.log_path="$REPO_PATH/logs/piper_mock"
-
-配置名包含 ``mock``，启动脚本因此启用 mock SDK。测试使用实际环境实现，设置 ``is_dummy: False``，接入两台假相机，并采用 ``action_dim: 7``、``obs_dim: 14`` 的 MLP。这只是短时软件集成检查，不会驱动物理机械臂，也不验证任务效果。
+在自己的程序中控制机械臂或接入相机，请参考 :doc:`机器人接口 </rst_source/concepts/robotics>`。
 
 新增真机任务
 ------------
 
-硬件检查通过后，参考 :doc:`新增真机任务 </rst_source/extending/new_task>` 定义任务观测、复位流程、奖励和成功条件。Piper 当前具备硬件接口与 reach 示例框架，尚无经过验证的真机任务方案。
-
-从 ``rlinf/envs/real/piper/base.py`` 中的 ``PiperEnv`` 与 ``PiperEnvConfig`` 开始。相邻的 ``reach.py`` 展示了如何从 ``override_cfg`` 构造任务配置并传给基类构造函数；指南中的 ``CONFIG_CLS`` 简写仅适用于 Franka。将新任务类加入 ``rlinf/envs/real/piper/__init__.py`` 的 ``TASKS``，再复制 ``examples/embodiment/config/env/piper_reach.yaml``，通过 ``init_params.id`` 选择新注册的 Gymnasium ID。
-
-硬件参数放在集群的 ``hardware`` 配置中，设置 ``type: Piper``；任务参数放在 ``env.train.override_cfg`` 中。现有 mock 配置展示了如何将 ``env`` 放置到携带机器人硬件的 node group。控制器位于另一台主机时，参考 :doc:`多节点训练 </rst_source/guides/multi_node>` 和 :doc:`机器人架构 </rst_source/concepts/robotics_architecture>`。当前没有已注册的遥操作设备能生成 Piper 所需的关节布局，添加兼容设备前请保持 ``teleop: none``。
-
-可视化与结果
-------------
-
-mock 运行将 TensorBoard 日志写入 ``logs/piper_mock``，用于检查软件执行流程，不代表物理任务成功率。此示例尚无经过验证的任务结果或预训练任务权重。完成自己的任务后，可按 :doc:`训练指标 </rst_source/reference/metrics>` 和 :doc:`日志记录 </rst_source/guides/logger>` 配置日志与视频。
+硬件检查通过后，参考 :doc:`新增真机任务 </rst_source/extending/new_task>` 定义任务的复位流程、观测、动作、奖励和成功条件。开始训练前，需要先实现可运行的真机任务。

--- a/docs/source-zh/rst_source/examples/embodied/piper.rst
+++ b/docs/source-zh/rst_source/examples/embodied/piper.rst
@@ -1,0 +1,283 @@
+AgileX Piper 配置与控制
+=======================
+
+.. figure:: https://raw.githubusercontent.com/agilexrobotics/piper_ros/noetic/asserts/pictures/piper_urdf_zero.png
+   :align: center
+   :width: 70%
+
+   Piper 机械臂与夹爪模型。图片来源：AgileX Robotics，piper_ros。
+
+将 AgileX Piper 机械臂接入 RLinf，读取关节与夹爪状态，并通过机器人接口发送控制指令。先在本机连接 CAN 总线，按需加入相机，再参考任务扩展指南定义自己的真机任务。现有 reach 环境和 mock SAC 配置用于检查集成流程，尚无经过验证的任务或训练方案。
+
+概览
+----
+
+RLinf 通过 ``pyAgxArm`` SDK 控制 Piper 机械臂及其 AgxGripper 夹爪。当前测试配置采用 MLP policy，通过 mock SDK 检查训练流程，无需物理硬件。
+
+.. grid:: 2 4 4 4
+   :gutter: 2
+
+   .. grid-item-card:: 模型
+      :text-align: center
+
+      MLP policy（集成测试）
+
+   .. grid-item-card:: 算法
+      :text-align: center
+
+      SAC（集成测试）
+
+   .. grid-item-card:: 任务
+      :text-align: center
+
+      自定义任务；reach 示例框架
+
+   .. grid-item-card:: 硬件
+      :text-align: center
+
+      Piper · CAN · AgxGripper
+
+| **操作流程：** 安装依赖 → 配置 CAN → 读取反馈 → 测试关节与夹爪 → 新增任务。
+| **前置条件：** :doc:`安装 </rst_source/start/installation>` · Piper 硬件 · Linux 控制主机 · CAN 适配器。
+
+任务
+~~~~
+
+先通过现有文件了解硬件与环境之间的 contract，再定义需要机器人学习的行为。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 40 35
+
+   * - 用途
+     - 入口
+     - 范围
+   * - 本机硬件操作
+     - ``PiperRobot`` 与 ``PiperArm``
+     - 读取状态，控制机械臂与夹爪。
+   * - 环境示例框架
+     - ``PiperReachEnv-v1``；``env/piper_reach.yaml``
+     - 展示关节目标、复位和奖励的接入方式。
+   * - 集成测试
+     - ``piper_mock_sac_mlp_reach``
+     - 使用 mock SDK 运行 SAC，不代表物理任务性能。
+
+观测与动作
+~~~~~~~~~~
+
+机器人返回嵌套字典。reach 示例框架将这些数据转换为测试 policy 使用的一维状态和动作数组。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 23 77
+
+   * - 字段
+     - Contract
+   * - Observation
+     - ``arm.arm_joint_position``：6 个关节角，单位为弧度；``arm.tcp_pose``：基座坐标系中的 ``[x, y, z, qx, qy, qz, qw]``，位置单位为米；``arm.end_effector.state``：1 个夹爪开度，范围为 ``[0, 1]``。带夹爪时，示例框架的一维状态包含 14 个数值。
+   * - Action
+     - ``arm.joint_position``：6 个绝对关节目标，单位为弧度；``arm.end_effector.target``：1 个夹爪开度，``0`` 为闭合，``1`` 为全开。示例框架的一维动作包含 7 个数值，关节目标不是增量。
+   * - Images
+     - 相机可选。示例框架对每张图像居中裁剪并缩放为 ``(128, 128, 3)``，存入 ``frames.wrist_1``、``frames.wrist_2`` 等 key。没有相机时不包含 ``frames``；mock MLP 不使用图像。
+   * - Reward
+     - 示例框架按关节距离计算稠密奖励，或按逐关节容差计算稀疏奖励。实际任务需要自行定义奖励与成功条件。
+   * - Prompt
+     - 示例框架返回 ``reach a joint configuration``。
+
+硬件配置
+--------
+
+先准备控制主机及其连接的机械臂，再安装软件。本机硬件检查在控制主机上运行；只有可选的 mock SAC 集成测试需要 GPU。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 组件
+     - 要求
+   * - 机械臂与夹爪
+     - AgileX Piper 及其电源；若安装夹爪，则使用 AgxGripper。
+   * - 控制主机
+     - Linux 计算机、处于 SocketCAN 模式的 USB-to-CAN 适配器，以及连接机械臂的 CAN 线缆。
+   * - 相机（可选）
+     - 连接到控制主机的 Intel RealSense 相机，用于图像检查。
+   * - GPU（可选）
+     - mock SAC 测试需要一张受支持的 GPU，本机硬件检查无需 GPU。
+
+将机械臂固定在稳定的台面上，并为小幅关节运动留出空间。上电前，按厂商说明连接电源与 CAN 线缆。
+
+安装
+----
+
+在控制主机上按下方自定义环境流程安装机器人依赖。后续检查均在同一仓库目录和已激活的环境中运行。
+
+机器人控制节点
+~~~~~~~~~~~~~~
+
+在连接机器人的主机上克隆 RLinf，然后安装对应环境。
+
+.. include:: _setup_common.rst
+   :end-before: 然后，使用
+
+在仓库根目录安装机器人依赖：
+
+.. code-block:: bash
+
+   # Mainland China users can add --use-mirror for faster downloads.
+   bash requirements/install.sh embodied --env piper
+   source .venv/bin/activate
+   export REPO_PATH="$PWD"
+
+后续命令均在此仓库目录中运行，并保持环境已激活。安装脚本会安装 ``PiperArm`` 使用的固定版本 ``pyAgxArm`` 驱动；平台要求见 :doc:`安装 </rst_source/start/installation>`。接口示例和 mock MLP 测试均无需下载模型 checkpoint。
+
+准备 CAN 连接
+^^^^^^^^^^^^^
+
+运行 ``ip -brief link`` 查找 SocketCAN 接口。处于 SocketCAN 模式的 USB-to-CAN 适配器通常显示为 ``can0``；如果名称不同，请替换下列命令中的接口名。连接机器人前，将接口配置为 1 Mbit/s：
+
+.. code-block:: bash
+
+   sudo ip link set can0 down
+   sudo ip link set can0 type can bitrate 1000000
+   sudo ip link set can0 up
+   ip -details link show can0
+
+输出中应显示接口已启用，且包含 ``bitrate 1000000``。机械臂上电后，运行 ``candump -n 5 can0`` 查看 5 帧反馈报文。如果一直没有报文，按 Ctrl+C 退出，检查电源、CAN 接线、适配器和波特率，再继续操作。SDK 不会配置 CAN 接口；适配器配置与硬件支持说明见 `pyAgxArm 文档 <https://github.com/agilexrobotics/pyAgxArm>`_。
+
+运行
+----
+
+CAN 配置完成后，先在当前 Python 进程中使用机械臂。``PiperArm`` 声明记录设备参数，但不打开硬件；``PiperRobot`` 将这条机械臂命名为 ``arm``。夹爪与机械臂共用 CAN 连接，访问路径为 ``arm.end_effector``。
+
+测试配置
+~~~~~~~~
+
+先在无硬件模式下检查测试工具：
+
+.. code-block:: bash
+
+   python -m toolkits.realworld_check.test_piper_controller --mock --read-only
+
+命令打印 6 个实测关节角、包含 7 个数值的工具位姿以及 1 个夹爪开度，然后退出。mock 数值仅用于验证软件流程。随后对已连接的机械臂执行相同检查：
+
+.. code-block:: bash
+
+   python -m toolkits.realworld_check.test_piper_controller \
+     --channel can0 --read-only
+
+此命令使能电机并读取反馈，不发送位置目标，也不复位机械臂。日志中会显示检测到的固件 profile。若 AgxGripper 行程为 0.1 m，添加 ``--gripper-max-width 0.1``；未安装夹爪时，添加 ``--no-gripper``。
+
+去掉 ``--read-only`` 即可测试小幅运动。逐条输入下列指令，每次运动结束后再继续：
+
+.. code-block:: bash
+
+   python -m toolkits.realworld_check.test_piper_controller \
+     --channel can0 --speed-percent 10
+
+.. code-block:: text
+
+   where
+   joint 1 2
+   where
+   joint 1 -2
+   grip 0.5
+   where
+   quit
+
+``joint 1 2`` 以关节 1 的实测位置为起点，增加 2 度。脚本接受关节编号 1 至 6，单次增量不超过 5 度；机械臂驱动还会按关节行程裁剪目标。``grip 0.5`` 将夹爪目标设为完整行程的一半。``where`` 读取反馈，夹爪停止后可再次执行。``quit``、EOF 或 Ctrl+C 关闭 CAN 会话，电机继续保持位置。添加 ``--mock`` 可在无硬件模式下演练同一组指令。
+
+.. warning::
+
+   即使指定 ``--read-only``，连接时也会使能电机。连接前清空运动区域，执行关节与夹爪指令时保持手部远离机器人。退出测试不等同于急停，也不会切断电机电源。
+
+使用机器人接口
+~~~~~~~~~~~~~~
+
+在自己的 Python 程序中可使用以下接口示例。``connect()`` 打开连接并使能机械臂，``get_observation()`` 返回嵌套状态。示例读取当前关节位置和夹爪开度，再将这些数值作为目标发送回机器人。
+
+.. code-block:: python
+
+   from rlinf.robotics import PiperRobot
+   from rlinf.robotics.parts.arms.piper import PiperArm
+   from rlinf.utils.logging import get_logger
+
+   logger = get_logger()
+   robot = PiperRobot(arm=PiperArm.declare("can0", speed_percent=10))
+   robot.connect()
+   try:
+       reading = robot.get_observation()["arm"]
+       logger.info("Joint positions: %s", reading["arm_joint_position"])
+       robot.send_action(
+           {
+               "arm": {
+                   "joint_position": reading["arm_joint_position"],
+                   "end_effector": {"target": reading["end_effector"]["state"]},
+               }
+           }
+       )
+   finally:
+       robot.disconnect()
+
+``send_action()`` 分发嵌套目标，返回已分发动作值的字典；如需测量执行结果，应再次读取观测。``disconnect()`` 释放机器人连接，包括机械臂与夹爪共用的连接。不指定 ``node_rank`` 时，上述示例在本机进程中运行，无需 Ray 集群。
+
+``gripper_max_width`` 表示所装夹爪的完整行程，单位为米，默认值为 ``0.07``。没有夹爪时，声明 ``with_gripper=False``，并移除夹爪动作与观测访问。此时示例框架包含 6 个动作值和 13 个状态值。
+
+加入相机
+~~~~~~~~
+
+如果需要同时读取图像和机械臂状态，可将上例的机器人声明替换为以下组合。``CameraInfo`` 描述物理相机，``Camera.declare()`` 返回按名称组织、尚未连接的相机零部件。机器人安装脚本在 x86 Linux 上包含 RealSense 支持。
+
+通过 ``Camera.backend("realsense")`` 选择相机驱动，再调用 ``discover()`` 列出已连接相机的序列号：
+
+.. code-block:: python
+
+   from rlinf.robotics import Camera
+
+   logger.info("RealSense serials: %s", Camera.backend("realsense").discover())
+
+将下例中的 ``CAMERA_SERIAL`` 替换为列出的一个序列号，再连接并读取图像：
+
+.. code-block:: python
+
+   from rlinf.robotics import Camera, CameraInfo
+
+   robot = PiperRobot(
+       arm=PiperArm.declare("can0", speed_percent=10),
+       **Camera.declare(
+           {"wrist_1": CameraInfo(name="wrist_1", serial_number="CAMERA_SERIAL")}
+       ),
+   )
+   robot.connect()
+   try:
+       image = robot.get_observation()["wrist_1"]["frame"]
+       logger.info("Camera image shape: %s", image.shape)
+   finally:
+       robot.disconnect()
+
+默认相机 backend 为 RealSense。接口返回相机配置分辨率下的图像，由环境负责缩放到 policy 输入所需的尺寸。机器人统一打开和关闭相机与机械臂；其他组合方式见 :doc:`机器人接口 </rst_source/concepts/robotics>`。
+
+无硬件集成检查
+~~~~~~~~~~~~~~
+
+理解接口后，可在配有一张受支持 GPU 的主机上运行现有 mock 配置，检查 scheduler、环境、rollout 与 actor 的完整调用流程：
+
+.. code-block:: bash
+
+   bash tests/e2e_tests/embodied/run.sh piper_mock_sac_mlp_reach \
+     runner.logger.log_path="$REPO_PATH/logs/piper_mock"
+
+配置名包含 ``mock``，启动脚本因此启用 mock SDK。测试使用实际环境实现，设置 ``is_dummy: False``，接入两台假相机，并采用 ``action_dim: 7``、``obs_dim: 14`` 的 MLP。这只是短时软件集成检查，不会驱动物理机械臂，也不验证任务效果。
+
+新增真机任务
+------------
+
+硬件检查通过后，参考 :doc:`新增真机任务 </rst_source/extending/new_task>` 定义任务观测、复位流程、奖励和成功条件。Piper 当前具备硬件接口与 reach 示例框架，尚无经过验证的真机任务方案。
+
+从 ``rlinf/envs/real/piper/base.py`` 中的 ``PiperEnv`` 与 ``PiperEnvConfig`` 开始。相邻的 ``reach.py`` 展示了如何从 ``override_cfg`` 构造任务配置并传给基类构造函数；指南中的 ``CONFIG_CLS`` 简写仅适用于 Franka。将新任务类加入 ``rlinf/envs/real/piper/__init__.py`` 的 ``TASKS``，再复制 ``examples/embodiment/config/env/piper_reach.yaml``，通过 ``init_params.id`` 选择新注册的 Gymnasium ID。
+
+硬件参数放在集群的 ``hardware`` 配置中，设置 ``type: Piper``；任务参数放在 ``env.train.override_cfg`` 中。现有 mock 配置展示了如何将 ``env`` 放置到携带机器人硬件的 node group。控制器位于另一台主机时，参考 :doc:`多节点训练 </rst_source/guides/multi_node>` 和 :doc:`机器人架构 </rst_source/concepts/robotics_architecture>`。当前没有已注册的遥操作设备能生成 Piper 所需的关节布局，添加兼容设备前请保持 ``teleop: none``。
+
+可视化与结果
+------------
+
+mock 运行将 TensorBoard 日志写入 ``logs/piper_mock``，用于检查软件执行流程，不代表物理任务成功率。此示例尚无经过验证的任务结果或预训练任务权重。完成自己的任务后，可按 :doc:`训练指标 </rst_source/reference/metrics>` 和 :doc:`日志记录 </rst_source/guides/logger>` 配置日志与视频。

--- a/docs/source-zh/rst_source/examples/embodied/so101.rst
+++ b/docs/source-zh/rst_source/examples/embodied/so101.rst
@@ -1,0 +1,347 @@
+SO101 配置与控制
+================
+
+.. figure:: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lerobot/SO101_Follower.webp
+   :align: center
+   :width: 70%
+
+   SO-101 follower 及其夹爪。图片来源：Hugging Face LeRobot。
+
+将 SO-101 follower 接入 RLinf，读取关节与夹爪状态，并通过机器人接口发送控制指令。先安装依赖、完成标定并在本机检查，再按应用需要加入相机或 leader。真实任务需参考任务扩展指南自行定义：现有 reach 环境和 mock SAC 配置仅用于集成检查，尚无经过验证的任务或训练方案。
+
+概览
+----
+
+SO101 通过 LeRobot 控制同一串行总线上的 5 个机械臂关节和夹爪。当前 MLP 与 SAC 配置使用 mock SDK 检查这条硬件接口调用链。
+
+.. grid:: 2 4 4 4
+   :gutter: 2
+
+   .. grid-item-card:: 模型
+      :text-align: center
+
+      MLP policy（集成测试）
+
+   .. grid-item-card:: 算法
+      :text-align: center
+
+      SAC（集成测试）
+
+   .. grid-item-card:: 任务
+      :text-align: center
+
+      自定义任务；reach 示例框架
+
+   .. grid-item-card:: 硬件
+      :text-align: center
+
+      SO-101 follower · USB 串口
+
+| **操作流程：** 安装依赖 → 配置电机 → 标定 → 测试 follower 与 leader → 新增任务。
+| **前置条件：** :doc:`安装 </rst_source/start/installation>` · SO-101 硬件 · Linux 控制主机 · USB 串口连接。
+
+任务
+~~~~
+
+现有示例用于连接硬件并将其接入环境。实际任务的定义与验证需要另外完成。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 40 35
+
+   * - 用途
+     - 入口
+     - 范围
+   * - 本机硬件操作
+     - ``SO101Robot`` 与 ``SO101Arm``
+     - 读取状态，控制 follower 的机械臂与夹爪。
+   * - 环境示例框架
+     - ``SO101ReachEnv-v1``；``env/so101_reach.yaml``
+     - 展示关节目标、复位和奖励的接入方式。
+   * - 集成测试
+     - ``so101_mock_sac_mlp_reach``
+     - 使用 mock SDK 运行 SAC，不代表物理任务性能。
+
+观测与动作
+~~~~~~~~~~
+
+RLinf 接口统一使用弧度。驱动负责在弧度与 LeRobot 的角度之间转换，并将夹爪的比例开度转换为 LeRobot 使用的 ``0..100`` 范围。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 23 77
+
+   * - 字段
+     - Contract
+   * - Observation
+     - ``arm.arm_joint_position``：5 个关节角，单位为弧度，顺序为 ``shoulder_pan``、``shoulder_lift``、``elbow_flex``、``wrist_flex``、``wrist_roll``；``arm.end_effector.state``：1 个夹爪开度，范围为 ``[0, 1]``。示例框架的一维状态包含 6 个数值，不提供 TCP 位姿、力或力矩观测。
+   * - Action
+     - ``arm.joint_position``：5 个绝对关节目标，单位为弧度；``arm.end_effector.target``：1 个夹爪开度，``0`` 为闭合，``1`` 为全开。示例框架的一维动作包含 6 个数值，关节目标不是增量。
+   * - Images
+     - 相机可选。示例框架对每张图像居中裁剪并缩放为 ``(128, 128, 3)``，存入 ``frames.wrist_1``、``frames.wrist_2`` 等 key。没有相机时不包含 ``frames``；mock MLP 不使用图像。
+   * - Reward
+     - 示例框架按关节距离计算稠密奖励，或按逐关节容差计算稀疏奖励。实际任务需要自行定义奖励与成功条件。
+   * - Prompt
+     - 示例框架返回 ``reach a joint configuration``。
+
+硬件配置
+--------
+
+先准备 follower 及其控制主机。leader 和相机均为可选设备，首次关节与夹爪检查不需要接入它们。
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - 组件
+     - 要求
+   * - Follower
+     - SO-101 机械臂及其夹爪、舵机控制板和套件指定的电源。
+   * - 控制主机
+     - 通过 USB 连接 follower 舵机控制板的 Linux 计算机。
+   * - Leader（可选）
+     - 独立的 SO-101 leader、电源和第二条 USB 串口连接。
+   * - 相机（可选）
+     - 连接到控制主机的 Intel RealSense 相机，用于图像检查。
+   * - GPU（可选）
+     - mock SAC 测试需要一张受支持的 GPU，本机硬件检查无需 GPU。
+
+未组装的机械臂请先参考 `LeRobot SO-101 指南 <https://huggingface.co/docs/lerobot/so101>`_ 中的零件清单与组装说明。完成接线前，需要逐个配置新电机；下方安装流程包含相应命令。
+
+安装
+----
+
+在控制主机上按下方自定义环境流程安装机器人依赖。后续检查均在同一仓库目录和已激活的环境中运行。
+
+机器人控制节点
+~~~~~~~~~~~~~~
+
+在连接机器人的主机上克隆 RLinf，然后安装对应环境。
+
+.. include:: _setup_common.rst
+   :end-before: 然后，使用
+
+在仓库根目录安装机器人依赖：
+
+.. code-block:: bash
+
+   # Mainland China users can add --use-mirror for faster downloads.
+   bash requirements/install.sh embodied --env so101
+   source .venv/bin/activate
+   export REPO_PATH="$PWD"
+
+安装脚本包含 LeRobot 及 Feetech 支持。后续命令均在此仓库目录中运行，并保持环境已激活。平台要求见 :doc:`安装 </rst_source/start/installation>`；接口示例和 mock MLP 测试均无需下载模型 checkpoint。
+
+查找串口并配置电机
+^^^^^^^^^^^^^^^^^^
+
+连接舵机控制板的 USB 线缆，以及套件指定的电源。先查找 follower 对应的串口：
+
+.. code-block:: bash
+
+   lerobot-find-port
+
+按提示拔下 USB 线缆，再重新接入。工具报告的设备路径就是后续使用的串口；以下示例假设为 ``/dev/ttyACM0``。检查设备权限和当前用户组：
+
+.. code-block:: bash
+
+   ls -l /dev/ttyACM0
+   id -nG
+
+在 Ubuntu 上，如果串口属于 ``dialout`` 组，运行程序的账号也需要加入该组。若尚未加入，执行 ``sudo usermod -aG dialout "$USER"``，退出登录并重新登录，然后回到仓库目录，重新激活 ``.venv``。USB 重新接入后，应再次确认串口路径。
+
+新电机或更换后的电机需要按上游指南的接线顺序，逐个设置 ID 与波特率；此步骤通常只需执行一次：
+
+.. code-block:: bash
+
+   lerobot-setup-motors \
+     --robot.type=so101_follower \
+     --robot.port=/dev/ttyACM0
+
+每次仅将提示中指定的电机连接到控制板。工具设置该电机的 ID 和波特率后，才会提示连接下一个。6 个电机全部配置完成后，按指南完成组装并恢复串联接线。已配置好的机械臂可跳过电机配置，但仍需使用 RLinf 将采用的 ID 完成标定。
+
+标定 Follower
+^^^^^^^^^^^^^
+
+电机配置与组装完成后，在终端中标定 follower，再让 RLinf 打开串行总线：
+
+.. code-block:: bash
+
+   lerobot-calibrate \
+     --robot.type=so101_follower \
+     --robot.port=/dev/ttyACM0 \
+     --robot.id=rlinf_follower
+
+将串口替换为实际设备。按照指南将关节移到中间位置并确认提示，再按要求逐个移动关节，覆盖其运动范围。工具会报告保存的标定文件；请保留在运行 RLinf 的账号下，并使用相同的 ``calibration_id="rlinf_follower"``。follower 不能使用 leader 的标定文件。
+
+.. warning::
+
+   RLinf worker 不会交互式标定 follower。标定缺失或与硬件不一致时，连接会失败。启动 worker 前，先用运行机械臂的账号完成标定。
+
+运行
+----
+
+follower 标定完成后，可检查关节与夹爪接口。``SO101Arm`` 声明记录串口和标定参数，但不打开硬件；``SO101Robot`` 将机械臂命名为 ``arm``，夹爪位于 ``arm.end_effector``，两者共用连接。
+
+测试配置
+~~~~~~~~
+
+先在无硬件模式下演练现有交互式检查工具：
+
+.. code-block:: bash
+
+   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env --mock
+
+在提示符后依次输入 ``where``、``up``、``where`` 和 ``quit``。mock 使用假舵机总线，但运行实际环境与驱动。此工具通过 scheduler worker 访问机械臂，可能启动本机 Ray 实例；这项检查无需 GPU。``CAMERA_SERIALS=''`` 明确关闭相机发现。
+
+.. warning::
+
+   在硬件模式下，环境构造函数会将机械臂移至折叠姿态，关节角为 ``[0, -99, 95, 65, 0]`` 度。启动前请清空这条运动路径。``--no-reset`` 只跳过后续的一次复位，无法跳过构造时的运动。若需连接时不发送复位目标，请使用下方的 Python 接口示例。
+
+确认 follower 已标定，且初始折叠动作的路径无遮挡后，运行：
+
+.. code-block:: bash
+
+   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env \
+     --port /dev/ttyACM0 --id rlinf_follower --step 2
+
+逐条输入以下指令，每次运动完成后再继续：
+
+.. code-block:: text
+
+   where
+   up
+   down
+   open
+   close
+   quit
+
+``up`` 和 ``down`` 分别将肩关节角度增加或减少 2 度，并非让末端沿竖直方向移动。每次关节运动后会打印反馈；``open`` 与 ``close`` 用于测试夹爪。``quit`` 关闭环境及其机械臂 worker。输入 ``help`` 可查看其他关节方向。
+
+使用机器人接口
+~~~~~~~~~~~~~~
+
+若希望在本机直接连接，不复位、不启动 scheduler worker，可在同一环境中运行以下 Python 示例。``connect()`` 打开已标定的机械臂，``get_observation()`` 返回嵌套状态。示例读取当前关节位置与夹爪开度，再将这些数值作为目标发送回机器人。
+
+.. code-block:: python
+
+   from rlinf.robotics import SO101Robot
+   from rlinf.robotics.parts.arms.so101 import SO101Arm
+   from rlinf.utils.logging import get_logger
+
+   logger = get_logger()
+   robot = SO101Robot(
+       arm=SO101Arm.declare(
+           "/dev/ttyACM0", calibration_id="rlinf_follower", max_relative_target=5
+       )
+   )
+   robot.connect()
+   try:
+       reading = robot.get_observation()["arm"]
+       logger.info("Joint positions: %s", reading["arm_joint_position"])
+       robot.send_action(
+           {
+               "arm": {
+                   "joint_position": reading["arm_joint_position"],
+                   "end_effector": {"target": reading["end_effector"]["state"]},
+               }
+           }
+       )
+   finally:
+       robot.disconnect()
+
+``send_action()`` 分发嵌套目标，返回已分发动作值的字典；如需测量执行结果，应再次读取观测。``disconnect()`` 释放机械臂及其与夹爪共用的连接。不指定 ``node_rank`` 时，示例在本机进程中运行，无需 Ray 集群。
+
+可选的 ``max_relative_target`` 按角度传给 LeRobot，``5`` 表示每个关节目标相对当前位置的变化不超过 5 度。RLinf 动作仍使用弧度。该参数默认为 ``None``，表示不启用此限制。
+
+加入相机
+~~~~~~~~
+
+如果需要同时读取图像和机械臂状态，可将上例的机器人声明替换为以下组合。``CameraInfo`` 描述物理相机，``Camera.declare()`` 返回按名称组织、尚未连接的相机零部件。机器人安装脚本在 x86 Linux 上包含 RealSense 支持。
+
+通过 ``Camera.backend("realsense")`` 选择相机驱动，再调用 ``discover()`` 列出已连接相机的序列号：
+
+.. code-block:: python
+
+   from rlinf.robotics import Camera
+
+   logger.info("RealSense serials: %s", Camera.backend("realsense").discover())
+
+将下例中的 ``CAMERA_SERIAL`` 替换为列出的一个序列号，再连接并读取图像：
+
+.. code-block:: python
+
+   from rlinf.robotics import Camera, CameraInfo
+
+   robot = SO101Robot(
+       arm=SO101Arm.declare(
+           "/dev/ttyACM0", calibration_id="rlinf_follower", max_relative_target=5
+       ),
+       **Camera.declare(
+           {"wrist_1": CameraInfo(name="wrist_1", serial_number="CAMERA_SERIAL")}
+       ),
+   )
+   robot.connect()
+   try:
+       image = robot.get_observation()["wrist_1"]["frame"]
+       logger.info("Camera image shape: %s", image.shape)
+   finally:
+       robot.disconnect()
+
+默认相机 backend 为 RealSense。接口按相机配置的分辨率返回图像，由环境准备 policy 所需的输入。机器人统一打开与关闭两条连接；其他组合方式见 :doc:`机器人接口 </rst_source/concepts/robotics>`。
+
+使用 Leader 机械臂
+~~~~~~~~~~~~~~~~~~
+
+需要操作员输入时，为 SO-101 leader 单独配置串口。按 follower 的方法查找设备，以下示例使用 ``/dev/ttyACM1``。新电机仍需按提示逐个接线并完成配置：
+
+.. code-block:: bash
+
+   lerobot-setup-motors \
+     --teleop.type=so101_leader \
+     --teleop.port=/dev/ttyACM1
+
+leader 组装完成后，通过以下终端命令标定并检查输入。此命令只读取 leader，不驱动 follower：
+
+.. code-block:: bash
+
+   python -m rlinf.robotics.parts.teleop.so101_leader \
+     --port /dev/ttyACM1 --id rlinf_leader --calibrate
+
+按提示完成标定，检查输出的关节与夹爪读数，然后按 Ctrl+C 关闭连接。环境的 ``teleop`` 可选择 ``so101_leader``，通过 ``port`` 和 ``calibration_id`` 配置设备。leader 生成与 follower 一致的 5 个关节目标和连续夹爪开度。设备尚未配置时保持 ``teleop: none``；遥操作接入流程见 :doc:`新增真机任务 </rst_source/extending/new_task>`。
+
+关闭 leader 检查后，向 follower 测试工具传入两台机械臂的串口与标定 ID：
+
+.. code-block:: bash
+
+   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env \
+     --port /dev/ttyACM0 --id rlinf_follower \
+     --leader /dev/ttyACM1 --leader-id rlinf_leader
+
+follower 启动时仍会按前述流程折叠。将 leader 移至接近该姿态的位置，输入 ``teleop``，小幅移动并检查 follower 是否跟随。发送的是绝对关节目标。按 Ctrl+C 停止跟随并返回提示符，再输入 ``quit`` 释放 follower。
+
+无硬件集成检查
+~~~~~~~~~~~~~~
+
+在配有一张受支持 GPU 的主机上，可运行现有 mock 配置，检查 scheduler、环境、rollout 与 actor 的完整调用流程：
+
+.. code-block:: bash
+
+   bash tests/e2e_tests/embodied/run.sh so101_mock_sac_mlp_reach \
+     runner.logger.log_path="$REPO_PATH/logs/so101_mock"
+
+配置名包含 ``mock``，启动脚本因此启用 mock SDK。测试使用实际环境实现，设置 ``is_dummy: False``，接入两台假相机，并采用 ``action_dim: 6``、``obs_dim: 6`` 的 MLP。这只是短时软件集成检查，无需物理标定，也不验证任务效果。
+
+新增真机任务
+------------
+
+硬件检查通过后，参考 :doc:`新增真机任务 </rst_source/extending/new_task>` 定义任务观测、复位流程、奖励和成功条件。SO101 当前具备硬件接口与 reach 示例框架，尚无经过验证的真机任务方案。
+
+从 ``rlinf/envs/real/so101/base.py`` 中的 ``SO101Env`` 与 ``SO101EnvConfig`` 开始。相邻的 ``reach.py`` 展示了如何从 ``override_cfg`` 构造任务配置并传给基类构造函数；指南中的 ``CONFIG_CLS`` 简写仅适用于 Franka。将新任务类加入 ``rlinf/envs/real/so101/__init__.py`` 的 ``TASKS``，再复制 ``examples/embodiment/config/env/so101_reach.yaml``，通过 ``init_params.id`` 选择新注册的 Gymnasium ID。若任务需要笛卡尔空间状态，还需加入正运动学或其他位姿观测来源。
+
+硬件参数放在集群的 ``hardware`` 配置中，设置 ``type: SO101``：``serial_port`` 指定 follower，``calibration_id`` 选择其标定，``camera_serials: []`` 表示不使用相机。任务参数放在 ``env.train.override_cfg`` 中。现有 mock 配置展示了如何将 ``env`` 放置到携带机器人硬件的 node group。控制器位于另一台主机时，参考 :doc:`多节点训练 </rst_source/guides/multi_node>` 和 :doc:`机器人架构 </rst_source/concepts/robotics_architecture>`。
+
+可视化与结果
+------------
+
+mock 运行将 TensorBoard 日志写入 ``logs/so101_mock``，用于检查软件执行流程，不代表物理任务成功率。此示例尚无经过验证的任务结果或预训练任务权重。完成自己的任务后，可按 :doc:`训练指标 </rst_source/reference/metrics>` 和 :doc:`日志记录 </rst_source/guides/logger>` 配置日志与视频。

--- a/docs/source-zh/rst_source/examples/embodied/so101.rst
+++ b/docs/source-zh/rst_source/examples/embodied/so101.rst
@@ -1,93 +1,23 @@
 SO101 配置与控制
 ================
 
+本文介绍如何配置 SO101 机械臂，并运行 RLinf 硬件测试脚本，读取反馈、检查关节运动与夹爪开合。
+
 .. figure:: https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lerobot/SO101_Follower.webp
    :align: center
    :width: 70%
 
    SO-101 follower 及其夹爪。图片来源：Hugging Face LeRobot。
 
-将 SO-101 follower 接入 RLinf，读取关节与夹爪状态，并通过机器人接口发送控制指令。先安装依赖、完成标定并在本机检查，再按应用需要加入相机或 leader。真实任务需参考任务扩展指南自行定义：现有 reach 环境和 mock SAC 配置仅用于集成检查，尚无经过验证的任务或训练方案。
-
 概览
 ----
 
-SO101 通过 LeRobot 控制同一串行总线上的 5 个机械臂关节和夹爪。当前 MLP 与 SAC 配置使用 mock SDK 检查这条硬件接口调用链。
-
-.. grid:: 2 4 4 4
-   :gutter: 2
-
-   .. grid-item-card:: 模型
-      :text-align: center
-
-      MLP policy（集成测试）
-
-   .. grid-item-card:: 算法
-      :text-align: center
-
-      SAC（集成测试）
-
-   .. grid-item-card:: 任务
-      :text-align: center
-
-      自定义任务；reach 示例框架
-
-   .. grid-item-card:: 硬件
-      :text-align: center
-
-      SO-101 follower · USB 串口
-
-| **操作流程：** 安装依赖 → 配置电机 → 标定 → 测试 follower 与 leader → 新增任务。
-| **前置条件：** :doc:`安装 </rst_source/start/installation>` · SO-101 硬件 · Linux 控制主机 · USB 串口连接。
-
-任务
-~~~~
-
-现有示例用于连接硬件并将其接入环境。实际任务的定义与验证需要另外完成。
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 40 35
-
-   * - 用途
-     - 入口
-     - 范围
-   * - 本机硬件操作
-     - ``SO101Robot`` 与 ``SO101Arm``
-     - 读取状态，控制 follower 的机械臂与夹爪。
-   * - 环境示例框架
-     - ``SO101ReachEnv-v1``；``env/so101_reach.yaml``
-     - 展示关节目标、复位和奖励的接入方式。
-   * - 集成测试
-     - ``so101_mock_sac_mlp_reach``
-     - 使用 mock SDK 运行 SAC，不代表物理任务性能。
-
-观测与动作
-~~~~~~~~~~
-
-RLinf 接口统一使用弧度。驱动负责在弧度与 LeRobot 的角度之间转换，并将夹爪的比例开度转换为 LeRobot 使用的 ``0..100`` 范围。
-
-.. list-table::
-   :header-rows: 1
-   :widths: 23 77
-
-   * - 字段
-     - Contract
-   * - Observation
-     - ``arm.arm_joint_position``：5 个关节角，单位为弧度，顺序为 ``shoulder_pan``、``shoulder_lift``、``elbow_flex``、``wrist_flex``、``wrist_roll``；``arm.end_effector.state``：1 个夹爪开度，范围为 ``[0, 1]``。示例框架的一维状态包含 6 个数值，不提供 TCP 位姿、力或力矩观测。
-   * - Action
-     - ``arm.joint_position``：5 个绝对关节目标，单位为弧度；``arm.end_effector.target``：1 个夹爪开度，``0`` 为闭合，``1`` 为全开。示例框架的一维动作包含 6 个数值，关节目标不是增量。
-   * - Images
-     - 相机可选。示例框架对每张图像居中裁剪并缩放为 ``(128, 128, 3)``，存入 ``frames.wrist_1``、``frames.wrist_2`` 等 key。没有相机时不包含 ``frames``；mock MLP 不使用图像。
-   * - Reward
-     - 示例框架按关节距离计算稠密奖励，或按逐关节容差计算稀疏奖励。实际任务需要自行定义奖励与成功条件。
-   * - Prompt
-     - 示例框架返回 ``reach a joint configuration``。
+测试在连接机械臂的 Linux 主机上运行，无需 GPU 或模型 checkpoint。RLinf 目前尚未提供适用于 SO101 的真机任务或训练流程；本指南仅介绍硬件检查。
 
 硬件配置
 --------
 
-先准备 follower 及其控制主机。leader 和相机均为可选设备，首次关节与夹爪检查不需要接入它们。
+安装软件前，先准备机械臂及其控制主机。
 
 .. list-table::
    :header-rows: 1
@@ -99,12 +29,6 @@ RLinf 接口统一使用弧度。驱动负责在弧度与 LeRobot 的角度之�
      - SO-101 机械臂及其夹爪、舵机控制板和套件指定的电源。
    * - 控制主机
      - 通过 USB 连接 follower 舵机控制板的 Linux 计算机。
-   * - Leader（可选）
-     - 独立的 SO-101 leader、电源和第二条 USB 串口连接。
-   * - 相机（可选）
-     - 连接到控制主机的 Intel RealSense 相机，用于图像检查。
-   * - GPU（可选）
-     - mock SAC 测试需要一张受支持的 GPU，本机硬件检查无需 GPU。
 
 未组装的机械臂请先参考 `LeRobot SO-101 指南 <https://huggingface.co/docs/lerobot/so101>`_ 中的零件清单与组装说明。完成接线前，需要逐个配置新电机；下方安装流程包含相应命令。
 
@@ -130,7 +54,7 @@ RLinf 接口统一使用弧度。驱动负责在弧度与 LeRobot 的角度之�
    source .venv/bin/activate
    export REPO_PATH="$PWD"
 
-安装脚本包含 LeRobot 及 Feetech 支持。后续命令均在此仓库目录中运行，并保持环境已激活。平台要求见 :doc:`安装 </rst_source/start/installation>`；接口示例和 mock MLP 测试均无需下载模型 checkpoint。
+安装脚本包含 LeRobot 及 Feetech 支持。后续命令均在此仓库目录中运行，并保持环境已激活。平台要求见 :doc:`安装 </rst_source/start/installation>`。
 
 查找串口并配置电机
 ^^^^^^^^^^^^^^^^^^
@@ -172,7 +96,7 @@ RLinf 接口统一使用弧度。驱动负责在弧度与 LeRobot 的角度之�
      --robot.port=/dev/ttyACM0 \
      --robot.id=rlinf_follower
 
-将串口替换为实际设备。按照指南将关节移到中间位置并确认提示，再按要求逐个移动关节，覆盖其运动范围。工具会报告保存的标定文件；请保留在运行 RLinf 的账号下，并使用相同的 ``calibration_id="rlinf_follower"``。follower 不能使用 leader 的标定文件。
+将串口替换为实际设备。按照指南将关节移到中间位置并确认提示，再按要求逐个移动关节，覆盖其运动范围。工具会报告保存的标定文件；请保留在运行 RLinf 的账号下，并使用相同的 ``--id rlinf_follower``。follower 不能使用 leader 的标定文件。
 
 .. warning::
 
@@ -181,22 +105,11 @@ RLinf 接口统一使用弧度。驱动负责在弧度与 LeRobot 的角度之�
 运行
 ----
 
-follower 标定完成后，可检查关节与夹爪接口。``SO101Arm`` 声明记录串口和标定参数，但不打开硬件；``SO101Robot`` 将机械臂命名为 ``arm``，夹爪位于 ``arm.end_effector``，两者共用连接。
-
-测试配置
-~~~~~~~~
-
-先在无硬件模式下演练现有交互式检查工具：
-
-.. code-block:: bash
-
-   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env --mock
-
-在提示符后依次输入 ``where``、``up``、``where`` 和 ``quit``。mock 使用假舵机总线，但运行实际环境与驱动。此工具通过 scheduler worker 访问机械臂，可能启动本机 Ray 实例；这项检查无需 GPU。``CAMERA_SERIALS=''`` 明确关闭相机发现。
+follower 标定完成后，使用交互式测试检查关节与夹爪。脚本可能启动本机 Ray 实例，用于与机械臂通信。
 
 .. warning::
 
-   在硬件模式下，环境构造函数会将机械臂移至折叠姿态，关节角为 ``[0, -99, 95, 65, 0]`` 度。启动前请清空这条运动路径。``--no-reset`` 只跳过后续的一次复位，无法跳过构造时的运动。若需连接时不发送复位目标，请使用下方的 Python 接口示例。
+   在硬件模式下，环境构造函数会将机械臂移至折叠姿态，关节角为 ``[0, -99, 95, 65, 0]`` 度。启动前请清空这条运动路径。``--no-reset`` 只跳过后续的一次复位，无法跳过构造时的运动。
 
 确认 follower 已标定，且初始折叠动作的路径无遮挡后，运行：
 
@@ -205,7 +118,7 @@ follower 标定完成后，可检查关节与夹爪接口。``SO101Arm`` 声明�
    CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env \
      --port /dev/ttyACM0 --id rlinf_follower --step 2
 
-逐条输入以下指令，每次运动完成后再继续：
+将串口替换为实际设备，ID 使用标定时的值。``CAMERA_SERIALS=''`` 关闭相机发现，使测试只使用机械臂。逐条输入以下指令，每次运动完成后再继续：
 
 .. code-block:: text
 
@@ -218,130 +131,9 @@ follower 标定完成后，可检查关节与夹爪接口。``SO101Arm`` 声明�
 
 ``up`` 和 ``down`` 分别将肩关节角度增加或减少 2 度，并非让末端沿竖直方向移动。每次关节运动后会打印反馈；``open`` 与 ``close`` 用于测试夹爪。``quit`` 关闭环境及其机械臂 worker。输入 ``help`` 可查看其他关节方向。
 
-使用机器人接口
-~~~~~~~~~~~~~~
-
-若希望在本机直接连接，不复位、不启动 scheduler worker，可在同一环境中运行以下 Python 示例。``connect()`` 打开已标定的机械臂，``get_observation()`` 返回嵌套状态。示例读取当前关节位置与夹爪开度，再将这些数值作为目标发送回机器人。
-
-.. code-block:: python
-
-   from rlinf.robotics import SO101Robot
-   from rlinf.robotics.parts.arms.so101 import SO101Arm
-   from rlinf.utils.logging import get_logger
-
-   logger = get_logger()
-   robot = SO101Robot(
-       arm=SO101Arm.declare(
-           "/dev/ttyACM0", calibration_id="rlinf_follower", max_relative_target=5
-       )
-   )
-   robot.connect()
-   try:
-       reading = robot.get_observation()["arm"]
-       logger.info("Joint positions: %s", reading["arm_joint_position"])
-       robot.send_action(
-           {
-               "arm": {
-                   "joint_position": reading["arm_joint_position"],
-                   "end_effector": {"target": reading["end_effector"]["state"]},
-               }
-           }
-       )
-   finally:
-       robot.disconnect()
-
-``send_action()`` 分发嵌套目标，返回已分发动作值的字典；如需测量执行结果，应再次读取观测。``disconnect()`` 释放机械臂及其与夹爪共用的连接。不指定 ``node_rank`` 时，示例在本机进程中运行，无需 Ray 集群。
-
-可选的 ``max_relative_target`` 按角度传给 LeRobot，``5`` 表示每个关节目标相对当前位置的变化不超过 5 度。RLinf 动作仍使用弧度。该参数默认为 ``None``，表示不启用此限制。
-
-加入相机
-~~~~~~~~
-
-如果需要同时读取图像和机械臂状态，可将上例的机器人声明替换为以下组合。``CameraInfo`` 描述物理相机，``Camera.declare()`` 返回按名称组织、尚未连接的相机零部件。机器人安装脚本在 x86 Linux 上包含 RealSense 支持。
-
-通过 ``Camera.backend("realsense")`` 选择相机驱动，再调用 ``discover()`` 列出已连接相机的序列号：
-
-.. code-block:: python
-
-   from rlinf.robotics import Camera
-
-   logger.info("RealSense serials: %s", Camera.backend("realsense").discover())
-
-将下例中的 ``CAMERA_SERIAL`` 替换为列出的一个序列号，再连接并读取图像：
-
-.. code-block:: python
-
-   from rlinf.robotics import Camera, CameraInfo
-
-   robot = SO101Robot(
-       arm=SO101Arm.declare(
-           "/dev/ttyACM0", calibration_id="rlinf_follower", max_relative_target=5
-       ),
-       **Camera.declare(
-           {"wrist_1": CameraInfo(name="wrist_1", serial_number="CAMERA_SERIAL")}
-       ),
-   )
-   robot.connect()
-   try:
-       image = robot.get_observation()["wrist_1"]["frame"]
-       logger.info("Camera image shape: %s", image.shape)
-   finally:
-       robot.disconnect()
-
-默认相机 backend 为 RealSense。接口按相机配置的分辨率返回图像，由环境准备 policy 所需的输入。机器人统一打开与关闭两条连接；其他组合方式见 :doc:`机器人接口 </rst_source/concepts/robotics>`。
-
-使用 Leader 机械臂
-~~~~~~~~~~~~~~~~~~
-
-需要操作员输入时，为 SO-101 leader 单独配置串口。按 follower 的方法查找设备，以下示例使用 ``/dev/ttyACM1``。新电机仍需按提示逐个接线并完成配置：
-
-.. code-block:: bash
-
-   lerobot-setup-motors \
-     --teleop.type=so101_leader \
-     --teleop.port=/dev/ttyACM1
-
-leader 组装完成后，通过以下终端命令标定并检查输入。此命令只读取 leader，不驱动 follower：
-
-.. code-block:: bash
-
-   python -m rlinf.robotics.parts.teleop.so101_leader \
-     --port /dev/ttyACM1 --id rlinf_leader --calibrate
-
-按提示完成标定，检查输出的关节与夹爪读数，然后按 Ctrl+C 关闭连接。环境的 ``teleop`` 可选择 ``so101_leader``，通过 ``port`` 和 ``calibration_id`` 配置设备。leader 生成与 follower 一致的 5 个关节目标和连续夹爪开度。设备尚未配置时保持 ``teleop: none``；遥操作接入流程见 :doc:`新增真机任务 </rst_source/extending/new_task>`。
-
-关闭 leader 检查后，向 follower 测试工具传入两台机械臂的串口与标定 ID：
-
-.. code-block:: bash
-
-   CAMERA_SERIALS='' python -m toolkits.realworld_check.test_so101_env \
-     --port /dev/ttyACM0 --id rlinf_follower \
-     --leader /dev/ttyACM1 --leader-id rlinf_leader
-
-follower 启动时仍会按前述流程折叠。将 leader 移至接近该姿态的位置，输入 ``teleop``，小幅移动并检查 follower 是否跟随。发送的是绝对关节目标。按 Ctrl+C 停止跟随并返回提示符，再输入 ``quit`` 释放 follower。
-
-无硬件集成检查
-~~~~~~~~~~~~~~
-
-在配有一张受支持 GPU 的主机上，可运行现有 mock 配置，检查 scheduler、环境、rollout 与 actor 的完整调用流程：
-
-.. code-block:: bash
-
-   bash tests/e2e_tests/embodied/run.sh so101_mock_sac_mlp_reach \
-     runner.logger.log_path="$REPO_PATH/logs/so101_mock"
-
-配置名包含 ``mock``，启动脚本因此启用 mock SDK。测试使用实际环境实现，设置 ``is_dummy: False``，接入两台假相机，并采用 ``action_dim: 6``、``obs_dim: 6`` 的 MLP。这只是短时软件集成检查，无需物理标定，也不验证任务效果。
+在自己的程序中控制机械臂或接入相机，请参考 :doc:`机器人接口 </rst_source/concepts/robotics>`。
 
 新增真机任务
 ------------
 
-硬件检查通过后，参考 :doc:`新增真机任务 </rst_source/extending/new_task>` 定义任务观测、复位流程、奖励和成功条件。SO101 当前具备硬件接口与 reach 示例框架，尚无经过验证的真机任务方案。
-
-从 ``rlinf/envs/real/so101/base.py`` 中的 ``SO101Env`` 与 ``SO101EnvConfig`` 开始。相邻的 ``reach.py`` 展示了如何从 ``override_cfg`` 构造任务配置并传给基类构造函数；指南中的 ``CONFIG_CLS`` 简写仅适用于 Franka。将新任务类加入 ``rlinf/envs/real/so101/__init__.py`` 的 ``TASKS``，再复制 ``examples/embodiment/config/env/so101_reach.yaml``，通过 ``init_params.id`` 选择新注册的 Gymnasium ID。若任务需要笛卡尔空间状态，还需加入正运动学或其他位姿观测来源。
-
-硬件参数放在集群的 ``hardware`` 配置中，设置 ``type: SO101``：``serial_port`` 指定 follower，``calibration_id`` 选择其标定，``camera_serials: []`` 表示不使用相机。任务参数放在 ``env.train.override_cfg`` 中。现有 mock 配置展示了如何将 ``env`` 放置到携带机器人硬件的 node group。控制器位于另一台主机时，参考 :doc:`多节点训练 </rst_source/guides/multi_node>` 和 :doc:`机器人架构 </rst_source/concepts/robotics_architecture>`。
-
-可视化与结果
-------------
-
-mock 运行将 TensorBoard 日志写入 ``logs/so101_mock``，用于检查软件执行流程，不代表物理任务成功率。此示例尚无经过验证的任务结果或预训练任务权重。完成自己的任务后，可按 :doc:`训练指标 </rst_source/reference/metrics>` 和 :doc:`日志记录 </rst_source/guides/logger>` 配置日志与视频。
+硬件检查通过后，参考 :doc:`新增真机任务 </rst_source/extending/new_task>` 定义任务的复位流程、观测、动作、奖励和成功条件。开始训练前，需要先实现可运行的真机任务。

--- a/docs/source-zh/rst_source/examples/real_world_index.rst
+++ b/docs/source-zh/rst_source/examples/real_world_index.rst
@@ -1,7 +1,7 @@
 真实机器人强化学习
 ========================================
 
-当你的出发点是真实机器人硬件时，请使用本节。如果你使用 Franka 机械臂或 Franka-based rig，请从 Franka 开始；GimArm、XSquare Turtle2 和 Dexmal DOS-W1 请进入对应机器人页面。
+按机器人硬件选择配置与使用指南。Franka 机械臂及其组合设备请从 Franka 页面开始；GimArm、XSquare Turtle2、Dexmal DOS-W1、AgileX Piper 和 SO101 请进入对应页面。
 
 每个章节都给出遥操作、数据采集、Sim-to-Real 迁移、部署或在线 RL 所需的配置路径。
 
@@ -62,6 +62,26 @@
 
    </div>
 
+Piper 与 SO101 配置
+--------------------------------
+
+通过以下指南完成机械臂连接与测试，再定义自己的任务。
+
+.. grid:: 1 2 2 2
+   :gutter: 2
+
+   .. grid-item-card:: AgileX Piper
+      :link: embodied/piper
+      :link-type: doc
+
+      配置 CAN，检查 Piper 关节、夹爪及相机组合。
+
+   .. grid-item-card:: SO101
+      :link: embodied/so101
+      :link-type: doc
+
+      配置电机、标定 SO-101，并检查 follower 与 leader 控制。
+
 .. toctree::
    :hidden:
    :maxdepth: 3
@@ -71,3 +91,5 @@
    GimArm <embodied/gim_arm>
    XSquare Turtle2 <embodied/xsquare_turtle2>
    DOS-W1 <embodied/dosw1>
+   Piper <embodied/piper>
+   SO101 <embodied/so101>

--- a/docs/source-zh/rst_source/examples/real_world_index.rst
+++ b/docs/source-zh/rst_source/examples/real_world_index.rst
@@ -3,7 +3,7 @@
 
 按机器人硬件选择配置与使用指南。Franka 机械臂及其组合设备请从 Franka 页面开始；GimArm、XSquare Turtle2、Dexmal DOS-W1、AgileX Piper 和 SO101 请进入对应页面。
 
-每个章节都给出遥操作、数据采集、Sim-to-Real 迁移、部署或在线 RL 所需的配置路径。
+根据硬件检查、遥操作、数据采集、Sim-to-Real 迁移、部署或在线 RL 的需求，选择相应指南。
 
 .. raw:: html
 
@@ -65,7 +65,7 @@
 Piper 与 SO101 配置
 --------------------------------
 
-通过以下指南完成机械臂连接与测试，再定义自己的任务。
+通过以下指南连接机械臂并运行硬件测试脚本。Piper 和 SO101 目前尚未提供真机任务或训练流程。
 
 .. grid:: 1 2 2 2
    :gutter: 2
@@ -74,13 +74,13 @@ Piper 与 SO101 配置
       :link: embodied/piper
       :link-type: doc
 
-      配置 CAN，检查 Piper 关节、夹爪及相机组合。
+      配置 CAN，运行 Piper 关节与夹爪测试脚本。
 
    .. grid-item-card:: SO101
       :link: embodied/so101
       :link-type: doc
 
-      配置电机、标定 SO-101，并检查 follower 与 leader 控制。
+      配置电机、标定 SO-101，并运行关节与夹爪测试脚本。
 
 .. toctree::
    :hidden:

--- a/tests/unit_tests/test_robotics.py
+++ b/tests/unit_tests/test_robotics.py
@@ -5087,6 +5087,90 @@ def test_piper_gripper_rides_the_arm_connection():
         arm.disconnect()
 
 
+def test_piper_controller_commands_use_measured_joints_after_clipping():
+    """An unreachable target must not accumulate into the next relative move."""
+    from robot_mocks import mocked_sdks
+
+    from rlinf.robotics import PiperRobot
+    from rlinf.robotics.parts.arms.piper import PiperArm
+    from toolkits.realworld_check.test_piper_controller import drive
+
+    with mocked_sdks():
+        robot = PiperRobot(arm=PiperArm.declare("can0"))
+        robot.connect()
+        try:
+            limit = PiperArm.JOINT_LIMITS_UPPER[0]
+            robot.send_action({"arm": {"joint_position": [limit, 0, 0, 0, 0, 0]}})
+            drive(robot, ["joint 1 5", "joint 1 -2", "grip 0.5", "quit"])
+            reading = robot.get_observation()["arm"]
+            assert reading["arm_joint_position"][0] == pytest.approx(
+                limit - np.deg2rad(2)
+            )
+            assert reading["end_effector"]["state"] == pytest.approx([0.5])
+        finally:
+            robot.disconnect()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "joint 0 2",
+        "joint 7 2",
+        "joint 1 6",
+        "joint 1 nan",
+        "joint 1 inf",
+        "joint one 2",
+        "grip -0.1",
+        "grip 1.1",
+        "grip nan",
+        "where extra",
+    ],
+)
+def test_piper_controller_rejects_invalid_commands_without_moving(command, caplog):
+    from robot_mocks import mocked_sdks
+
+    from rlinf.robotics import PiperRobot
+    from rlinf.robotics.parts.arms.piper import PiperArm
+    from toolkits.realworld_check.test_piper_controller import drive
+
+    with mocked_sdks():
+        robot = PiperRobot(arm=PiperArm.declare("can0"))
+        robot.connect()
+        try:
+            before = robot.get_observation()["arm"]
+            drive(robot, [command])
+            after = robot.get_observation()["arm"]
+            np.testing.assert_array_equal(
+                after["arm_joint_position"], before["arm_joint_position"]
+            )
+            np.testing.assert_array_equal(
+                after["end_effector"]["state"], before["end_effector"]["state"]
+            )
+            assert any(record.levelname == "WARNING" for record in caplog.records)
+        finally:
+            robot.disconnect()
+
+
+def test_piper_controller_operates_without_a_gripper(caplog):
+    from robot_mocks import mocked_sdks
+
+    from rlinf.robotics import PiperRobot
+    from rlinf.robotics.parts.arms.piper import PiperArm
+    from toolkits.realworld_check.test_piper_controller import drive
+
+    with mocked_sdks():
+        robot = PiperRobot(arm=PiperArm.declare("can0", with_gripper=False))
+        robot.connect()
+        try:
+            drive(robot, ["where", "grip 0.5", "joint 1 2", "quit", "joint 1 2"])
+            reading = robot.get_observation()["arm"]
+            assert "end_effector" not in reading
+            assert reading["arm_joint_position"][0] == pytest.approx(np.deg2rad(2))
+            assert "without a gripper" in caplog.text
+        finally:
+            robot.disconnect()
+
+
 def test_piper_without_a_gripper_exports_no_end_effector():
     from robot_mocks import mocked_sdks
 

--- a/toolkits/realworld_check/test_piper_controller.py
+++ b/toolkits/realworld_check/test_piper_controller.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Read and command a local Piper through the robotics interface.
+
+Bring the CAN interface up at 1 Mbit/s before connecting. Start with a state
+read, then omit --read-only for an interactive session::
+
+    python -m toolkits.realworld_check.test_piper_controller --channel can0 --read-only
+    python -m toolkits.realworld_check.test_piper_controller --mock
+
+Connection enables the motors but sends no position target or reset. Motion
+commands use measured joint positions, so a previous clipped target cannot
+accumulate into the next move. Disconnect leaves the motors holding position.
+"""
+
+import argparse
+import contextlib
+import signal
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+import numpy as np
+
+from rlinf.robotics import PiperRobot
+from rlinf.robotics.parts.arms.piper import PiperArm
+from rlinf.utils.logging import get_logger
+
+logger = get_logger()
+
+HELP = """Commands:
+  where             read measured joints, tool pose, and gripper
+  joint N DEGREES   move joint 1..6 by -5..5 degrees from its measured position
+  grip FRACTION    set gripper opening: 0 closed, 1 open
+  help              show commands
+  quit              disconnect (also EOF or Ctrl-C)
+"""
+
+
+def drive(robot: PiperRobot, commands: Iterable[str]) -> None:
+    """Read commands for a connected robot, reporting invalid input.
+
+    Args:
+        robot: Connected local Piper robot, with an arm named ``arm``.
+        commands: Terminal input or a finite sequence of commands.
+    """
+    arm = robot.child("arm", PiperArm)
+    for command in commands:
+        words = command.lower().split()
+        if not words:
+            continue
+        if words == ["quit"]:
+            return
+        if words == ["help"]:
+            logger.info(HELP)
+            continue
+        reading = robot.get_observation()["arm"]
+        if words == ["where"]:
+            logger.info(
+                "Measured joints (deg): %s", np.rad2deg(reading["arm_joint_position"])
+            )
+            logger.info("Tool pose (m, xyzw): %s", reading["tcp_pose"])
+            if "end_effector" in reading:
+                logger.info("Gripper opening: %s", reading["end_effector"]["state"])
+            continue
+        try:
+            if len(words) == 3 and words[0] == "joint":
+                joint, degrees = int(words[1]), float(words[2])
+                if not 1 <= joint <= 6 or not np.isfinite(degrees) or abs(degrees) > 5:
+                    raise ValueError(
+                        "Use joint 1..6 and an increment in [-5, 5] degrees."
+                    )
+                target = np.array(reading["arm_joint_position"], dtype=float)
+                target[joint - 1] += np.deg2rad(degrees)
+                action = {"joint_position": target}
+            elif len(words) == 2 and words[0] == "grip":
+                opening = float(words[1])
+                if not np.isfinite(opening) or not 0 <= opening <= 1:
+                    raise ValueError("Use a gripper opening in [0, 1].")
+                if "end_effector" not in reading:
+                    raise ValueError("This arm was declared without a gripper.")
+                action = {"end_effector": {"target": np.array([opening])}}
+            else:
+                raise ValueError("Unknown command; type help for the accepted forms.")
+        except ValueError as error:
+            logger.warning("%s", error)
+            continue
+        robot.send_action({"arm": action})
+        if "joint_position" in action:
+            arm.wait_until_still()
+        logger.info("Command sent. Use where to read the measured state.")
+
+
+def terminal_commands() -> Iterator[str]:
+    """Yield terminal commands until EOF or Ctrl-C."""
+    while True:
+        try:
+            yield input("piper> ")
+        except (EOFError, KeyboardInterrupt):
+            return
+
+
+def main() -> None:
+    """Connect the selected Piper, run the check, and release its connection."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel", default="can0", help="CAN channel (default: can0)")
+    parser.add_argument("--interface", default="socketcan", help="python-can interface")
+    parser.add_argument(
+        "--model", choices=("piper", "piper_h", "piper_l", "piper_x"), default="piper"
+    )
+    parser.add_argument(
+        "--firmware", default=None, help="firmware profile; default: auto-detect"
+    )
+    parser.add_argument(
+        "--speed-percent",
+        type=int,
+        default=10,
+        help="motion speed, 1..100 (default: 10)",
+    )
+    parser.add_argument(
+        "--gripper-max-width",
+        type=float,
+        default=0.07,
+        help="full gripper stroke in metres (default: 0.07)",
+    )
+    parser.add_argument(
+        "--no-gripper", action="store_true", help="arm has no AgxGripper"
+    )
+    parser.add_argument(
+        "--read-only",
+        action="store_true",
+        help="connect, read state, and exit without sending targets",
+    )
+    parser.add_argument(
+        "--mock", action="store_true", help="use mock vendor SDKs without hardware"
+    )
+    args = parser.parse_args()
+    if not 1 <= args.speed_percent <= 100:
+        parser.error("--speed-percent must be in [1, 100].")
+    if not np.isfinite(args.gripper_max_width) or args.gripper_max_width <= 0:
+        parser.error("--gripper-max-width must be a positive finite width in metres.")
+
+    context = contextlib.nullcontext()
+    if args.mock:
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tests"))
+        from robot_mocks import mocked_sdks
+
+        context = mocked_sdks()
+
+    with context:
+        robot = PiperRobot(
+            arm=PiperArm.declare(
+                args.channel,
+                interface=args.interface,
+                model=args.model,
+                firmware=args.firmware,
+                speed_percent=args.speed_percent,
+                gripper_max_width=args.gripper_max_width,
+                with_gripper=not args.no_gripper,
+            )
+        )
+        robot.connect()
+        try:
+            drive(robot, ["where"])
+            if not args.read_only:
+                logger.info(HELP)
+                drive(robot, terminal_commands())
+        except KeyboardInterrupt:
+            logger.info("Interrupted; disconnecting the Piper.")
+        finally:
+            # Let cleanup finish even if another Ctrl-C arrives during teardown.
+            previous = signal.signal(signal.SIGINT, signal.SIG_IGN)
+            try:
+                robot.disconnect()
+            finally:
+                signal.signal(signal.SIGINT, previous)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description

Add English and Chinese guides for setting up AgileX Piper and SO101 and running their hardware test scripts. The guides cover dependency installation, CAN setup or motor calibration, feedback reads, and joint/gripper checks. They state that no real-world task or training workflow is supported yet and link to the shared robotics and task-extension guides. Both are linked from the robot gallery and READMEs.

Add `toolkits/realworld_check/test_piper_controller.py` for local feedback reads and interactive joint/gripper checks. Joint commands start from measured positions and accept finite increments within five degrees; gripper commands validate the opening and attachment. The script also supports read-only operation and testing without hardware.

Retry failed Ray cleanup once in the unit-test jobs so a process disappearing during `ray stop` does not abort the suite. Test failures and persistent cleanup failures still fail the job. Remove `@zanghz21` from the real-world checks CODEOWNERS entry.

### Motivation and Context

The robot interfaces are available, but users need a complete hardware setup and test path before implementing a physical task. Piper also needs a standalone check alongside the existing SO101 toolkit. The CPU unit-test job failed during cleanup with `psutil.NoSuchProcess` after its completed test files had passed.

### How has this been tested?

- `PYTHONPATH="$PWD:$PWD/tests/unit_tests" python -m pytest tests/unit_tests/test_robotics.py -q`: 267 passed, including the 12 new Piper toolkit cases.
- Workflow YAML and shell syntax validated; 30 shell scenarios across all six test loops verify successful cleanup, one transient failure, persistent cleanup failure, and preservation of pytest's exit status.
- Piper and SO101 toolkit commands exercised with shared test SDKs; physical hardware was not available.
- English and Chinese Sphinx HTML builds: zero warnings after the docs-check helper's standard filtering of autodoc import failures in the docs-only environment.
- Documentation markup, symbols, internal links, command syntax, English/Chinese command parity, and absence of mock/training examples checked.
- Ruff lint/format checks and `git diff --check` passed.

### Additional information (optional, e.g., figures and logs):

Physical hardware was not tested. SO101's existing toolkit performs an initial folded-pose move during environment construction; the guide documents that behavior explicitly. The guides make no claim of task performance or training results.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
