### PR TITLE
fix(envs): add optional methods to ManiskillOffloadEnv

### DIFF
--- a/rlinf/envs/sim/maniskill/maniskill_offload_env.py
+++ b/rlinf/envs/sim/maniskill/maniskill_offload_env.py
@@ -430,6 +430,18 @@ class ManiskillOffloadEnv(EnvOffloadMixin):
             return getattr(self, name)
         return self.__getattr__(name)
 
+    async def wait_delay(self):
+        """No-op: delays are sampled by ``InsertDelay`` wrappers, never here.
+
+        Defined locally so existence probes like ``get_env_attr`` resolve to a
+        real method instead of an RPC proxy for a method the worker process
+        does not have.
+        """
+
+    def insert_delay_metrics(self):
+        """Report no recorded delays; samples live in ``InsertDelay`` wrappers."""
+        return torch.tensor([], dtype=torch.float32)
+
     def _force_shutdown(self):
         if self.command_queue is not None:
             self.command_queue.close()

--- a/tests/unit_tests/test_envs.py
+++ b/tests/unit_tests/test_envs.py
@@ -1,0 +1,48 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment attribute contracts seen by the env worker."""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("mani_skill")
+
+import torch  # noqa: E402
+
+from rlinf.envs.sim.maniskill.maniskill_offload_env import (  # noqa: E402
+    ManiskillOffloadEnv,
+)
+from rlinf.envs.utils import get_env_attr  # noqa: E402
+
+
+def _bare_offload_env() -> ManiskillOffloadEnv:
+    """Build the proxy without starting its simulator worker process."""
+    return object.__new__(ManiskillOffloadEnv)
+
+
+def test_optional_protocol_methods_resolve_locally():
+    """get_env_attr probes must see the local protocol methods, not RPC proxies."""
+    env = _bare_offload_env()
+
+    wait_delay = get_env_attr(env, "wait_delay")
+    assert callable(wait_delay)
+    assert asyncio.iscoroutinefunction(wait_delay)
+
+    insert_delay_metrics = get_env_attr(env, "insert_delay_metrics")
+    metrics = insert_delay_metrics()
+    assert isinstance(metrics, torch.Tensor)
+    assert metrics.dtype == torch.float32
+    assert metrics.numel() == 0


### PR DESCRIPTION
### Description

`ManiskillOffloadEnv` resolves every unknown public attribute to an RPC method proxy, so existence probes such as `get_env_attr(env, "wait_delay") is None` never return `None` for it. The env worker's interaction path then awaits `wait_delay` on the simulator process, whose dispatch has no such method, and training dies at the first rollout epoch with `Method 'wait_delay' not found`.

This change implements the two optional protocol methods locally on the proxy:

- `async def wait_delay()`: a no-op. Delays are sampled by `InsertDelay` wrappers around the env, never by the simulator process, so there is nothing to wait here.
- `insert_delay_metrics()`: returns an empty float32 tensor; `compute_delay_stats` already handles empty input and reports zeros.

Existence probes now resolve to real methods, the same semantics every in-process gym env already provides. A unit test pins the contract.

### Motivation and Context

Fixes #1555. Any ManiSkill run with `enable_offload: true` (the published quickstart default) crashed at the first interaction step. The issue has the full analysis, a no-GPU reproducer, and why the e2e suite does not cover this combination (`maniskill_async_ppo_openvlaoft.yaml` sets `enable_offload: false`).

### How has this been tested?

- New unit test `tests/unit_tests/test_envs.py::test_optional_protocol_methods_resolve_locally` (auto-skips without `mani_skill`); runs green locally together with `test_utils.py` (16 passed). The ray-based cluster/placement suites need more local resources and are left to CI.
- A minimal reproducer on a clean checkout confirmed `get_env_attr` resolved arbitrary names — including a fabricated one — to RPC proxies before the change.
- End-to-end: the published `maniskill_ppo_openvlaoft_quickstart` on 2x A100 trains stably past the previous crash point (9+ rollout epochs, ~169 s/step, rewards/success/`time/interact_delay` logged).
- `ruff check` and `ruff format --check` pass on both changed files.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
