### PR TITLE
fix(fsdp): reduce the gradient norm over every shard

### DIFF
--- a/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
+++ b/rlinf/hybrid_engines/fsdp/fsdp_model_manager.py
@@ -43,6 +43,7 @@ from rlinf.hybrid_engines.fsdp.strategy.base import FSDPStrategyBase
 from rlinf.hybrid_engines.fsdp.utils import (
     create_device_mesh,
     get_lr_scheduler,
+    gradient_reduction_group,
 )
 from rlinf.models.tokenization.hf import hf_tokenizer
 from rlinf.scheduler import Worker
@@ -97,11 +98,7 @@ class FSDPModelManager:
             self.tokenizer = hf_tokenizer(cfg.tokenizer.tokenizer_model)
 
         self._device_mesh = create_device_mesh(world_size)
-        self._dp_group = (
-            self._device_mesh["ddp"].get_group()
-            if "ddp" in self._device_mesh.mesh_dim_names
-            else None
-        )
+        self._dp_group = gradient_reduction_group(self._device_mesh)
 
         self._strategy = FSDPStrategyBase.create(
             self._cfg, world_size, self._dp_group, self._logger

--- a/rlinf/hybrid_engines/fsdp/utils.py
+++ b/rlinf/hybrid_engines/fsdp/utils.py
@@ -97,6 +97,23 @@ def create_device_mesh(world_size: int) -> DeviceMesh:
     )
 
 
+def gradient_reduction_group(device_mesh: DeviceMesh) -> torch.distributed.ProcessGroup:
+    """Return the group a gradient's shards are spread over.
+
+    :func:`get_grad_norm` sums per-rank shard norms over this group, so it has
+    to span the sharding dimension and nothing else. Passing ``None`` yields one
+    rank's shard norm instead of the gradient's, and under hybrid sharding the
+    ``ddp`` dimension holds replicas whose norms would be counted once each.
+
+    Args:
+        device_mesh (DeviceMesh): The mesh FSDP was built over.
+
+    Returns:
+        torch.distributed.ProcessGroup: The group behind the ``fsdp`` dimension.
+    """
+    return device_mesh["fsdp"].get_group()
+
+
 def init_fn(x: torch.nn.Module):
     if not torch.distributed.get_rank() == 0:
         x = x.to_empty(device=Worker.torch_platform.current_device(), recurse=False)

--- a/tests/unit_tests/test_fsdp.py
+++ b/tests/unit_tests/test_fsdp.py
@@ -12,15 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the collective timeout of the FSDP device mesh.
+"""Tests for the FSDP device mesh and the process groups derived from it.
 
-``init_device_mesh`` creates the default process group itself when none exists,
-using whatever watchdog timeout the backend ships with — 30 minutes for
-NCCL/Gloo, about 60 for HCCL, in every case below the 180 minutes RLinf gives
-its own groups. A mesh dimension that spans the whole world reuses that group,
-so every FSDP collective inherits that timeout, and no environment variable can
-raise it. ``create_device_mesh`` therefore creates the group first, with the
-same ``RLINF_TIMEOUT`` that RLinf applies to its own inter-worker groups.
+Two properties of that mesh are easy to get wrong and silent when they are, so
+they are pinned here: the timeout its collectives run under, and which of its
+dimensions a gradient norm reduces over.
+
+The timeout. ``init_device_mesh`` creates the default process group itself when
+none exists, using whatever watchdog timeout the backend ships with — 30 minutes
+for NCCL/Gloo, about 60 for HCCL, in every case below the 180 minutes RLinf
+gives its own groups. A mesh dimension that spans the whole world reuses that
+group, so every FSDP collective inherits that timeout, and no environment
+variable can raise it. ``create_device_mesh`` therefore creates the group first,
+with the same ``RLINF_TIMEOUT`` that RLinf applies to its own inter-worker
+groups.
+
+The reduction group. FSDP leaves each rank only its slice of every gradient, so
+a norm over one of them is not the gradient's norm. ``gradient_reduction_group``
+picks the dimension the shards are spread over, which stays ``fsdp`` even once a
+replicated ``ddp`` dimension exists beside it.
 """
 
 import logging

--- a/tests/unit_tests/test_fsdp_device_mesh_timeout.py
+++ b/tests/unit_tests/test_fsdp_device_mesh_timeout.py
@@ -216,3 +216,28 @@ def test_mesh_dimension_reuses_the_default_group(single_rank_env):
     """
     mesh = create_device_mesh(1)
     assert mesh["fsdp"].get_group() is dist.distributed_c10d._get_default_group()
+
+
+def test_gradients_reduce_over_the_sharding_dimension(single_rank_env):
+    """The norm's process group is the one gradients are sharded over.
+
+    FSDP leaves each rank only its slice of every gradient, so the group has to
+    span the sharding dimension. Reducing over nothing reports one rank's shard
+    norm rather than the gradient's, and gradient clipping then loosens as the
+    job grows; reducing over a replicated dimension counts each shard once per
+    replica. Both are silent, so the lookup fails loudly instead of falling back
+    when no sharding dimension is present.
+    """
+    from torch.distributed.device_mesh import init_device_mesh
+
+    from rlinf.hybrid_engines.fsdp.utils import gradient_reduction_group
+
+    sharded = create_device_mesh(1)
+    assert gradient_reduction_group(sharded) is sharded["fsdp"].get_group()
+
+    hybrid = init_device_mesh("cpu", (1, 1), mesh_dim_names=["ddp", "fsdp"])
+    assert gradient_reduction_group(hybrid) is hybrid["fsdp"].get_group()
+
+    replicated_only = init_device_mesh("cpu", (1,), mesh_dim_names=["ddp"])
+    with pytest.raises(KeyError):
+        gradient_reduction_group(replicated_only)


### PR DESCRIPTION
### Description

`create_device_mesh` builds a 1-D mesh whose only dimension is named `fsdp`, so the `"ddp" in mesh_dim_names` guard on `_dp_group` never matched and the group stayed `None` for every FSDP and FSDP2 run. `get_grad_norm` skipped its `all_reduce` as a result and returned the norm of whichever shard the local rank held, which `clip_grad_norm_` then clipped against.

The selection now lives in a named `gradient_reduction_group(device_mesh)` rather than inline in the manager, because it carries a constraint that is easy to get wrong: the group has to span the sharding dimension and nothing else. Hybrid sharding replicates across `ddp`, so reducing over that dimension would count each shard once per replica.

### Motivation and Context

The reported norm was roughly `1/sqrt(world_size)` of the real one and shrank as the job grew, so gradient clipping silently loosened with scale. A two-GPU measurement from #1498 puts numbers on it: without the reduction `grad_norm` came out 50.6862 against a reference DDP value of 71.9728 (≈ 1/√2); with it, 72.0690.

**This changes training behaviour for every existing FSDP config.** Clipping now bites at the configured threshold, so runs that were effectively unclipped will now be clipped even though nothing in their YAML moved. That is the intended correction, but it is worth knowing before rerunning a baseline.

Overlaps with #1522, which reaches the same `_dp_group = mesh["fsdp"].get_group()` while adding the 2-D hybrid mesh. The two agree on the value; whichever lands second should take the other's version of the line.

### How has this been tested?

- `tests/unit_tests/test_fsdp_device_mesh_timeout.py` gains a case pinning which mesh dimension the group comes from, including the loud failure when no sharding dimension exists — silently reducing over the wrong one is how this went unnoticed.
- Full file: 10 passed. Note this file is order-sensitive on a busy machine; its real `init_process_group` tests race for ephemeral ports and fail intermittently on `main` as well.
- The cross-rank reduction itself needs more than one rank and is **not** covered by a unit test. A 2-rank gloo spawn test does cover it but costs ~60s and polluted the other tests in the file, so it was dropped in favour of the two-GPU measurement above.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
