### PR TITLE
feat(robotics): add arm moves and robots built from config

### DIFF
--- a/docs/source-en/rst_source/concepts/robotics.rst
+++ b/docs/source-en/rst_source/concepts/robotics.rst
@@ -56,7 +56,10 @@ the hardware. The following example keeps those phases visible in one place:
 ``Robot``. Construction records hardware arguments and placement, but it does
 not import a vendor SDK or open a device. ``describe()`` reads that declaration,
 so it can report paths, nodes, and connection ownership before the hardware is
-powered or reachable.
+powered or reachable. An environment starts from the scheduler's hardware config
+instead of builder arguments, and calls ``from_config()`` on the registered
+robot class. It forwards each config field to ``build()`` and places parts on
+the environment's node unless the config names another.
 
 Setup code then selects the capabilities it needs. ``child("arm", Arm)`` returns
 the part at ``arm`` and checks that it implements ``Arm``; the expected class is
@@ -70,7 +73,12 @@ names.
 already opened if a later one fails. Once connected, category methods such as
 ``Arm.is_robot_up()`` and ``Camera.is_ready()`` check whether the devices can be
 used; ``clear_errors()`` and ``reset_joint()`` are available for setup outside
-the per-step action stream.
+the per-step action stream. An arm that accepts ``tcp_pose`` commands also
+offers ``move_to()``, which travels to a tool pose through evenly spaced targets
+for homing between episodes. An end effector opens and closes fully with
+``open()`` and ``close()`` and reports ``is_open``. Each arm class states
+``DOF``, the number of joints it drives, so a joint target's width can be
+checked before any hardware is opened.
 
 The step loop uses two calls. ``get_observation()`` reads the composed robot once
 and returns a nested dictionary whose keys are the part paths.

--- a/docs/source-en/rst_source/extending/new_robot.rst
+++ b/docs/source-en/rst_source/extending/new_robot.rst
@@ -487,7 +487,8 @@ robot composition. After the robot type is registered, callers can use either
 ``Robot.of_type("MobileManipulator", ...)`` or the convenience function
 ``build_robot("MobileManipulator", ...)``. Both calls still require the
 builder's keyword arguments; registration does not turn a hardware config into
-those arguments automatically.
+those arguments. The robot's own ``from_config()``, described with the cluster
+configuration below, is where that translation lives.
 
 For an in-tree implementation, place the module under
 ``rlinf/robotics/robots/`` and import it from that package's ``__init__.py``.
@@ -535,28 +536,55 @@ node. The env config selects the Gym ID separately, so the same hardware
 composition can serve navigation, mobile manipulation, or data-collection
 tasks.
 
-The environment receives that ``RobotInfo`` and calls the registered builder
-explicitly. This is the visible boundary where scheduler metadata such as the
-env worker rank is added:
+The environment receives that ``RobotInfo`` and turns its config into a robot
+through ``from_config()``. Implement it on the robot class beside ``build()``,
+so the translation from config fields to builder arguments is written once
+rather than in every environment that uses the robot:
 
 .. code-block:: python
 
-   hardware = robot_info.config
-   robot = build_robot(
-       "MobileManipulator",
-       base_backend=hardware.base_backend,
-       base_endpoint=hardware.base_endpoint,
-       arm_ip=hardware.arm_ip,
-       node_rank=hardware.node_rank,
-       controller_node_rank=hardware.controller_node_rank,
-       worker_rank=worker_info.rank,
+   class MobileManipulator(Robot):
+       ...
+
+       @classmethod
+       def from_config(
+           cls,
+           config: MobileManipulatorConfig,
+           *,
+           cameras=None,
+           env_idx: int = 0,
+           node_rank: int = 0,
+           worker_rank: int = 0,
+       ) -> "MobileManipulator":
+           return cls.build(
+               base_backend=config.base_backend,
+               base_endpoint=config.base_endpoint,
+               arm_ip=config.arm_ip,
+               node_rank=node_rank,
+               controller_node_rank=config.controller_node_rank,
+               worker_rank=worker_rank,
+               env_idx=env_idx,
+           )
+
+The config supplies the hardware. The keyword arguments supply what only the
+environment knows: the node it runs on, its worker rank and index, and the
+cameras its policy reads, which this robot does not carry. Parts run on
+``node_rank`` unless the config places them elsewhere, as
+``controller_node_rank`` does for the arm. The environment then builds the robot
+without restating any hardware field:
+
+.. code-block:: python
+
+   robot = MobileManipulator.from_config(
+       robot_info.config,
        env_idx=env_idx,
+       node_rank=worker_info.cluster_node_rank,
+       worker_rank=worker_info.rank,
    )
 
-Keeping this call explicit prevents the hardware registry from becoming an
-implicit adapter between unrelated config shapes. If several environments use
-the same robot, place the translation in shared setup code rather than copying
-it into each task.
+Name every field ``from_config()`` forwards, as ``build()`` names every
+argument it takes. The mapping stays short, and it is the one place a reader
+looks to see which setting reaches which part.
 
 8. Test the Integration
 -----------------------

--- a/docs/source-zh/rst_source/concepts/robotics.rst
+++ b/docs/source-zh/rst_source/concepts/robotics.rst
@@ -42,11 +42,11 @@
    finally:
        robot.disconnect()
 
-``build_robot()`` 根据注册名找到对应的机器人 builder，并返回尚未连接的 ``Robot``。构建阶段只记录硬件参数和 placement，不导入厂商 SDK，也不打开设备。``describe()`` 读取这些声明，因此机器人尚未上电或网络不可达时，也能检查访问路径、部署节点和连接归属。
+``build_robot()`` 根据注册名找到对应的机器人 builder，并返回尚未连接的 ``Robot``。构建阶段只记录硬件参数和 placement，不导入厂商 SDK，也不打开设备。``describe()`` 读取这些声明，因此机器人尚未上电或网络不可达时，也能检查访问路径、部署节点和连接归属。env 拿到的是 scheduler 分配的硬件配置，而不是 builder 参数，因此它调用已注册机器人类的 ``from_config()``：该方法把配置字段逐一传给 ``build()``，并把零部件部署到 env 所在节点，配置另行指定节点时除外。
 
 初始化代码随后取得所需能力。``child("arm", Arm)`` 返回 ``arm`` 路径上的零部件，并立即检查它是否属于 ``Arm``；编辑器也会将返回值推断为 ``Arm``。``parts_of_type(Camera)`` 则遍历完整组合，返回以完整路径为 key 的所有相机。任务依赖固定路径时使用 ``child()``；只关心设备类别而不依赖相机名称时，使用 ``parts_of_type()``。
 
-``connect()`` 会为每条 owner connection 打开一次资源；如果后续 connection 打开失败，它会回滚此前已经打开的资源。连接完成后，可通过 ``Arm.is_robot_up()`` 和 ``Camera.is_ready()`` 检查设备是否可用；``clear_errors()`` 与 ``reset_joint()`` 等初始化操作位于单步动作流之外。
+``connect()`` 会为每条 owner connection 打开一次资源；如果后续 connection 打开失败，它会回滚此前已经打开的资源。连接完成后，可通过 ``Arm.is_robot_up()`` 和 ``Camera.is_ready()`` 检查设备是否可用；``clear_errors()`` 与 ``reset_joint()`` 等初始化操作位于单步动作流之外。接受 ``tcp_pose`` 命令的机械臂还提供 ``move_to()``，它以均匀间隔的目标位姿移动到指定工具位姿，适合在两个 episode 之间回零。末端执行器通过 ``open()`` 与 ``close()`` 完全张开或闭合，并由 ``is_open`` 报告当前状态。每个机械臂类都声明 ``DOF``，即其驱动的关节数，因此在打开任何硬件之前就能检查关节目标的维度。
 
 step 循环只需两个接口。``get_observation()`` 对组合后的机器人执行一次完整读取，并按访问路径返回嵌套字典。``send_action()`` 接收层级相同的动作，只下发本次提供的分支，并将各零部件实际发送的动作作为 ``applied`` 返回。``disconnect()`` 最后按相反顺序关闭 connection；将它置于 ``finally`` 中，可以保证读取或控制失败后仍完成清理，而且重复调用不会产生额外影响。
 

--- a/docs/source-zh/rst_source/extending/new_robot.rst
+++ b/docs/source-zh/rst_source/extending/new_robot.rst
@@ -359,7 +359,7 @@ builder 已经能够根据明确参数构造机器人；注册则为这一组合
 
 标准 discovery 流程会筛选属于当前节点的配置，通过同名大写环境变量补全未设置字段，并为每项配置返回一条硬件记录。如果配置包含相机字段，该流程还会复用公共的相机发现与校验逻辑。只有机器人的枚举方式确实不同时，才需要将自定义 ``RobotDiscovery`` 子类作为第二个参数传给 ``register_type()``。
 
-``Connection.register()`` 与 ``Robot.register_type()`` 对应两个不同的 registry：前者注册单个设备 driver，后者注册整台机器人的组合。完成机器人类型注册后，调用方既可以使用 ``Robot.of_type("MobileManipulator", ...)``，也可以调用便捷函数 ``build_robot("MobileManipulator", ...)``。两种方式都需要提供 builder 声明的参数；注册操作不会自动将硬件配置转换为这些参数。
+``Connection.register()`` 与 ``Robot.register_type()`` 对应两个不同的 registry：前者注册单个设备 driver，后者注册整台机器人的组合。完成机器人类型注册后，调用方既可以使用 ``Robot.of_type("MobileManipulator", ...)``，也可以调用便捷函数 ``build_robot("MobileManipulator", ...)``。两种方式都需要提供 builder 声明的参数；注册操作不会将硬件配置转换为这些参数，这一转换由机器人自身的 ``from_config()`` 完成，下文配置集群时会介绍。
 
 项目内置实现应放在 ``rlinf/robotics/robots/`` 下，并由该目录的 ``__init__.py`` 导入。这样，无论构造 ``Cluster`` 还是运行检查脚本，导入 ``rlinf.robotics.robots`` 时都会先完成注册。项目外部的集成则需在自己的 entry point 中显式导入注册模块。node probe 也会导入已注册的机器人模块，因此每个节点配置的 Python 环境都必须能够导入该模块。
 
@@ -389,23 +389,45 @@ builder 已经能够根据明确参数构造机器人；注册则为这一组合
 
 这些字段与前文的构造流程逐一对应：``type`` 选择已注册的机器人，每个 ``configs`` 项生成一条硬件记录；``node_rank`` 指定该记录由哪个节点持有，``base_backend`` 和两个地址标识具体设备，``controller_node_rank`` 则将复用的 Franka connection 部署到控制节点。env 配置另行选择 Gym ID，因此同一套硬件组合可以服务于导航、移动操作或数据采集任务。
 
-env 收到 ``RobotInfo`` 后，需要显式调用已注册的 builder。scheduler 提供的 env worker rank 等运行时信息也在这一边界加入：
+env 收到 ``RobotInfo`` 后，通过 ``from_config()`` 将其中的配置转换为机器人。该方法与 ``build()`` 一同实现在机器人类上，这样从配置字段到 builder 参数的转换只需编写一次，不必在每个使用该机器人的 env 中重复：
 
 .. code-block:: python
 
-   hardware = robot_info.config
-   robot = build_robot(
-       "MobileManipulator",
-       base_backend=hardware.base_backend,
-       base_endpoint=hardware.base_endpoint,
-       arm_ip=hardware.arm_ip,
-       node_rank=hardware.node_rank,
-       controller_node_rank=hardware.controller_node_rank,
-       worker_rank=worker_info.rank,
+   class MobileManipulator(Robot):
+       ...
+
+       @classmethod
+       def from_config(
+           cls,
+           config: MobileManipulatorConfig,
+           *,
+           cameras=None,
+           env_idx: int = 0,
+           node_rank: int = 0,
+           worker_rank: int = 0,
+       ) -> "MobileManipulator":
+           return cls.build(
+               base_backend=config.base_backend,
+               base_endpoint=config.base_endpoint,
+               arm_ip=config.arm_ip,
+               node_rank=node_rank,
+               controller_node_rank=config.controller_node_rank,
+               worker_rank=worker_rank,
+               env_idx=env_idx,
+           )
+
+硬件信息来自配置；关键字参数则提供只有 env 才知道的信息：它所在的节点、worker rank 与序号，以及 policy 读取的相机（这台机器人本身不带相机）。零部件默认部署在 ``node_rank`` 上，配置另行指定时除外，例如机械臂由 ``controller_node_rank`` 决定。env 随后无需重复任何硬件字段即可构造机器人：
+
+.. code-block:: python
+
+   robot = MobileManipulator.from_config(
+       robot_info.config,
        env_idx=env_idx,
+       node_rank=worker_info.cluster_node_rank,
+       worker_rank=worker_info.rank,
    )
 
-显式保留这次调用，可以避免硬件 registry 隐式转换不同层的配置结构。如果多个 env 共用同一种机器人，应将这段转换逻辑放入公共的硬件初始化代码，而不是复制到每个任务中。
+``from_config()`` 应逐一写明转发的字段，正如 ``build()`` 逐一写明接受的参数。这段映射很短，读者要确认某项设置最终作用于哪个零部件时，只需查看这一处。
 
 8. 测试集成
 -----------

--- a/examples/embodiment/config/env/realworld_gim_arm_peg_insertion.yaml
+++ b/examples/embodiment/config/env/realworld_gim_arm_peg_insertion.yaml
@@ -1,4 +1,4 @@
-
+env_type: real
 total_num_envs: null
 
 auto_reset: True

--- a/rlinf/envs/real/franka/base.py
+++ b/rlinf/envs/real/franka/base.py
@@ -45,7 +45,6 @@ from ..utils.pose import (
     clip_euler_to_target_window,
     construct_adjoint_matrix,
     construct_homogeneous_matrix,
-    quat_slerp,
 )
 
 #: Default Cartesian impedance gains shared by Franka tasks.
@@ -279,28 +278,14 @@ class FrankaEnv(gym.Env):
     def _setup_hardware(self) -> None:
         assert self.env_idx >= 0, "env_idx must be set for FrankaEnv."
 
-        hardware = self.hardware
         self._camera_infos = self._build_camera_infos()
-
-        # Default the arm controller to the environment worker's node.
-        controller_node_rank = hardware.controller_node_rank
-        if controller_node_rank is None:
-            controller_node_rank = self.node_rank
         # The composed robot owns camera placement and lifecycle.
-        camera_node_rank = hardware.camera_node_rank
-        self.robot = FrankaRobot.build(
-            robot_ip=self.hardware.robot_ip,
-            env_idx=self.env_idx,
-            node_rank=controller_node_rank,
-            worker_rank=self.env_worker_rank,
-            backend=self.hardware.backend,
-            gripper_type=self.hardware.gripper_type,
-            compliance=hardware.compliance,
-            end_effector_type=self.hardware.end_effector_type,
-            end_effector_config=self.hardware.end_effector_config,
-            gripper_connection=self.hardware.gripper_connection,
+        self.robot = FrankaRobot.from_config(
+            self.hardware,
             cameras={info.name: info for info in self._camera_infos},
-            camera_node_rank=camera_node_rank,
+            env_idx=self.env_idx,
+            node_rank=self.node_rank,
+            worker_rank=self.env_worker_rank,
         )
         self.robot.connect()
         # Naming the class each part is expected to be keeps the driver's own
@@ -952,21 +937,13 @@ class FrankaEnv(gym.Env):
             return True
 
     def _interpolate_move(self, pose: np.ndarray, timeout: float = 1.5) -> None:
-        num_steps = int(timeout * self.config.step_frequency)
-        self._franka_state: FrankaRobotState = self._read_robot()
-        pos_path = np.linspace(
-            self._franka_state.tcp_pose[:3], pose[:3], int(num_steps) + 1
+        self._arm.move_to(
+            pose,
+            duration=timeout,
+            rate_hz=self.config.step_frequency,
+            clear_errors=True,
         )
-        quat_path = quat_slerp(
-            self._franka_state.tcp_pose[3:], pose[3:], int(num_steps) + 1
-        )
-
-        for pos, quat in zip(pos_path[1:], quat_path[1:]):
-            pose = np.concatenate([pos, quat])
-            self._move_action(pose.astype(np.float32))
-            time.sleep(1.0 / self.config.step_frequency)
-
-        self._franka_state: FrankaRobotState = self._read_robot()
+        self._franka_state = self._read_robot()
 
     def _move_action(self, position: np.ndarray) -> None:
         if self.config.is_dummy:

--- a/rlinf/envs/real/gim_arm/base.py
+++ b/rlinf/envs/real/gim_arm/base.py
@@ -196,21 +196,13 @@ class GimArmEnv(gym.Env):
     def _setup_hardware(self) -> None:
         """Compose and connect the configured hardware."""
         assert self.env_idx >= 0, "env_idx must be nonnegative."
-        hardware = self.hardware
-        controller_node_rank = hardware.controller_node_rank
-        if controller_node_rank is None:
-            controller_node_rank = self.node_rank
-
-        self.robot = GimArmRobot.build(
-            can_interface=hardware.can_interface,
-            arm_variant=hardware.arm_variant,
-            enable_gripper=hardware.enable_gripper,
-            gripper_type=hardware.gripper_type,
-            control_mode=self.config.control_mode,
-            env_idx=self.env_idx,
-            node_rank=controller_node_rank,
-            worker_rank=self.env_worker_rank,
+        self.robot = GimArmRobot.from_config(
+            self.hardware,
             cameras={info.name: info for info in self._camera_infos()},
+            env_idx=self.env_idx,
+            node_rank=self.node_rank,
+            worker_rank=self.env_worker_rank,
+            control_mode=self.config.control_mode,
         )
         self.robot.connect()
         # The arm part, for the operations the Arm contract names. Reading

--- a/rlinf/envs/real/piper/base.py
+++ b/rlinf/envs/real/piper/base.py
@@ -164,25 +164,12 @@ class PiperEnv(gym.Env):
     def _setup_hardware(self) -> None:
         """Compose and connect the configured hardware."""
         assert self.env_idx >= 0, "env_idx must be nonnegative."
-        hardware = self.hardware
-        controller_node_rank = hardware.controller_node_rank
-        if controller_node_rank is None:
-            controller_node_rank = self.node_rank
-
-        self.robot = PiperRobot.build(
-            can_channel=hardware.can_channel,
-            backend=hardware.backend,
-            can_interface=hardware.can_interface,
-            model=hardware.model,
-            firmware=hardware.firmware,
-            speed_percent=hardware.speed_percent,
-            gripper_force=hardware.gripper_force,
-            gripper_max_width=hardware.gripper_max_width,
-            with_gripper=hardware.with_gripper,
-            env_idx=self.env_idx,
-            node_rank=controller_node_rank,
-            worker_rank=self.env_worker_rank,
+        self.robot = PiperRobot.from_config(
+            self.hardware,
             cameras={info.name: info for info in self._camera_infos()},
+            env_idx=self.env_idx,
+            node_rank=self.node_rank,
+            worker_rank=self.env_worker_rank,
         )
         self.robot.connect()
         # The arm part, for the operations the Arm contract names. Reading and

--- a/rlinf/envs/real/so101/base.py
+++ b/rlinf/envs/real/so101/base.py
@@ -170,19 +170,12 @@ class SO101Env(gym.Env):
     def _setup_hardware(self) -> None:
         """Compose and connect the configured hardware."""
         assert self.env_idx >= 0, "env_idx must be nonnegative."
-        hardware = self.hardware
-        controller_node_rank = hardware.controller_node_rank
-        if controller_node_rank is None:
-            controller_node_rank = self.node_rank
-
-        self.robot = SO101Robot.build(
-            port=hardware.serial_port,
-            calibration_id=hardware.calibration_id,
-            max_relative_target=hardware.max_relative_target,
-            env_idx=self.env_idx,
-            node_rank=controller_node_rank,
-            worker_rank=self.env_worker_rank,
+        self.robot = SO101Robot.from_config(
+            self.hardware,
             cameras={info.name: info for info in self._camera_infos()},
+            env_idx=self.env_idx,
+            node_rank=self.node_rank,
+            worker_rank=self.env_worker_rank,
         )
         self.robot.connect()
         # The arm part, for the operations the Arm contract names. Reading

--- a/rlinf/envs/real/utils/pose.py
+++ b/rlinf/envs/real/utils/pose.py
@@ -13,16 +13,7 @@
 # limitations under the License.
 
 import numpy as np
-from numpy.typing import ArrayLike
 from scipy.spatial.transform import Rotation as R
-
-
-def normalize(q: ArrayLike) -> np.ndarray:
-    q = np.array(q, dtype=float)
-    n = np.linalg.norm(q)
-    if n == 0:
-        raise ValueError("Zero-norm quaternion")
-    return q / n
 
 
 def wrap_to_pi(angle: float | np.ndarray) -> float | np.ndarray:
@@ -55,48 +46,6 @@ def clip_euler_to_target_window(
     upper_delta = upper_euler - target_euler
     clipped_delta = np.clip(delta, lower_delta, upper_delta)
     return wrap_to_pi(target_euler + clipped_delta)
-
-
-def quat_slerp(q0: ArrayLike, q1: ArrayLike, t: float) -> np.ndarray:
-    """Spherically interpolate between two quaternions."""
-
-    q0 = normalize(q0)
-    q1 = normalize(q1)
-
-    dot = np.dot(q0, q1)
-
-    # Align quaternion hemispheres to follow the shortest path.
-    if dot < 0:
-        q1 = -q1
-        dot = -dot
-
-    dot = np.clip(dot, -1.0, 1.0)
-
-    if np.isscalar(t):
-        t_arr = np.linspace(0, 1, t, dtype=float)
-    else:
-        t_arr = np.array(t, dtype=float)
-
-    results = []
-
-    # Use normalized linear interpolation for nearly identical quaternions.
-    if dot > 0.9995:
-        for tt in t_arr:
-            q = normalize(q0 + tt * (q1 - q0))
-            results.append(q)
-    else:
-        theta_0 = np.arccos(dot)
-        sin_theta_0 = np.sin(theta_0)
-
-        for tt in t_arr:
-            theta = theta_0 * tt
-            s0 = np.sin(theta_0 - theta) / sin_theta_0
-            s1 = np.sin(theta) / sin_theta_0
-            q = s0 * q0 + s1 * q1
-            results.append(q)
-
-    results = np.stack(results)
-    return results
 
 
 def construct_adjoint_matrix(tcp_pose: np.ndarray) -> np.ndarray:

--- a/rlinf/robotics/parts/arms/base.py
+++ b/rlinf/robotics/parts/arms/base.py
@@ -23,6 +23,7 @@ from typing import Any, ClassVar, Optional, Protocol
 import numpy as np
 
 from rlinf.robotics.parts.base import ControllablePart, Features, Observation
+from rlinf.robotics.pose import quat_slerp
 from rlinf.utils.logging import get_logger
 
 #: Canonical arm fields; mounted devices expose their own observations.
@@ -97,6 +98,11 @@ class Arm(ControllablePart):
         @Arm.register("franky")
         class FrankyArm(BaseArm): ...
     """
+
+    #: Joints the arm drives, when the class knows it before connecting. A
+    #: task checks its targets against this in dummy runs too, where no arm is
+    #: ever opened. ``None`` means the count is only known from the device.
+    DOF: ClassVar[Optional[int]] = None
 
     @classmethod
     def backends(cls) -> dict[str, type]:
@@ -175,6 +181,51 @@ class Arm(ControllablePart):
             "configuration you want through send_action, or use a backend that "
             "implements reset_joint()."
         )
+
+    def move_to(
+        self,
+        pose: "Sequence[float]",
+        *,
+        duration: float = 1.5,
+        rate_hz: float = 10.0,
+        clear_errors: bool = False,
+    ) -> None:
+        """Travel to a tool pose through evenly spaced ``tcp_pose`` commands.
+
+        Position is interpolated linearly and orientation by slerp, one
+        command every ``1 / rate_hz`` seconds, so a controller that tracks each
+        target arrives without a jump. The call returns once the last command
+        is sent, not when the arm has settled.
+
+        Args:
+            pose: Target pose, ``xyz`` plus an ``xyzw`` quaternion, in the
+                frame the arm reports ``tcp_pose`` in.
+            duration: Seconds the motion is spread over.
+            rate_hz: Commands per second.
+            clear_errors: Clear a latched fault before every command, for a
+                controller that stops accepting targets after one.
+
+        Raises:
+            NotImplementedError: If the arm does not accept ``tcp_pose``
+                commands.
+        """
+        if "tcp_pose" not in self.action_features:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not accept 'tcp_pose' commands, so "
+                "it cannot move to a tool pose. Drive its joints with "
+                "reset_joint() or 'joint_position' actions instead."
+            )
+        target = np.asarray(pose, dtype=float)
+        current = np.asarray(self.get_observation()["tcp_pose"], dtype=float)
+        waypoints = int(duration * rate_hz)
+        positions = np.linspace(current[:3], target[:3], waypoints + 1)
+        orientations = quat_slerp(current[3:], target[3:], waypoints + 1)
+        for position, orientation in zip(positions[1:], orientations[1:]):
+            if clear_errors:
+                self.clear_errors()
+            waypoint = np.concatenate([position, orientation]).astype(np.float32)
+            self.send_action({"tcp_pose": waypoint})
+            time.sleep(1.0 / rate_hz)
 
     def reconfigure_compliance_params(self, params: "Mapping[str, float]") -> None:
         """Apply a task's compliance request, as far as the backend can."""

--- a/rlinf/robotics/parts/arms/franka_ros.py
+++ b/rlinf/robotics/parts/arms/franka_ros.py
@@ -14,7 +14,7 @@
 
 import sys
 import time
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 import psutil
@@ -29,6 +29,8 @@ from rlinf.utils.logging import get_logger
 @Arm.register("franka_ros")
 class FrankaROSArm(BaseArm):
     """Franka arm controlled through ROS."""
+
+    DOF: ClassVar[int] = 7
 
     @classmethod
     def declare(

--- a/rlinf/robotics/parts/arms/franky.py
+++ b/rlinf/robotics/parts/arms/franky.py
@@ -45,6 +45,8 @@ from rlinf.utils.logging import get_logger
 class FrankyArm(BaseArm):
     """Franka arm controlled through libfranka by Franky."""
 
+    DOF: ClassVar[int] = 7
+
     #: Collision reflex trip points, in Nm and N.
     TORQUE_THRESHOLD: ClassVar[list[float]] = [80.0] * 4 + [11.0] * 3
     FORCE_THRESHOLD: ClassVar[list[float]] = [100.0] * 3 + [25.0] * 3

--- a/rlinf/robotics/parts/arms/gim_arm.py
+++ b/rlinf/robotics/parts/arms/gim_arm.py
@@ -17,7 +17,7 @@ import threading
 import time
 import warnings
 from dataclasses import asdict, dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 
@@ -95,6 +95,8 @@ class GimArm(BaseArm):
     position targets. Hardware dependencies are loaded during :meth:`connect`.
     """
 
+    DOF: ClassVar[int] = 6
+
     def __init__(
         self,
         can_interface: str,
@@ -133,7 +135,10 @@ class GimArm(BaseArm):
             return {}
         return {
             "end_effector": MethodEndEffector(
-                self, state_field="gripper_position", is_gripper=True
+                self,
+                state_field="gripper_position",
+                is_gripper=True,
+                open_field="gripper_open",
             )
         }
 

--- a/rlinf/robotics/parts/arms/so101.py
+++ b/rlinf/robotics/parts/arms/so101.py
@@ -30,7 +30,7 @@ Two things differ from the lerobot API and are converted here:
 
 import time
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Sequence
 
 import numpy as np
 
@@ -85,6 +85,8 @@ class SO101Arm(BaseArm):
         "wrist_flex",
         "wrist_roll",
     )
+
+    DOF: ClassVar[int] = len(MOTORS)
 
     #: The gripper rides on the same bus and is exported as an end effector.
     GRIPPER: str = "gripper"

--- a/rlinf/robotics/parts/views.py
+++ b/rlinf/robotics/parts/views.py
@@ -125,6 +125,8 @@ class MethodEndEffector(EndEffector):
         close_method: Host method that closes, in binary mode.
         state_index: Optional index or slice selecting the end-effector value
             out of a wider state field.
+        open_field: Host state field that says whether the gripper is open.
+            Without one, :attr:`is_open` keeps the base answer.
     """
 
     def __init__(
@@ -138,6 +140,7 @@ class MethodEndEffector(EndEffector):
         state_index: Optional[Union[int, slice]] = None,
         *,
         is_gripper: bool = False,
+        open_field: Optional[str] = None,
     ) -> None:
         self._host = self._owner = host
         self.state_field = state_field
@@ -147,6 +150,7 @@ class MethodEndEffector(EndEffector):
         self.close_method = close_method
         self.state_index = state_index
         self.is_gripper = is_gripper
+        self.open_field = open_field
 
     @property
     def action_dim(self) -> int:
@@ -185,6 +189,32 @@ class MethodEndEffector(EndEffector):
         opening = bool(target[0] >= 0)
         getattr(self._host, self.open_method if opening else self.close_method)()
         return True
+
+    def open(self, speed: float = 0.3) -> None:
+        """Open fully through the host; the host sets its own speed."""
+        self._host_method(self.open_method)()
+
+    def close(self, speed: float = 0.3, force: float = 130.0) -> None:
+        """Close fully through the host; the host sets its own speed and force."""
+        self._host_method(self.close_method)()
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the host reports the gripper open."""
+        if self.open_field is None:
+            return super().is_open
+        return bool(host_state(self._host)[self.open_field])
+
+    def _host_method(self, name: str) -> Any:
+        """Return a host method, naming the host when it has none."""
+        method = getattr(self._host, name, None)
+        if method is None:
+            raise NotImplementedError(
+                f"{type(self._host).__name__} has no {name}(), so this end "
+                "effector cannot open or close fully. Command it through "
+                "'target' instead."
+            )
+        return method
 
 
 class MethodCamera(Camera):

--- a/rlinf/robotics/pose.py
+++ b/rlinf/robotics/pose.py
@@ -1,0 +1,69 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Quaternion helpers for poses given as ``xyz`` plus an ``xyzw`` quaternion."""
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def normalize(q: ArrayLike) -> np.ndarray:
+    """Return ``q`` scaled to unit length."""
+    q = np.array(q, dtype=float)
+    n = np.linalg.norm(q)
+    if n == 0:
+        raise ValueError("Zero-norm quaternion")
+    return q / n
+
+
+def quat_slerp(q0: ArrayLike, q1: ArrayLike, t: float) -> np.ndarray:
+    """Spherically interpolate between two quaternions."""
+
+    q0 = normalize(q0)
+    q1 = normalize(q1)
+
+    dot = np.dot(q0, q1)
+
+    # Align quaternion hemispheres to follow the shortest path.
+    if dot < 0:
+        q1 = -q1
+        dot = -dot
+
+    dot = np.clip(dot, -1.0, 1.0)
+
+    if np.isscalar(t):
+        t_arr = np.linspace(0, 1, t, dtype=float)
+    else:
+        t_arr = np.array(t, dtype=float)
+
+    results = []
+
+    # Use normalized linear interpolation for nearly identical quaternions.
+    if dot > 0.9995:
+        for tt in t_arr:
+            q = normalize(q0 + tt * (q1 - q0))
+            results.append(q)
+    else:
+        theta_0 = np.arccos(dot)
+        sin_theta_0 = np.sin(theta_0)
+
+        for tt in t_arr:
+            theta = theta_0 * tt
+            s0 = np.sin(theta_0 - theta) / sin_theta_0
+            s1 = np.sin(theta) / sin_theta_0
+            q = s0 * q0 + s1 * q1
+            results.append(q)
+
+    results = np.stack(results)
+    return results

--- a/rlinf/robotics/robot.py
+++ b/rlinf/robotics/robot.py
@@ -14,6 +14,7 @@
 
 """Robot composition and lifecycle management."""
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from .parts.base import PartGroup, RobotPart, RobotPartType
@@ -38,6 +39,35 @@ class Robot(PartGroup):
             f"{cls.__name__} does not implement build(), which only robots "
             "composed from the registry by type name need. Construct "
             f"{cls.__name__}(part=..., ...) directly instead."
+        )
+
+    @classmethod
+    def from_config(
+        cls,
+        config: "RobotConfig",
+        *,
+        cameras: Optional[Mapping[str, Any]] = None,
+        env_idx: int = 0,
+        node_rank: int = 0,
+        worker_rank: int = 0,
+    ) -> "Robot":
+        """Compose an unconnected robot from its registered hardware config.
+
+        This is how an environment gets its robot without knowing which one
+        it is: the config the scheduler hands it names every setting, and the
+        robot class knows which of its build arguments each one feeds.
+
+        Args:
+            config: The hardware config registered for this robot type.
+            cameras: Camera declarations by name, as the policy will see them.
+            env_idx: Index of the environment within its worker.
+            node_rank: Node of the environment using the robot. Parts go
+                there unless the config places them elsewhere.
+            worker_rank: Rank of the environment worker, for worker names.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} does not implement from_config(). Call "
+            f"{cls.__name__}.build(...) with the settings it takes instead."
         )
 
     @classmethod

--- a/rlinf/robotics/robots/franka.py
+++ b/rlinf/robotics/robots/franka.py
@@ -201,6 +201,44 @@ class FrankaRobot(Robot):
             **cls.build_cameras(cameras, node_rank=camera_node_rank),
         )
 
+    @classmethod
+    def from_config(
+        cls,
+        config: "FrankaConfig",
+        *,
+        cameras: Optional[Mapping[str, Any]] = None,
+        env_idx: int = 0,
+        node_rank: int = 0,
+        worker_rank: int = 0,
+    ) -> "FrankaRobot":
+        """Compose a single-arm Franka from a :class:`FrankaConfig`.
+
+        The arm runs on ``config.controller_node_rank`` when it is set, else on
+        ``node_rank``, and the cameras on ``config.camera_node_rank``.
+        """
+        if not isinstance(config, FrankaConfig):
+            raise TypeError(
+                f"{cls.__name__}.from_config() takes a FrankaConfig, got "
+                f"{type(config).__name__}."
+            )
+        controller_node_rank = config.controller_node_rank
+        return cls.build(
+            robot_ip=config.robot_ip,
+            env_idx=env_idx,
+            node_rank=node_rank
+            if controller_node_rank is None
+            else controller_node_rank,
+            worker_rank=worker_rank,
+            backend=config.backend,
+            gripper_type=config.gripper_type,
+            compliance=config.compliance,
+            end_effector_type=config.end_effector_type,
+            end_effector_config=config.end_effector_config,
+            gripper_connection=config.gripper_connection,
+            cameras=cameras,
+            camera_node_rank=config.camera_node_rank,
+        )
+
 
 @dataclass
 class FrankaConfig(RobotConfig):

--- a/rlinf/robotics/robots/gim_arm.py
+++ b/rlinf/robotics/robots/gim_arm.py
@@ -96,6 +96,43 @@ class GimArmRobot(Robot):
             **cls.build_cameras(cameras, node_rank=camera_node_rank),
         )
 
+    @classmethod
+    def from_config(
+        cls,
+        config: "GimArmConfig",
+        *,
+        cameras: Optional[Mapping[str, Any]] = None,
+        env_idx: int = 0,
+        node_rank: int = 0,
+        worker_rank: int = 0,
+        control_mode: str = "momentum_observer",
+    ) -> "GimArmRobot":
+        """Compose a GimArm from a :class:`GimArmConfig`.
+
+        The arm runs on ``config.controller_node_rank`` when it is set, else on
+        ``node_rank``.
+
+        Args:
+            control_mode: SDK control mode the arm starts in: ``"idle"``,
+                ``"gravity_comp"``, ``"momentum_observer"``, ``"position"``,
+                or ``"torque"``. The environment config chooses it, not the
+                hardware config.
+        """
+        controller_node_rank = config.controller_node_rank
+        return cls.build(
+            can_interface=config.can_interface,
+            arm_variant=config.arm_variant,
+            enable_gripper=config.enable_gripper,
+            gripper_type=config.gripper_type,
+            control_mode=control_mode,
+            env_idx=env_idx,
+            node_rank=node_rank
+            if controller_node_rank is None
+            else controller_node_rank,
+            worker_rank=worker_rank,
+            cameras=cameras,
+        )
+
 
 @dataclass
 class GimArmConfig(RobotConfig):

--- a/rlinf/robotics/robots/piper.py
+++ b/rlinf/robotics/robots/piper.py
@@ -120,6 +120,40 @@ class PiperRobot(Robot):
             **cls.build_cameras(cameras, node_rank=camera_node_rank),
         )
 
+    @classmethod
+    def from_config(
+        cls,
+        config: "PiperConfig",
+        *,
+        cameras: Optional[Mapping[str, Any]] = None,
+        env_idx: int = 0,
+        node_rank: int = 0,
+        worker_rank: int = 0,
+    ) -> "PiperRobot":
+        """Compose a Piper from a :class:`PiperConfig`.
+
+        The arm runs on ``config.controller_node_rank`` when it is set, else on
+        ``node_rank``.
+        """
+        controller_node_rank = config.controller_node_rank
+        return cls.build(
+            can_channel=config.can_channel,
+            backend=config.backend,
+            can_interface=config.can_interface,
+            model=config.model,
+            firmware=config.firmware,
+            speed_percent=config.speed_percent,
+            gripper_force=config.gripper_force,
+            gripper_max_width=config.gripper_max_width,
+            with_gripper=config.with_gripper,
+            env_idx=env_idx,
+            node_rank=node_rank
+            if controller_node_rank is None
+            else controller_node_rank,
+            worker_rank=worker_rank,
+            cameras=cameras,
+        )
+
 
 @dataclass
 class PiperConfig(RobotConfig):

--- a/rlinf/robotics/robots/so101.py
+++ b/rlinf/robotics/robots/so101.py
@@ -92,6 +92,34 @@ class SO101Robot(Robot):
             **cls.build_cameras(cameras, node_rank=camera_node_rank),
         )
 
+    @classmethod
+    def from_config(
+        cls,
+        config: "SO101Config",
+        *,
+        cameras: Optional[Mapping[str, Any]] = None,
+        env_idx: int = 0,
+        node_rank: int = 0,
+        worker_rank: int = 0,
+    ) -> "SO101Robot":
+        """Compose an SO-101 from a :class:`SO101Config`.
+
+        The arm runs on ``config.controller_node_rank`` when it is set, else on
+        ``node_rank``.
+        """
+        controller_node_rank = config.controller_node_rank
+        return cls.build(
+            port=config.serial_port,
+            calibration_id=config.calibration_id,
+            max_relative_target=config.max_relative_target,
+            env_idx=env_idx,
+            node_rank=node_rank
+            if controller_node_rank is None
+            else controller_node_rank,
+            worker_rank=worker_rank,
+            cameras=cameras,
+        )
+
 
 @dataclass
 class SO101Config(RobotConfig):

--- a/tests/robot_mocks/sdks.py
+++ b/tests/robot_mocks/sdks.py
@@ -100,6 +100,8 @@ def gim_arm() -> dict[str, types.ModuleType]:
             self.started = False
             self.mode = None
             self.targets: list[Any] = []
+            # The gripper goes where it was last sent, as a real one settles.
+            self.gripper_position = self.gripper_open_position
 
         def start(self, return_to_zero=False):
             self.started = True
@@ -115,13 +117,18 @@ def gim_arm() -> dict[str, types.ModuleType]:
             return ARM_DOF
 
         def get_reading(self):
-            return Reading() if self.started else None
+            if not self.started:
+                return None
+            reading = Reading()
+            reading.gripper_position = self.gripper_position
+            return reading
 
         def set_feedforward_target(self, target, dq, ddq):
             self.targets.append((target, dq, ddq))
 
         def set_gripper(self, position):
             self.targets.append(("gripper", position))
+            self.gripper_position = position
 
     class ButterworthFilter:
         def __init__(self, _cutoff, _dt, dof):

--- a/tests/unit_tests/test_real_env.py
+++ b/tests/unit_tests/test_real_env.py
@@ -304,6 +304,60 @@ def test_a_franka_observation_comes_from_one_snapshot():
     )
 
 
+def test_franka_step_moves_the_arm_by_the_scaled_clipped_delta(monkeypatch):
+    """One action is one Cartesian target: scaled, clipped, sent once.
+
+    The fake arm reports the identity pose at the origin, so the target is the
+    scaled delta itself until the safety box clips it.
+    """
+    from robot_mocks import mocked_sdks
+    from robot_mocks.cameras import SERIAL
+    from scipy.spatial.transform import Rotation as R
+
+    with mocked_sdks():
+        env = FrankaEnv(
+            override_cfg={
+                "enable_camera_player": False,
+                "step_frequency": 10000.0,
+                "action_scale": [0.02, 0.1, 1.0],
+                "ee_pose_limit_min": [-0.05, -0.05, 0.0, -0.1, -0.1, -0.5],
+                "ee_pose_limit_max": [0.05, 0.05, 0.01, 0.1, 0.1, 0.5],
+            },
+            worker_info=None,
+            env_idx=0,
+            robot_info=_robot_info(
+                FrankaConfig(
+                    node_rank=0,
+                    robot_ip="0.0.0.0",
+                    camera_serials=[SERIAL],
+                    disable_validate=True,
+                )
+            ),
+        )
+        try:
+            env.reset()
+            sent = []
+            send = env.robot.send_action
+            monkeypatch.setattr(
+                env.robot,
+                "send_action",
+                lambda action: sent.append(action) or send(action),
+            )
+
+            # Full scale on every axis, gripper untouched.
+            env.step(np.array([1.0, -1.0, 1.0, 0.0, 0.0, 1.0, 0.0]))
+
+            assert len(sent) == 1
+            target = sent[0]["arm"]["tcp_pose"]
+            assert target.dtype == np.float32
+            # x and y move by the scaled delta; z is clipped to the box's top.
+            np.testing.assert_allclose(target[:3], [0.02, -0.02, 0.01], atol=1e-6)
+            yaw = R.from_quat(target[3:]).as_euler("xyz")[2]
+            assert yaw == pytest.approx(0.1, abs=1e-6)
+        finally:
+            env.close()
+
+
 def test_franka_depth_reaches_the_observation_only_when_asked_for():
     """A rig without a depth camera keeps the schema a policy already reads.
 
@@ -3225,6 +3279,429 @@ def test_task_schema_uses_enumerated_hardware_without_changing_it(
             if robot_type == "Piper":
                 assert info.model == "Piper"
                 assert info.config.model == "piper_h"
+        finally:
+            env.close()
+
+
+#: Hardware each task below is built on, by name in ``TASK_SCHEMAS``.
+SCHEMA_HARDWARE = {
+    "Franka": ("Franka", {"camera_serials": ["MOCK0001"]}),
+    "FrankaHand": (
+        "Franka",
+        {"camera_serials": ["MOCK0001"], "end_effector_type": "ruiyan_hand"},
+    ),
+    "DualFranka": (
+        "DualFranka",
+        {
+            "base_camera_serials": ["MOCK0001"],
+            "left_camera_serials": ["MOCK0002"],
+            "right_camera_serials": [],
+        },
+    ),
+    "SO101": (
+        "SO101",
+        {
+            "serial_port": "/dev/bench",
+            "calibration_id": "bench",
+            "camera_serials": ["MOCK0001"],
+        },
+    ),
+    "Piper": ("Piper", {"camera_serials": ["MOCK0001"]}),
+    "GimArm": ("GimArm", {"camera_serials": ["MOCK0001"]}),
+    "DOSW1": ("DOSW1", {"robot_url": "bench", "camera_serials": ["MOCK0001"]}),
+    "Turtle2": ("Turtle2", {"camera_ids": [0]}),
+}
+
+#: What a policy sees for every registered task, through the default wrapper
+#: stack: action width and bounds (one number when every element shares it),
+#: action parts, state widths, frame sizes, and the teleop devices and wrappers
+#: the env declares. A policy is trained against exactly this, so a row changes
+#: only for a behaviour change named in the commit that makes it.
+TASK_SCHEMAS = {
+    "FrankaEnv-v1": (
+        "Franka",
+        {
+            "action": (6, -1.0, 1.0),
+            "parts": (("arm", 6, "CARTESIAN_DELTA"),),
+            "state": {
+                "gripper_position": 1,
+                "tcp_force": 3,
+                "tcp_pose": 6,
+                "tcp_torque": 3,
+                "tcp_vel": 6,
+            },
+            "frames": {"wrist_1": 128},
+            "teleop": (("spacemouse", "gello", "glove", "pico"), "spacemouse"),
+            "wrappers": (("GripperCloseEnv",), ("RelativeFrame", "Quat2EulerWrapper")),
+        },
+    ),
+    "PegInsertionEnv-v1": (
+        "Franka",
+        {
+            "action": (6, -1.0, 1.0),
+            "parts": (("arm", 6, "CARTESIAN_DELTA"),),
+            "state": {
+                "gripper_position": 1,
+                "tcp_force": 3,
+                "tcp_pose": 6,
+                "tcp_torque": 3,
+                "tcp_vel": 6,
+            },
+            "frames": {"wrist_1": 128},
+            "teleop": (("spacemouse", "gello", "glove", "pico"), "spacemouse"),
+            "wrappers": (("GripperCloseEnv",), ("RelativeFrame", "Quat2EulerWrapper")),
+        },
+    ),
+    "FrankaBinRelocationEnv-v1": (
+        "Franka",
+        {
+            "action": (6, -1.0, 1.0),
+            "parts": (("arm", 6, "CARTESIAN_DELTA"),),
+            "state": {
+                "gripper_position": 1,
+                "tcp_force": 3,
+                "tcp_pose": 6,
+                "tcp_torque": 3,
+                "tcp_vel": 6,
+            },
+            "frames": {"wrist_1": 128},
+            "teleop": (("spacemouse", "gello", "glove", "pico"), "spacemouse"),
+            "wrappers": (("GripperCloseEnv",), ("RelativeFrame", "Quat2EulerWrapper")),
+        },
+    ),
+    "BottleEnv-v1": (
+        "Franka",
+        {
+            "action": (6, -1.0, 1.0),
+            "parts": (("arm", 6, "CARTESIAN_DELTA"),),
+            "state": {
+                "gripper_position": 1,
+                "tcp_force": 3,
+                "tcp_pose": 6,
+                "tcp_torque": 3,
+                "tcp_vel": 6,
+            },
+            "frames": {"wrist_1": 128},
+            "teleop": (("spacemouse", "gello", "glove", "pico"), "spacemouse"),
+            "wrappers": (("GripperCloseEnv",), ("RelativeFrame", "Quat2EulerWrapper")),
+        },
+    ),
+    "DexpnpEnv-v1": (
+        "FrankaHand",
+        {
+            "action": (12, -1.0, 1.0),
+            "parts": (("arm", 6, "CARTESIAN_DELTA"), ("hand", 6, "HAND")),
+            "state": {
+                "hand_position": 6,
+                "tcp_force": 3,
+                "tcp_pose": 6,
+                "tcp_torque": 3,
+                "tcp_vel": 6,
+            },
+            "frames": {"wrist_1": 128},
+            "teleop": (("spacemouse", "gello", "glove", "pico"), "spacemouse"),
+            "wrappers": (("GripperCloseEnv",), ("RelativeFrame", "Quat2EulerWrapper")),
+        },
+    ),
+    "DualFrankaJointEnv-v1": (
+        "DualFranka",
+        {
+            "action": (
+                16,
+                (
+                    -2.8973,
+                    -1.7628,
+                    -2.8973,
+                    -3.0718,
+                    -2.8973,
+                    -0.0175,
+                    -2.8973,
+                    -1.0,
+                    -2.8973,
+                    -1.7628,
+                    -2.8973,
+                    -3.0718,
+                    -2.8973,
+                    -0.0175,
+                    -2.8973,
+                    -1.0,
+                ),
+                (
+                    2.8973,
+                    1.7628,
+                    2.8973,
+                    -0.0698,
+                    2.8973,
+                    3.7525,
+                    2.8973,
+                    1.0,
+                    2.8973,
+                    1.7628,
+                    2.8973,
+                    -0.0698,
+                    2.8973,
+                    3.7525,
+                    2.8973,
+                    1.0,
+                ),
+            ),
+            "parts": (
+                ("left.arm", 7, "JOINT_POSITION"),
+                ("left.end_effector", 1, "GRIPPER"),
+                ("right.arm", 7, "JOINT_POSITION"),
+                ("right.end_effector", 1, "GRIPPER"),
+            ),
+            "state": {
+                "gripper_position": 2,
+                "joint_position": 14,
+                "joint_velocity": 14,
+                "tcp_force": 6,
+                "tcp_pose": 14,
+                "tcp_torque": 6,
+                "tcp_vel": 12,
+            },
+            "frames": {"base_0_rgb": 224, "left_wrist_0_rgb": 224},
+            "teleop": (("gello_joint", "pico"), "none"),
+            "wrappers": ((), ()),
+        },
+    ),
+    "DualFrankaTCPEnv-v1": (
+        "DualFranka",
+        {
+            "action": (
+                20,
+                (
+                    -np.inf,
+                    -np.inf,
+                    -np.inf,
+                    -1.5,
+                    -1.5,
+                    -1.5,
+                    -1.5,
+                    -1.5,
+                    -1.5,
+                    -1.0,
+                    -np.inf,
+                    -np.inf,
+                    -np.inf,
+                    -1.5,
+                    -1.5,
+                    -1.5,
+                    -1.5,
+                    -1.5,
+                    -1.5,
+                    -1.0,
+                ),
+                (
+                    np.inf,
+                    np.inf,
+                    np.inf,
+                    1.5,
+                    1.5,
+                    1.5,
+                    1.5,
+                    1.5,
+                    1.5,
+                    1.0,
+                    np.inf,
+                    np.inf,
+                    np.inf,
+                    1.5,
+                    1.5,
+                    1.5,
+                    1.5,
+                    1.5,
+                    1.5,
+                    1.0,
+                ),
+            ),
+            "parts": (
+                ("left.arm", 9, "CARTESIAN_POSE"),
+                ("left.end_effector", 1, "GRIPPER"),
+                ("right.arm", 9, "CARTESIAN_POSE"),
+                ("right.end_effector", 1, "GRIPPER"),
+            ),
+            "state": {"gripper_position": 2, "tcp_pose_rot6d": 18},
+            "frames": {"base_0_rgb": 224, "left_wrist_0_rgb": 224},
+            "teleop": (("gello_joint", "pico"), "none"),
+            "wrappers": ((), ()),
+        },
+    ),
+    "SO101ReachEnv-v1": (
+        "SO101",
+        {
+            "action": (
+                6,
+                (-1.91, -1.75, -1.69, -1.66, -2.79, 0.0),
+                (1.91, 1.75, 1.69, 1.66, 2.79, 1.0),
+            ),
+            "parts": (("arm", 5, "JOINT_POSITION"), ("end_effector", 1, "GRIPPER")),
+            "state": {"arm_joint_position": 5, "gripper_position": 1},
+            "frames": {"wrist_1": 128},
+            "teleop": (("so101_leader",), "none"),
+            "wrappers": ((), ()),
+        },
+    ),
+    "PiperReachEnv-v1": (
+        "Piper",
+        {
+            "action": (
+                7,
+                (-2.618, 0.0, -2.9671, -1.7453, -1.2217, -2.0944, 0.0),
+                (2.618, 3.1416, 0.0, 1.7453, 1.2217, 2.0944, 1.0),
+            ),
+            "parts": (("arm", 6, "JOINT_POSITION"), ("end_effector", 1, "GRIPPER")),
+            "state": {"arm_joint_position": 6, "gripper_position": 1, "tcp_pose": 7},
+            "frames": {"wrist_1": 128},
+            "teleop": ((), "none"),
+            "wrappers": ((), ()),
+        },
+    ),
+    "GimArmPegInsertionEnv-v1": (
+        "GimArm",
+        {
+            "action": (
+                7,
+                (-1.4, -3.0, 0.0, -1.5, -1.5, -1.88, -1.0),
+                (1.4, 0.0, 3.0, 1.5, 1.5, 1.9, 1.0),
+            ),
+            "parts": (("arm", 6, "JOINT_POSITION"), ("end_effector", 1, "GRIPPER")),
+            "state": {
+                "arm_joint_position": 6,
+                "gripper_position": 1,
+                "tcp_force": 3,
+                "tcp_pose": 7,
+                "tcp_torque": 3,
+                "tcp_vel": 6,
+            },
+            "frames": {"wrist_1": 128},
+            "teleop": ((), "none"),
+            "wrappers": ((), ()),
+        },
+    ),
+    "DOSW1PickEnv-v1": (
+        "DOSW1",
+        {
+            "action": (
+                14,
+                (
+                    -3.1416,
+                    -3.1416,
+                    -3.1416,
+                    -3.1416,
+                    -3.1416,
+                    -3.1416,
+                    0.0,
+                    -3.1416,
+                    -3.1416,
+                    -3.1416,
+                    -3.1416,
+                    -3.1416,
+                    -3.1416,
+                    0.0,
+                ),
+                (
+                    3.1416,
+                    3.1416,
+                    3.1416,
+                    3.1416,
+                    3.1416,
+                    3.1416,
+                    0.07,
+                    3.1416,
+                    3.1416,
+                    3.1416,
+                    3.1416,
+                    3.1416,
+                    3.1416,
+                    0.07,
+                ),
+            ),
+            "parts": (
+                ("left.arm", 6, "JOINT_POSITION"),
+                ("left.end_effector", 1, "GRIPPER"),
+                ("right.arm", 6, "JOINT_POSITION"),
+                ("right.end_effector", 1, "GRIPPER"),
+            ),
+            "state": {
+                "left_gripper": 1,
+                "left_joint_positions": 6,
+                "right_gripper": 1,
+                "right_joint_positions": 6,
+            },
+            "frames": {"cam_front": 128},
+            "teleop": ((), "none"),
+            "wrappers": ((), ()),
+        },
+    ),
+    "ButtonEnv-v1": (
+        "Turtle2",
+        {
+            "action": (6, -1.0, 1.0),
+            "parts": (("arm", 6, "CARTESIAN_DELTA"),),
+            "state": {"tcp_pose": 6},
+            "frames": {"wrist_1": 128},
+            "teleop": (("spacemouse", "gello", "pico"), "spacemouse"),
+            "wrappers": (("GripperCloseEnv",), ("RelativeFrame", "Quat2EulerWrapper")),
+        },
+    ),
+}
+
+
+def _policy_schema(env) -> dict:
+    """Read the schema a policy sees off a built env, in ``TASK_SCHEMAS`` form."""
+
+    def bound(values):
+        values = [round(float(x), 4) for x in np.asarray(values).reshape(-1)]
+        return values[0] if len(set(values)) == 1 else tuple(values)
+
+    inner, observation, action = env.unwrapped, env.observation_space, env.action_space
+    frames = observation.spaces.get("frames", gym.spaces.Dict())
+    assert action.dtype == np.float32
+    assert all(space.dtype == np.float32 for space in observation["state"].values())
+    assert all(space.dtype == np.uint8 for space in frames.values())
+    return {
+        "action": (action.shape[0], bound(action.low), bound(action.high)),
+        "parts": tuple(
+            (part.name, part.width, part.kind.name)
+            for part in env.get_wrapper_attr("action_parts")()
+        ),
+        "state": {
+            key: space.shape[0] for key, space in sorted(observation["state"].items())
+        },
+        "frames": {key: space.shape[0] for key, space in sorted(frames.items())},
+        "teleop": (tuple(inner.TELEOP), inner.TELEOP_DEFAULT),
+        "wrappers": (tuple(inner.ACTION_WRAPPERS), tuple(inner.TRANSFORMS)),
+    }
+
+
+@pytest.mark.parametrize("env_id", sorted(TASK_SCHEMAS))
+def test_a_task_keeps_the_schema_its_policies_were_trained_on(env_id):
+    from robot_mocks import mocked_sdks
+
+    hardware_name, expected = TASK_SCHEMAS[env_id]
+    robot_type, hardware = SCHEMA_HARDWARE[hardware_name]
+    load_tasks()
+    registration = RobotDiscovery.registry[robot_type]
+    config = registration.config_cls(node_rank=0, **hardware)
+    override_cfg = {"is_dummy": True}
+    if robot_type != "Turtle2":
+        override_cfg["enable_camera_player"] = False
+    env_cfg = {"teleop": "none"}
+    if robot_type == "DualFranka":
+        env_cfg["no_gripper"] = False
+    with mocked_sdks():
+        info = registration.discovery_cls.enumerate(0, [config]).infos[0]
+        env = gym.make(
+            env_id,
+            override_cfg=override_cfg,
+            worker_info=None,
+            robot_info=info,
+            env_idx=0,
+            env_cfg=env_cfg,
+        )
+        try:
+            assert _policy_schema(env) == expected
         finally:
             env.close()
 

--- a/tests/unit_tests/test_robotics.py
+++ b/tests/unit_tests/test_robotics.py
@@ -4818,6 +4818,221 @@ def test_an_arm_that_cannot_reset_its_joints_says_so():
     arm.disconnect()
 
 
+class _PoseArm(Arm):
+    """An arm that goes wherever it is sent and reports where it is."""
+
+    def __init__(self, pose: np.ndarray, commands: tuple[str, ...]) -> None:
+        self.pose = np.asarray(pose, dtype=float)
+        self.commands = commands
+        self.events: list[Any] = []
+
+    @property
+    def observation_features(self) -> dict[str, dict]:
+        return {"tcp_pose": {}}
+
+    @property
+    def action_features(self) -> dict[str, dict]:
+        return {name: {} for name in self.commands}
+
+    def _open(self) -> Any:
+        return "device"
+
+    def get_observation(self) -> dict[str, np.ndarray]:
+        return {"tcp_pose": self.pose.copy()}
+
+    def send_action(self, action: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        self.events.append(("send", action["tcp_pose"]))
+        self.pose = np.asarray(action["tcp_pose"], dtype=float)
+        return action
+
+    def clear_errors(self) -> None:
+        self.events.append("clear")
+
+
+def test_an_arm_moves_to_a_pose_through_evenly_spaced_commands(monkeypatch):
+    start = np.array([0.4, 0.0, 0.3, 0.0, 0.0, 0.0, 1.0])
+    target = np.concatenate(
+        [[0.5, 0.2, 0.1], R.from_euler("z", 90, degrees=True).as_quat()]
+    )
+    arm = _PoseArm(start, commands=("tcp_pose",))
+    sleeps: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    arm.move_to(target, duration=1.0, rate_hz=4.0, clear_errors=True)
+
+    # One command per period, each preceded by a fault clear when asked for.
+    assert [event if event == "clear" else event[0] for event in arm.events] == [
+        "clear",
+        "send",
+    ] * 4
+    sent = [event[1] for event in arm.events if event != "clear"]
+    assert sleeps == [0.25] * 4
+    assert all(command.dtype == np.float32 for command in sent)
+    np.testing.assert_allclose(sent[-1], target, atol=1e-6)
+    # A quarter of the way: position on the straight line, rotation a quarter
+    # of the arc. Averaging the quaternions instead would turn 21.6 degrees.
+    np.testing.assert_allclose(sent[0][:3], start[:3] + 0.25 * (target[:3] - start[:3]))
+    yaw = R.from_quat(sent[0][3:]).as_euler("xyz", degrees=True)[2]
+    assert yaw == pytest.approx(22.5, abs=1e-3)
+
+
+def test_an_arm_that_takes_no_pose_commands_refuses_to_move_to_a_pose():
+    arm = _PoseArm(np.array([0.4, 0.0, 0.3, 0.0, 0.0, 0.0, 1.0]), ("joint_position",))
+
+    with pytest.raises(NotImplementedError, match="does not accept 'tcp_pose'"):
+        arm.move_to(np.array([0.5, 0.0, 0.3, 0.0, 0.0, 0.0, 1.0]))
+    assert arm.events == []
+
+
+def test_an_arm_declares_how_many_joints_it_drives():
+    from robot_mocks import mocked_sdks
+
+    with mocked_sdks():
+        backends = Arm.backends()
+    # Known before anything connects, so a dummy run can check a target's width.
+    assert {
+        name: backends[name].DOF
+        for name in ("franky", "franka_ros", "pyagxarm", "so101", "gim_arm")
+    } == {"franky": 7, "franka_ros": 7, "pyagxarm": 6, "so101": 5, "gim_arm": 6}
+
+
+def test_a_hosted_gripper_opens_closes_and_says_which_it_is():
+    from robot_mocks import mocked_sdks
+
+    with mocked_sdks():
+        arm = GimArm("can0", "gim_arm_xl", True, "parallel")
+        arm.connect()
+        try:
+            gripper = arm.child("end_effector", EndEffector)
+            gripper.close()
+            assert not gripper.is_open
+            gripper.open()
+            assert gripper.is_open
+        finally:
+            arm.disconnect()
+
+    # A host with no way to open fully says so, rather than doing nothing.
+    host = SimpleNamespace(get_state=lambda: {"width": np.array([0.02])})
+    gripper = MethodEndEffector(host, "width", command="set_width", is_gripper=True)
+    with pytest.raises(NotImplementedError, match="no open_gripper"):
+        gripper.open()
+
+
+def _from_config_cases() -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+    """Each robot's config, with the build arguments the envs gave it by hand."""
+    from rlinf.robotics.parts.arms.base import CartesianCompliance
+
+    return [
+        (
+            "Franka",
+            {
+                "robot_ip": "10.0.0.2",
+                "backend": "franky",
+                "camera_node_rank": 5,
+                "gripper_type": "robotiq",
+                "gripper_connection": "/dev/gripper",
+                "end_effector_config": {"port": "/dev/hand"},
+            },
+            {
+                "robot_ip": "10.0.0.2",
+                "backend": "franky",
+                "gripper_type": "robotiq",
+                "compliance": CartesianCompliance(),
+                "end_effector_type": None,
+                "end_effector_config": {"port": "/dev/hand"},
+                "gripper_connection": "/dev/gripper",
+                "camera_node_rank": 5,
+            },
+        ),
+        (
+            "Piper",
+            {"can_channel": "can1", "model": "piper_h", "with_gripper": False},
+            {
+                "can_channel": "can1",
+                "backend": None,
+                "can_interface": "socketcan",
+                "model": "piper_h",
+                "firmware": None,
+                "speed_percent": 30,
+                "gripper_force": 1.0,
+                "gripper_max_width": 0.07,
+                "with_gripper": False,
+            },
+        ),
+        (
+            "SO101",
+            {"serial_port": "/dev/bench", "calibration_id": "bench"},
+            {
+                "port": "/dev/bench",
+                "calibration_id": "bench",
+                "max_relative_target": None,
+            },
+        ),
+        (
+            "GimArm",
+            {"arm_variant": "gim_arm", "enable_gripper": False},
+            {
+                "can_interface": "can0",
+                "arm_variant": "gim_arm",
+                "enable_gripper": False,
+                "gripper_type": "parallel",
+                "control_mode": "momentum_observer",
+            },
+        ),
+    ]
+
+
+@pytest.mark.parametrize("controller_node_rank", [None, 7])
+@pytest.mark.parametrize("robot_type,settings,expected", _from_config_cases())
+def test_a_robot_is_built_from_the_config_the_scheduler_hands_out(
+    monkeypatch, robot_type, settings, expected, controller_node_rank
+):
+    import pickle
+
+    from rlinf.robotics.discovery import RobotDiscovery
+
+    registration = RobotDiscovery.registry[robot_type]
+    robot_cls = registration.robot_cls
+    config = registration.config_cls(
+        node_rank=3, controller_node_rank=controller_node_rank, **settings
+    )
+    before = pickle.dumps(config)
+    calls: list[dict[str, Any]] = []
+    build = robot_cls.build
+    monkeypatch.setattr(
+        robot_cls,
+        "build",
+        classmethod(lambda cls, **kwargs: calls.append(kwargs) or build(**kwargs)),
+    )
+    from rlinf.robotics.parts.cameras import CameraInfo
+
+    cameras = {"wrist_1": CameraInfo(name="wrist_1", serial_number="MOCK0001")}
+
+    robot = robot_cls.from_config(
+        config, cameras=cameras, env_idx=4, node_rank=3, worker_rank=2
+    )
+
+    assert isinstance(robot, robot_cls)
+    assert calls == [
+        {
+            **expected,
+            "env_idx": 4,
+            # The arm follows the env to its node unless the config places it.
+            "node_rank": 3 if controller_node_rank is None else 7,
+            "worker_rank": 2,
+            "cameras": cameras,
+        }
+    ]
+    assert pickle.dumps(config) == before
+
+
+def test_a_single_arm_franka_refuses_a_dual_arm_config():
+    from rlinf.robotics import DualFrankaConfig
+
+    with pytest.raises(TypeError, match="takes a FrankaConfig"):
+        FrankaRobot.from_config(DualFrankaConfig(node_rank=0))
+
+
 def test_so101_reports_joints_in_radians_and_the_gripper_as_a_fraction():
     """lerobot speaks degrees and 0..100; every other arm here speaks radians."""
     from robot_mocks import mocked_sdks


### PR DESCRIPTION
### Description

Adds the robot-layer operations a robot-independent task will need, moves each real-world env's config-to-robot mapping onto its robot class, and pins the schema every registered task shows its policy.

- `Arm.move_to(pose, duration=, rate_hz=, clear_errors=)` travels to a tool pose through evenly spaced `tcp_pose` commands (linear position, slerp rotation). It is `FrankaEnv._interpolate_move` moved onto the arm, so a remotely hosted arm now runs the whole move on its own node.
- `Arm.DOF` states the joint count before anything connects: Franka 7, Piper 6, SO-101 5, GimArm 6.
- `MethodEndEffector.open()` / `close()` go through the host, and `is_open` reads a host state field when one is named. GimArm's gripper used to report open whatever it held.
- `Robot.from_config(config, cameras=, env_idx=, node_rank=, worker_rank=)` on Franka, Piper, SO-101 and GimArm replaces the mapping each env wrote by hand in `_setup_hardware`.
- `normalize` and `quat_slerp` move from `rlinf.envs.real.utils.pose` to `rlinf.robotics.pose`, so the robot layer does not import from `envs`.
- `realworld_gim_arm_peg_insertion.yaml` gets back the `env_type: real` line #1481 dropped; without it the GimArm mock e2e stopped at config validation.
- Docs (EN and ZH): `concepts/robotics.rst` covers the new arm and gripper operations; `extending/new_robot.rst` shows `from_config()` where it used to tell readers to write that translation in shared setup code.

### Motivation and Context

First of the steps that let a real-world task (peg insertion, bin relocation, reach) run on any robot meeting its requirements instead of subclassing one robot's env. Later steps move each env onto a shared task env; the schema table added here is what they must leave unchanged, row by row, unless a change is named.

The one behaviour difference: `FrankaEnv` no longer reads its cameras before an interpolated move, only the arm. The read after the move is unchanged.

### How has this been tested?

- `pytest tests/unit_tests/test_robotics.py`: 282 passed. New: `move_to` command count, pacing, endpoint and slerp quarter-point; refusal on joint-only arms; `DOF`; gripper open/close/`is_open` on the GimArm driver against its fake SDK; `from_config` forwarding for all four robots with and without `controller_node_rank`.
- `pytest tests/unit_tests/test_real_env.py`: 225 passed. New: `test_a_task_keeps_the_schema_its_policies_were_trained_on` for all 12 registered ids, generated from `main` and compared equal to this branch; `test_franka_step_moves_the_arm_by_the_scaled_clipped_delta` on fakes.
- Each new test was checked against a one-line mutation that breaks it (no fault clear, nlerp instead of slerp, dropped config field, wrong controller node, no `open_field`, no `Quat2EulerWrapper`, no clip, no scale).
- Mock e2e: `realworld_mock_sac_cnn`, `piper_mock_sac_mlp_reach`, `so101_mock_sac_mlp_reach`, `gim_arm_mock_sac_cnn` all reach step 2/2.
- `build_docs.py`: EN and ZH build with 0 warnings. `pre-commit run` clean.

### Additional information (optional, e.g., figures and logs):

The GimArm mock e2e job has been green on `main` without training anything: `Cluster._shutdown_ray_at_exit` calls `os._exit(0)` at exit unless `sys.excepthook` saw a failure, and Hydra catches the exception and calls `sys.exit(1)` before the hook can see it. That masking is left for a separate PR because fixing it may turn other jobs red.

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
