### PR TITLE
fix(config): enforce group_size>1 for the ReinForce++ baseline

### DIFF
--- a/rlinf/config.py
+++ b/rlinf/config.py
@@ -1518,6 +1518,29 @@ def validate_coding_online_rl_cfg(cfg: DictConfig) -> DictConfig:
     return cfg
 
 
+def adv_requires_group_baseline(
+    adv_type: str, use_reinpp_baseline: bool = False
+) -> bool:
+    """Whether an advantage estimator draws its baseline from within-group
+    statistics and therefore requires ``algorithm.group_size > 1``.
+
+    GRPO and GRPO-dynamic always normalize each reward against its group, so a
+    group of one leaves nothing to compare against. ReinForce++ only subtracts a
+    per-group mean when its baseline mode is enabled (``use_reinpp_baseline``);
+    plain ReinForce++ normalizes over the whole batch and is exempt.
+
+    ``adv_type`` is lower-cased to match how :func:`get_adv_and_returns`
+    dispatches, so a differently-cased name cannot slip past the guard and still
+    reach the group-based estimator.
+    """
+    adv_type = adv_type.lower()
+    if adv_type in ("grpo", "grpo_dynamic"):
+        return True
+    if adv_type == "reinpp":
+        return bool(use_reinpp_baseline)
+    return False
+
+
 def validate_cfg(cfg: DictConfig) -> DictConfig:
     OmegaConf.set_struct(cfg, True)
 
@@ -1583,8 +1606,15 @@ def validate_cfg(cfg: DictConfig) -> DictConfig:
         cfg = validate_offline_cfg(cfg)
 
     if cfg.runner.task_type != "sft" and not cfg.runner.get("only_eval", False):
-        if cfg.algorithm.adv_type in ("grpo", "grpo_dynamic", "reinpp_baseline"):
-            assert cfg.algorithm.group_size > 1
+        if adv_requires_group_baseline(
+            cfg.algorithm.adv_type,
+            cfg.algorithm.get("use_reinpp_baseline", False),
+        ):
+            assert cfg.algorithm.group_size > 1, (
+                f"algorithm.adv_type={cfg.algorithm.adv_type!r} uses a "
+                f"within-group baseline and requires algorithm.group_size > 1, "
+                f"got {cfg.algorithm.group_size}."
+            )
 
     assert cfg.actor.training_backend in SUPPORTED_TRAINING_BACKENDS, (
         f"Unsupported training_backend {cfg.actor.training_backend}. Supported training backends are {SUPPORTED_TRAINING_BACKENDS}."

--- a/tests/unit_tests/test_config_adv_group_baseline.py
+++ b/tests/unit_tests/test_config_adv_group_baseline.py
@@ -1,0 +1,57 @@
+# Copyright 2025 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Which advantage estimators require ``algorithm.group_size > 1``.
+
+The group-baseline guard in ``validate_cfg`` used to test for a
+``reinpp_baseline`` ``adv_type`` that is never produced (ReinForce++ registers as
+``reinpp`` and toggles its baseline through the separate ``use_reinpp_baseline``
+flag), so the check silently never fired for the ReinForce++ baseline.
+"""
+
+import pytest
+
+from rlinf.config import adv_requires_group_baseline
+
+
+@pytest.mark.parametrize("adv_type", ["grpo", "grpo_dynamic"])
+def test_grpo_variants_always_require_a_group(adv_type):
+    # These normalize every reward against its group regardless of any flag.
+    assert adv_requires_group_baseline(adv_type)
+    assert adv_requires_group_baseline(adv_type, use_reinpp_baseline=False)
+
+
+@pytest.mark.parametrize("adv_type", ["GRPO", "Grpo_Dynamic", "ReinPP"])
+def test_guard_matches_case_insensitive_dispatch(adv_type):
+    # get_adv_and_returns dispatches on adv_type.lower(); the guard must too, or
+    # a differently-cased name skips the check yet still runs the estimator.
+    assert adv_requires_group_baseline(adv_type, use_reinpp_baseline=True)
+
+
+def test_reinpp_requires_a_group_only_in_baseline_mode():
+    # The bug: this case was never guarded, so reinpp + baseline + group_size=1
+    # silently subtracted each reward from itself and zeroed every advantage.
+    assert adv_requires_group_baseline("reinpp", use_reinpp_baseline=True)
+    # Plain ReinForce++ normalizes over the whole batch; a group of one is fine.
+    assert not adv_requires_group_baseline("reinpp", use_reinpp_baseline=False)
+    assert not adv_requires_group_baseline("reinpp")
+
+
+@pytest.mark.parametrize("adv_type", ["gae", "raw", "opd"])
+def test_non_group_adv_types_are_exempt(adv_type):
+    # Exempt even if a stray baseline flag is set: the flag only applies to reinpp.
+    # (grpo_video is deliberately not asserted here: its group requirement is
+    # advantage_mode-dependent and left to a separate change.)
+    assert not adv_requires_group_baseline(adv_type)
+    assert not adv_requires_group_baseline(adv_type, use_reinpp_baseline=True)


### PR DESCRIPTION
### Description

Fix the group-baseline guard in `validate_cfg` so it actually fires for the ReinForce++ baseline.

- Replace the dead `adv_type == "reinpp_baseline"` check (a value no code ever produces) with a helper `adv_requires_group_baseline(adv_type, use_reinpp_baseline)`.
- The helper returns `True` for `grpo`, `grpo_dynamic`, and `reinpp` **when** `use_reinpp_baseline` is set, and lower-cases `adv_type` to match `get_adv_and_returns`' case-insensitive dispatch.
- Give the `group_size > 1` assertion an explanatory message.

### Motivation and Context

`validate_cfg` guards group-based advantage estimators with `assert group_size > 1`, but it tested `cfg.algorithm.adv_type in ("grpo", "grpo_dynamic", "reinpp_baseline")`. `reinpp_baseline` is never a produced `adv_type`: ReinForce++ registers as `reinpp` (`rlinf/algorithms/advantages.py:302`) and selects its baseline through the separate boolean `use_reinpp_baseline`. The guard therefore never fired for the ReinForce++ baseline.

The consequence is a silent failure, not an error. With `adv_type: reinpp`, `use_reinpp_baseline: true`, `group_size: 1`, config validation passes and `compute_reinpp_advantages` runs `grouped_rewards -= grouped_rewards.mean(dim=1)` over a group of one — subtracting each reward from itself and zeroing every advantage, so the policy trains on no signal. GRPO with `group_size: 1` is rejected up front; the ReinForce++ baseline should be too.

A second, related gap surfaced in review: `get_adv_and_returns` dispatches on `adv_type.lower()`, so a differently-cased name (`GRPO`) would skip the guard yet still reach the group-based estimator. The helper now normalizes case as well.

The dead string dates back to #867; `reinpp` and `use_reinpp_baseline` were added later, so the two drifted apart. No shipped config sets `use_reinpp_baseline: true`, so no existing run changes behavior — this only rejects a misconfiguration that used to fail silently.

### How has this been tested?

New unit test `tests/unit_tests/test_config_adv_group_baseline.py` (9 cases) pins the predicate: grpo/grpo_dynamic always require a group, reinpp requires one only in baseline mode, plain reinpp/gae/raw/opd are exempt, and the check is case-insensitive.

```
$ PYTHONPATH=$PWD python -m pytest tests/unit_tests/test_config_adv_group_baseline.py -q
9 passed
$ ruff check rlinf/config.py tests/unit_tests/test_config_adv_group_baseline.py
All checks passed!
```

Both fixes were mutation-tested: reverting the reinpp-baseline branch fails `test_reinpp_requires_a_group_only_in_baseline_mode`, and removing the `.lower()` fails `test_guard_matches_case_insensitive_dispatch`.

### Additional information (optional, e.g., figures and logs):

`grpo_video` with `advantage_mode: frame` and `group_size: 1` has the same singleton-group problem (its `std(dim=-1)` over one element is NaN), but whether it needs a group depends on `advantage_mode`, so it is intentionally left out of this guard and noted for a separate change.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
