### PR TITLE
fix(embodied): stop scaling the entropy bonus by micro-batch size

### DIFF
--- a/rlinf/utils/utils.py
+++ b/rlinf/utils/utils.py
@@ -454,6 +454,52 @@ def reshape_entropy(
     return entropy
 
 
+def compute_entropy_loss(
+    entropy: Optional[torch.Tensor],
+    entropy_type: str,
+    loss_mask: Optional[torch.Tensor],
+    action_dim: int = 7,
+    batch_size: int = 1,
+) -> torch.Tensor:
+    """
+    Reshape entropy for ``entropy_type`` and average it over the valid entries.
+
+    Two shape mismatches have to be reconciled before the average is a mean.
+    ``reshape_entropy`` can return one rank less than ``loss_mask``: models that
+    already reduce entropy to [bsz, 1] leave the "chunk_level" branch as [bsz],
+    and a [bsz] value tensor against a [bsz, 1] mask is an outer product rather
+    than a mask. And ``masked_mean`` divides by the sum of the mask it is handed
+    while its numerator sums the broadcast product, so a mask narrower than
+    ``entropy`` inflates the result by the broadcast factor.
+
+    Args:
+        entropy(Optional[torch.Tensor]): entropy as the model produced it.
+        entropy_type(str): "action_level", "chunk_level" or "token_level".
+        loss_mask(Optional[torch.Tensor]): valid-entry mask, or None to average all.
+        action_dim(int): action dimension, default is 7.
+        batch_size(int): batch size used to reshape action-level entropy.
+
+    Returns:
+        torch.Tensor: scalar mean entropy over the valid entries.
+    """
+    entropy = reshape_entropy(
+        entropy,
+        entropy_type=entropy_type,
+        action_dim=action_dim,
+        batch_size=batch_size,
+    )
+    if loss_mask is None:
+        return masked_mean(entropy, mask=None)
+
+    while entropy.dim() < loss_mask.dim():
+        entropy = entropy.unsqueeze(-1)
+    if loss_mask.shape != entropy.shape:
+        loss_mask = loss_mask.expand(
+            torch.broadcast_shapes(loss_mask.shape, entropy.shape)
+        )
+    return masked_mean(entropy, mask=loss_mask)
+
+
 def logprobs_from_logits_flash_attn(
     logits: torch.Tensor, labels: torch.Tensor, inplace_backward: bool = True
 ) -> torch.Tensor:

--- a/rlinf/workers/actor/async_ppo_fsdp_worker.py
+++ b/rlinf/workers/actor/async_ppo_fsdp_worker.py
@@ -35,7 +35,7 @@ from rlinf.utils.metric_utils import (
     pop_critic_explained_variance_stats,
 )
 from rlinf.utils.nested_dict_process import put_tensor_device, split_dict_to_chunk
-from rlinf.utils.utils import clear_memory, masked_mean, reshape_entropy
+from rlinf.utils.utils import clear_memory, compute_entropy_loss
 from rlinf.workers.actor.embodied_fsdp_actor_worker import EmbodiedFSDPActor
 
 
@@ -445,14 +445,13 @@ class AsyncPPOEmbodiedFSDPActor(EmbodiedFSDPActor):
                         self.cfg.algorithm.entropy_bonus > 0
                         and not loss_kwargs["critic_warmup"]
                     ):
-                        entropy = out["entropy"]
-                        entropy = reshape_entropy(
-                            entropy,
+                        entropy_loss = compute_entropy_loss(
+                            out["entropy"],
                             entropy_type=self.cfg.algorithm.entropy_type,
+                            loss_mask=loss_mask,
                             action_dim=self.cfg.actor.model.get("action_dim", 7),
                             batch_size=out["logprobs"].shape[0],
                         )
-                        entropy_loss = masked_mean(entropy, mask=loss_mask)
                         loss = loss - self.cfg.algorithm.entropy_bonus * entropy_loss
 
                     loss = loss / self.gradient_accumulation

--- a/rlinf/workers/actor/embodied_fsdp_actor_worker.py
+++ b/rlinf/workers/actor/embodied_fsdp_actor_worker.py
@@ -53,8 +53,8 @@ from rlinf.utils.placement import (
 )
 from rlinf.utils.utils import (
     clear_memory,
+    compute_entropy_loss,
     masked_mean,
-    reshape_entropy,
 )
 
 
@@ -755,14 +755,13 @@ class EmbodiedFSDPActor(FSDPModelManager, Worker):
         loss, metrics_data = policy_loss(**loss_kwargs)
         entropy_loss = torch.tensor(0.0, device=Worker.torch_platform.current_device())
         if self.cfg.algorithm.entropy_bonus > 0 and not loss_kwargs["critic_warmup"]:
-            entropy = output_dict["entropy"]
-            entropy = reshape_entropy(
-                entropy,
+            entropy_loss = compute_entropy_loss(
+                output_dict["entropy"],
                 entropy_type=self.cfg.algorithm.entropy_type,
+                loss_mask=loss_mask,
                 action_dim=self.cfg.actor.model.get("action_dim", 7),
                 batch_size=output_dict["logprobs"].shape[0],
             )
-            entropy_loss = masked_mean(entropy, mask=loss_mask)
             loss -= self.cfg.algorithm.entropy_bonus * entropy_loss
         metrics_data["actor/entropy_loss"] = entropy_loss.detach().item()
 

--- a/tests/unit_tests/test_entropy_loss.py
+++ b/tests/unit_tests/test_entropy_loss.py
@@ -1,0 +1,156 @@
+# Copyright 2026 The RLinf Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the embodied actor's entropy bonus aggregation.
+
+The shapes below are the ones the shipped models actually emit:
+``openpi``/``lingbotvla`` reduce entropy to ``[bsz, 1]``, ``cnn_policy`` returns
+``[bsz, action_dim]`` and ``openvla_oft`` returns ``[bsz, seq_len]``. ``loss_mask``
+is ``[bsz, 1]`` under ``reward_type: chunk_level`` and ``[bsz, num_action_chunks]``
+otherwise.
+"""
+
+import pytest
+import torch
+
+from rlinf.utils.utils import compute_entropy_loss
+
+
+def _entropy(*shape, seed=0):
+    generator = torch.Generator().manual_seed(seed)
+    return torch.rand(*shape, generator=generator) + 0.5
+
+
+@pytest.mark.parametrize("batch_size", [4, 16, 64, 500])
+def test_chunk_level_entropy_does_not_scale_with_batch_size(batch_size):
+    """The bug signature: entropy_loss came out multiplied by the micro-batch size."""
+    entropy = _entropy(batch_size, 1)
+    loss_mask = torch.ones(batch_size, 1, dtype=torch.bool)
+
+    got = compute_entropy_loss(entropy, "chunk_level", loss_mask)
+
+    assert float(got) == pytest.approx(float(entropy.mean()), rel=1e-6)
+
+
+def test_chunk_level_entropy_averages_only_the_valid_rows():
+    entropy = _entropy(16, 1)
+    loss_mask = torch.zeros(16, 1, dtype=torch.bool)
+    loss_mask[:6] = True
+
+    got = compute_entropy_loss(entropy, "chunk_level", loss_mask)
+
+    assert float(got) == pytest.approx(float(entropy[:6].mean()), rel=1e-6)
+
+
+def test_chunk_level_sums_a_wide_entropy_before_averaging():
+    # cnn_policy shape: one entropy per action dimension.
+    entropy = _entropy(12, 4)
+    loss_mask = torch.zeros(12, 1, dtype=torch.bool)
+    loss_mask[:5] = True
+
+    got = compute_entropy_loss(entropy, "chunk_level", loss_mask)
+
+    assert float(got) == pytest.approx(float(entropy[:5].sum(dim=-1).mean()), rel=1e-6)
+
+
+def test_token_level_averages_over_every_valid_element():
+    # openvla_oft shape: entropy per token, mask per chunk step.
+    entropy = _entropy(10, 7)
+    loss_mask = torch.zeros(10, 1, dtype=torch.bool)
+    loss_mask[:4] = True
+
+    got = compute_entropy_loss(entropy, "token_level", loss_mask)
+
+    assert float(got) == pytest.approx(float(entropy[:4].mean()), rel=1e-6)
+
+
+def test_action_level_sums_action_dim_then_averages():
+    entropy = _entropy(6, 3 * 7)
+    loss_mask = torch.zeros(6, 1, dtype=torch.bool)
+    loss_mask[:2] = True
+
+    got = compute_entropy_loss(
+        entropy, "action_level", loss_mask, action_dim=7, batch_size=6
+    )
+
+    per_chunk = entropy.reshape(6, 3, 7).sum(dim=-1)
+    assert float(got) == pytest.approx(float(per_chunk[:2].mean()), rel=1e-6)
+
+
+def test_a_wider_mask_than_entropy_still_weights_by_valid_steps():
+    # lingbotvla: entropy is [bsz, 1] while reward_type != chunk_level keeps the
+    # mask at [bsz, num_action_chunks]. Each sample is weighted by its valid steps.
+    entropy = _entropy(5, 1)
+    loss_mask = torch.zeros(5, 4, dtype=torch.bool)
+    loss_mask[0, :4] = True
+    loss_mask[1, :1] = True
+
+    got = compute_entropy_loss(entropy, "token_level", loss_mask)
+
+    expected = (entropy[0, 0] * 4 + entropy[1, 0] * 1) / 5
+    assert float(got) == pytest.approx(float(expected), rel=1e-6)
+
+
+def test_three_dim_entropy_reduces_to_the_mask_rank():
+    # StarVLA action heads return [bsz, num_action_chunks, action_dim]; the
+    # chunk_level sum already lands on the mask's rank, so nothing is unsqueezed.
+    entropy = _entropy(4, 8, 7)
+    loss_mask = torch.zeros(4, 8, dtype=torch.bool)
+    loss_mask[:, :3] = True
+
+    got = compute_entropy_loss(entropy, "chunk_level", loss_mask)
+
+    per_chunk = entropy.sum(dim=-1)
+    assert float(got) == pytest.approx(float(per_chunk[:, :3].mean()), rel=1e-6)
+
+
+def test_three_dim_entropy_is_right_when_batch_equals_num_chunks():
+    # Same shape family with bsz == num_action_chunks, where a rank mismatch
+    # broadcasts successfully instead of raising and would go unnoticed.
+    entropy = _entropy(8, 8, 7)
+    loss_mask = torch.zeros(8, 8, dtype=torch.bool)
+    loss_mask[:3] = True
+
+    got = compute_entropy_loss(entropy, "chunk_level", loss_mask)
+
+    per_chunk = entropy.sum(dim=-1)
+    assert float(got) == pytest.approx(float(per_chunk[:3].mean()), rel=1e-6)
+
+
+def test_no_mask_averages_everything():
+    entropy = _entropy(9, 1)
+
+    got = compute_entropy_loss(entropy, "chunk_level", None)
+
+    assert float(got) == pytest.approx(float(entropy.mean()), rel=1e-6)
+
+
+def test_a_fully_masked_batch_contributes_zero():
+    entropy = _entropy(8, 1)
+    loss_mask = torch.zeros(8, 1, dtype=torch.bool)
+
+    got = compute_entropy_loss(entropy, "chunk_level", loss_mask)
+
+    assert float(got) == pytest.approx(0.0)
+
+
+def test_entropy_loss_keeps_the_gradient_path():
+    entropy = _entropy(8, 1).requires_grad_(True)
+    loss_mask = torch.ones(8, 1, dtype=torch.bool)
+
+    compute_entropy_loss(entropy, "chunk_level", loss_mask).backward()
+
+    # A correct mean spreads 1/8 of the gradient onto each row; the outer-product
+    # bug put 1.0 on each instead.
+    assert torch.allclose(entropy.grad, torch.full((8, 1), 1 / 8))


### PR DESCRIPTION
### Description

Both embodied actors computed the entropy bonus as `masked_mean(reshape_entropy(...), mask=loss_mask)`. `reshape_entropy`'s `chunk_level` branch is `entropy.sum(dim=-1)`, which drops a dimension, and the models that already reduce entropy to `[bsz, 1]` come out of it rank-1 `[bsz]` while `loss_mask` is rank-2 `[bsz, 1]`. `masked_mean` then multiplied them into a `[bsz, bsz]` outer product in the numerator while still dividing by the `bsz` entries of the un-broadcast mask, so the result was `sum(entropy)` where `mean(entropy)` was meant.

That value is multiplied by `algorithm.entropy_bonus` and subtracted from the loss, so the error reached the gradient, not just `actor/entropy_loss`.

This adds `compute_entropy_loss` in `rlinf/utils/utils.py`, shared by `embodied_fsdp_actor_worker` and `async_ppo_fsdp_worker`, which restores the rank before masking and broadcasts the mask to the entropy shape so the numerator and the denominator count the same elements.

`reshape_entropy` itself is unchanged — the diff to `rlinf/utils/utils.py` is additions only.

### Motivation and Context

Fixes #1564.

The `[bsz, 1]` shape is deliberate on the model side. `rlinf/models/embodiment/openpi/openpi_action_model.py:756`:

```python
entropy = entropy.mean(dim=[1, 2, 3], keepdim=False)[
    :, None
]  # [:,None] to align with loss-mask shape
```

`lingbotvla_action_model.py:1151` does the same, and `cnn_policy` returns `[bsz, action_dim]`, which the same `sum(dim=-1)` also flattens to `[bsz]`. `reshape_entropy` undid the alignment that comment describes.

11 shipped configs pair `entropy_bonus > 0` with `entropy_type: chunk_level`; the inflation factor is that config's `actor.micro_batch_size`, from 32x (`maniskill_ppo_openpi.yaml`) to 500x (`realworld_peginsertion_async_ppo_cnn.yaml`). A side effect is that `micro_batch_size`, normally a pure memory/throughput knob, silently changed the entropy regularization with it.

### How has this been tested?

- New `tests/unit_tests/test_entropy_loss.py`, 14 tests, all passing. They pin the
shapes the shipped models actually emit: `[bsz, 1]` (openpi, lingbotvla), `[bsz, action_dim]` (cnn_policy), `[bsz, seq_len]` (openvla_oft) and `[bsz, num_action_chunks, action_dim]` (the StarVLA action heads).
- Mutation-tested rather than just run. Against the code as it stands on `main`,
9 of the 14 fail. Each half of the fix is independently covered: deleting the rank restore fails 2, deleting the mask broadcast fails 2 (a different 2).
- `pytest tests/unit_tests/test_entropy_loss.py` → 14 passed.
Python 3.13, torch CPU; no GPU is needed for the bug or the fix.
- `ruff format` and `ruff check` clean on all four files.
- `test_robotics.py`, `test_real_env.py` and `test_utils.py` fail identically on
this branch and on a clean `b8c22a39` checkout (`torchdata` is missing locally and `test_robotics.py` needs hardware), so they are unrelated to this change.

### Additional information (optional, e.g., figures and logs):

Same input, `entropy_type: chunk_level`, openpi-shaped entropy:

| `micro_batch_size` | before | after | true masked mean |
|---:|---:|---:|---:|
| 4 | 3.4850 | 0.8712 | 0.8712 |
| 16 | 15.1112 | 0.9444 | 0.9444 |
| 64 | 64.8133 | 1.0127 | 1.0127 |
| 500 | 510.3187 | 1.0206 | 1.0206 |

Two things for the reviewer to decide on, both deliberately left out of this PR:

1. **The shipped `entropy_bonus` values are not rescaled.** Every affected config keeps `entropy_bonus: 0.005`, so its *effective* entropy regularization drops by its `micro_batch_size` once this lands — 32x for the ManiSkill recipes, 500x for `realworld_peginsertion_async_ppo_cnn.yaml`. The knob now means what it says, but the published recipes were presumably tuned with the old scale. I did not want to guess new values for recipes I cannot retrain; happy to follow up with a rescale if you tell me which way you want it.

2. **`keepdim=True` on the `chunk_level` branch would have been the smaller diff and is wrong.** The StarVLA action heads return 3-D `[bsz, num_action_chunks, action_dim]`, where `sum(dim=-1)` already lands exactly on the mask's rank; `keepdim=True` there yields `[bsz, n_chunks, 1]` against a `[bsz, n_chunks]` mask, which raises for `bsz != n_chunks` and returns a silently wrong value when they happen to be equal. Two of the new tests cover that shape specifically.

Also noticed while in here, not changed: `reshape_entropy` has no `token_level` branch and no `else`, so a misspelled `entropy_type` silently passes entropy through, and `entropy_type` is not validated in `rlinf/config.py`. And `algorithm.loss_agg_func` is documented in `guides/embodiment_config.rst` but the embodied actors never read it — harmless today only because every embodied config sets `token-mean`, which is the default they hardcode. Happy to open separate issues for either.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (Document-only update)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
